### PR TITLE
Migrate test suite to mocha + chai + chai-kefir

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,8 @@
 language: node_js
 sudo: false
+before_script:
+  - npm link
+  - npm link kefir
 node_js:
 - '4'
 - '7'

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,9 @@ before_script:
   - npm link
   - npm link kefir
 node_js:
-- '4'
-- '7'
+  - 6
+  - 8
+  - stable
 notifications:
   webhooks:
     urls:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,5 @@
 language: node_js
 sudo: false
-before_script:
-  - npm link
-  - npm link kefir
 node_js:
   - 6
   - 8

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "build": "npm run clean && npm run build-js && npm run build-docs",
     "test": "./configs/prettier.sh check && rollup -c ./configs/rollup.dev.js && mocha && flow check",
     "test-only": "rollup -c ./configs/rollup.dev.js && mocha",
-    "test-debug": "rollup -c ./configs/rollup.dev.js && node --inspect-brk `npm bin`/mocha"
+    "test-debug": "rollup -c ./configs/rollup.dev.js && mocha --inspect-brk"
   },
   "keywords": [
     "frp",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "@reactivex/rxjs": "5.3.0",
     "babel-preset-es2015-loose-rollup": "7.0.0",
     "chai": "^4.1.2",
-    "chai-kefir": "^1.2.0",
+    "chai-kefir": "^2.0.1",
     "flow-bin": "0.50.0",
     "inquirer": "0.10.1",
     "mocha": "^4.0.1",

--- a/package.json
+++ b/package.json
@@ -9,9 +9,9 @@
     "build-docs": "node configs/docs.js",
     "clean": "rm -r dist index.html || true",
     "build": "npm run clean && npm run build-js && npm run build-docs",
-    "test": "./configs/prettier.sh check && rollup -c ./configs/rollup.dev.js && jasmine-node --matchall test/specs && flow check",
-    "test-only": "rollup -c ./configs/rollup.dev.js && jasmine-node --matchall test/specs",
-    "test-debug": "rollup -c ./configs/rollup.dev.js && node --inspect-brk `npm bin`/jasmine-node --matchall test/specs"
+    "test": "./configs/prettier.sh check && rollup -c ./configs/rollup.dev.js && mocha && flow check",
+    "test-only": "rollup -c ./configs/rollup.dev.js && mocha",
+    "test-debug": "rollup -c ./configs/rollup.dev.js && node --inspect-brk `npm bin`/mocha"
   },
   "keywords": [
     "frp",
@@ -38,9 +38,11 @@
   "devDependencies": {
     "@reactivex/rxjs": "5.3.0",
     "babel-preset-es2015-loose-rollup": "7.0.0",
+    "chai": "^4.1.2",
+    "chai-kefir": "^1.2.0",
     "flow-bin": "0.50.0",
     "inquirer": "0.10.1",
-    "jasmine-node": "1.14.5",
+    "mocha": "^4.0.1",
     "prettier": "1.0.2",
     "pug": "2.0.0-beta11",
     "rollup": "0.41.6",
@@ -51,6 +53,7 @@
     "semver": "5.3.0",
     "shelljs": "0.5.3",
     "sinon": "1.17.1",
+    "sinon-chai": "^2.14.0",
     "transducers-js": "0.4.174",
     "transducers.js": "0.3.2",
     "zen-observable": "0.5.1"

--- a/test/mocha.opts
+++ b/test/mocha.opts
@@ -1,0 +1,3 @@
+--reporter spec
+--ui bdd
+test/specs/*.js

--- a/test/specs/before-end.js
+++ b/test/specs/before-end.js
@@ -1,4 +1,4 @@
-const {stream, prop, send, expect} = require('../test-helpers')
+const {stream, prop, send, value, end, expect} = require('../test-helpers')
 
 describe('beforeEnd', () => {
   describe('stream', () => {
@@ -12,12 +12,14 @@ describe('beforeEnd', () => {
     })
 
     it('should be ended if source was ended', () => {
-      expect(send(stream(), ['<end>']).beforeEnd(() => 42)).to.emit([{current: 42}, '<end:current>'])
+      expect(send(stream(), [end()]).beforeEnd(() => 42)).to.emit([value(42, {current: true}), end({current: true})])
     })
 
     it('should handle events', () => {
       const a = stream()
-      expect(a.beforeEnd(() => 42)).to.emit([1, 2, 42, '<end>'], () => send(a, [1, 2, '<end>']))
+      expect(a.beforeEnd(() => 42)).to.emit([value(1), value(2), value(42), end()], () =>
+        send(a, [value(1), value(2), end()])
+      )
     })
 
     it('errors should flow', () => {
@@ -37,13 +39,18 @@ describe('beforeEnd', () => {
     })
 
     it('should be ended if source was ended', () => {
-      expect(send(prop(), ['<end>']).beforeEnd(() => 42)).to.emit([{current: 42}, '<end:current>'])
-      expect(send(prop(), [1, '<end>']).beforeEnd(() => 42)).to.emit([{current: 42}, '<end:current>'])
+      expect(send(prop(), [end()]).beforeEnd(() => 42)).to.emit([value(42, {current: true}), end({current: true})])
+      expect(send(prop(), [value(1), end()]).beforeEnd(() => 42)).to.emit([
+        value(42, {current: true}),
+        end({current: true}),
+      ])
     })
 
     it('should handle events and current', () => {
-      const a = send(prop(), [1])
-      expect(a.beforeEnd(() => 42)).to.emit([{current: 1}, 2, 3, 42, '<end>'], () => send(a, [2, 3, '<end>']))
+      const a = send(prop(), [value(1)])
+      expect(a.beforeEnd(() => 42)).to.emit([value(1, {current: true}), value(2), value(3), value(42), end()], () =>
+        send(a, [value(2), value(3), end()])
+      )
     })
 
     it('errors should flow', () => {

--- a/test/specs/before-end.js
+++ b/test/specs/before-end.js
@@ -1,54 +1,54 @@
-const {stream, prop, send} = require('../test-helpers')
+const {stream, prop, send, expect} = require('../test-helpers')
 
 describe('beforeEnd', () => {
   describe('stream', () => {
     it('should return stream', () => {
-      expect(stream().beforeEnd(() => {})).toBeStream()
+      expect(stream().beforeEnd(() => {})).to.be.observable.stream()
     })
 
     it('should activate/deactivate source', () => {
       const a = stream()
-      expect(a.beforeEnd(() => {})).toActivate(a)
+      expect(a.beforeEnd(() => {})).to.activate(a)
     })
 
     it('should be ended if source was ended', () => {
-      expect(send(stream(), ['<end>']).beforeEnd(() => 42)).toEmit([{current: 42}, '<end:current>'])
+      expect(send(stream(), ['<end>']).beforeEnd(() => 42)).to.emit([{current: 42}, '<end:current>'])
     })
 
     it('should handle events', () => {
       const a = stream()
-      expect(a.beforeEnd(() => 42)).toEmit([1, 2, 42, '<end>'], () => send(a, [1, 2, '<end>']))
+      expect(a.beforeEnd(() => 42)).to.emit([1, 2, 42, '<end>'], () => send(a, [1, 2, '<end>']))
     })
 
     it('errors should flow', () => {
       const a = stream()
-      expect(a.beforeEnd(() => {})).errorsToFlow(a)
+      expect(a.beforeEnd(() => {})).to.flowErrors(a)
     })
   })
 
   describe('property', () => {
     it('should return property', () => {
-      expect(prop().beforeEnd(() => {})).toBeProperty()
+      expect(prop().beforeEnd(() => {})).to.be.observable.property()
     })
 
     it('should activate/deactivate source', () => {
       const a = prop()
-      expect(a.beforeEnd(() => {})).toActivate(a)
+      expect(a.beforeEnd(() => {})).to.activate(a)
     })
 
     it('should be ended if source was ended', () => {
-      expect(send(prop(), ['<end>']).beforeEnd(() => 42)).toEmit([{current: 42}, '<end:current>'])
-      expect(send(prop(), [1, '<end>']).beforeEnd(() => 42)).toEmit([{current: 42}, '<end:current>'])
+      expect(send(prop(), ['<end>']).beforeEnd(() => 42)).to.emit([{current: 42}, '<end:current>'])
+      expect(send(prop(), [1, '<end>']).beforeEnd(() => 42)).to.emit([{current: 42}, '<end:current>'])
     })
 
     it('should handle events and current', () => {
       const a = send(prop(), [1])
-      expect(a.beforeEnd(() => 42)).toEmit([{current: 1}, 2, 3, 42, '<end>'], () => send(a, [2, 3, '<end>']))
+      expect(a.beforeEnd(() => 42)).to.emit([{current: 1}, 2, 3, 42, '<end>'], () => send(a, [2, 3, '<end>']))
     })
 
     it('errors should flow', () => {
       const a = prop()
-      expect(a.beforeEnd(() => {})).errorsToFlow(a)
+      expect(a.beforeEnd(() => {})).to.flowErrors(a)
     })
   })
 })

--- a/test/specs/buffer-by.js
+++ b/test/specs/buffer-by.js
@@ -1,61 +1,61 @@
-const {stream, prop, send} = require('../test-helpers')
+const {stream, prop, send, expect} = require('../test-helpers')
 
 describe('bufferBy', () => {
   describe('common', () => {
     it('should activate/deactivate sources', () => {
       let a = stream()
       let b = stream()
-      expect(a.bufferBy(b)).toActivate(a, b)
+      expect(a.bufferBy(b)).to.activate(a, b)
       a = stream()
       b = prop()
-      expect(a.bufferBy(b)).toActivate(a, b)
+      expect(a.bufferBy(b)).to.activate(a, b)
       a = prop()
       b = stream()
-      expect(a.bufferBy(b)).toActivate(a, b)
+      expect(a.bufferBy(b)).to.activate(a, b)
       a = prop()
       b = prop()
-      expect(a.bufferBy(b)).toActivate(a, b)
+      expect(a.bufferBy(b)).to.activate(a, b)
     })
 
     it('should end when primary ends', () => {
-      expect(send(stream(), ['<end>']).bufferBy(stream())).toEmit([{current: []}, '<end:current>'])
+      expect(send(stream(), ['<end>']).bufferBy(stream())).to.emit([{current: []}, '<end:current>'])
       const a = stream()
       const b = stream()
-      expect(a.bufferBy(b)).toEmit([[], '<end>'], () => send(a, ['<end>']))
+      expect(a.bufferBy(b)).to.emit([[], '<end>'], () => send(a, ['<end>']))
     })
 
     it('should flush buffer on end', () => {
-      expect(send(prop(), [1, '<end>']).bufferBy(stream())).toEmit([{current: [1]}, '<end:current>'])
+      expect(send(prop(), [1, '<end>']).bufferBy(stream())).to.emit([{current: [1]}, '<end:current>'])
       const a = stream()
       const b = stream()
-      expect(a.bufferBy(b)).toEmit([[1, 2], '<end>'], () => send(a, [1, 2, '<end>']))
+      expect(a.bufferBy(b)).to.emit([[1, 2], '<end>'], () => send(a, [1, 2, '<end>']))
     })
 
     it('should not flush buffer on end if {flushOnEnd: false}', () => {
-      expect(send(prop(), [1, '<end>']).bufferBy(stream(), {flushOnEnd: false})).toEmit(['<end:current>'])
+      expect(send(prop(), [1, '<end>']).bufferBy(stream(), {flushOnEnd: false})).to.emit(['<end:current>'])
       const a = stream()
       const b = stream()
-      expect(a.bufferBy(b, {flushOnEnd: false})).toEmit(['<end>'], () => send(a, [1, 2, '<end>']))
+      expect(a.bufferBy(b, {flushOnEnd: false})).to.emit(['<end>'], () => send(a, [1, 2, '<end>']))
     })
 
     it('should not end when secondary ends', () => {
-      expect(stream().bufferBy(send(stream(), ['<end>']))).toEmit([])
+      expect(stream().bufferBy(send(stream(), ['<end>']))).to.emit([])
       const a = stream()
       const b = stream()
-      expect(a.bufferBy(b)).toEmit([], () => send(b, ['<end>']))
+      expect(a.bufferBy(b)).to.emit([], () => send(b, ['<end>']))
     })
 
     it('should do end when secondary ends if {flushOnEnd: false}', () => {
-      expect(stream().bufferBy(send(stream(), ['<end>']), {flushOnEnd: false})).toEmit(['<end:current>'])
+      expect(stream().bufferBy(send(stream(), ['<end>']), {flushOnEnd: false})).to.emit(['<end:current>'])
       const a = stream()
       const b = stream()
-      expect(a.bufferBy(b, {flushOnEnd: false})).toEmit(['<end>'], () => send(b, ['<end>']))
+      expect(a.bufferBy(b, {flushOnEnd: false})).to.emit(['<end>'], () => send(b, ['<end>']))
     })
 
     it('should flush buffer on each value from secondary', () => {
       const a = stream()
       const b = stream()
-      expect(a.bufferBy(b)).toEmit([[], [1, 2], [], [3]], () => {
+      expect(a.bufferBy(b)).to.emit([[], [1, 2], [], [3]], () => {
         send(b, [0])
         send(a, [1, 2])
         send(b, [0])
@@ -69,64 +69,64 @@ describe('bufferBy', () => {
     it('errors should flow', () => {
       let a = stream()
       let b = stream()
-      expect(a.bufferBy(b)).errorsToFlow(a)
+      expect(a.bufferBy(b)).to.flowErrors(a)
       a = stream()
       b = stream()
-      expect(a.bufferBy(b)).errorsToFlow(b)
+      expect(a.bufferBy(b)).to.flowErrors(b)
       a = prop()
       b = stream()
-      expect(a.bufferBy(b)).errorsToFlow(a)
+      expect(a.bufferBy(b)).to.flowErrors(a)
       a = prop()
       b = stream()
-      expect(a.bufferBy(b)).errorsToFlow(b)
+      expect(a.bufferBy(b)).to.flowErrors(b)
       a = stream()
       b = prop()
-      expect(a.bufferBy(b)).errorsToFlow(a)
+      expect(a.bufferBy(b)).to.flowErrors(a)
       a = stream()
       b = prop()
-      expect(a.bufferBy(b)).errorsToFlow(b)
+      expect(a.bufferBy(b)).to.flowErrors(b)
       a = prop()
       b = prop()
-      expect(a.bufferBy(b)).errorsToFlow(a)
+      expect(a.bufferBy(b)).to.flowErrors(a)
       a = prop()
       b = prop()
-      expect(a.bufferBy(b)).errorsToFlow(b)
+      expect(a.bufferBy(b)).to.flowErrors(b)
     })
   })
 
   describe('stream + stream', () => {
     it('returns stream', () => {
-      expect(stream().bufferBy(stream())).toBeStream()
+      expect(stream().bufferBy(stream())).to.be.observable.stream()
     })
   })
 
   describe('stream + property', () => {
     it('returns stream', () => {
-      expect(stream().bufferBy(prop())).toBeStream()
+      expect(stream().bufferBy(prop())).to.be.observable.stream()
     })
   })
 
   describe('property + stream', () => {
     it('returns property', () => {
-      expect(prop().bufferBy(stream())).toBeProperty()
+      expect(prop().bufferBy(stream())).to.be.observable.property()
     })
 
     it('includes current to buffer', () => {
       const a = send(prop(), [1])
       const b = stream()
-      expect(a.bufferBy(b)).toEmit([[1]], () => send(b, [0]))
+      expect(a.bufferBy(b)).to.emit([[1]], () => send(b, [0]))
     })
   })
 
   describe('property + property', () => {
     it('returns property', () => {
-      expect(prop().bufferBy(prop())).toBeProperty()
+      expect(prop().bufferBy(prop())).to.be.observable.property()
     })
 
     it('both have current', () => {
       const a = send(prop(), [1])
       const b = send(prop(), [2])
-      expect(a.bufferBy(b)).toEmit([{current: [1]}])
+      expect(a.bufferBy(b)).to.emit([{current: [1]}])
     })
   })
 })

--- a/test/specs/buffer-while-by.js
+++ b/test/specs/buffer-while-by.js
@@ -1,90 +1,90 @@
-const {stream, prop, send} = require('../test-helpers')
+const {stream, prop, send, expect} = require('../test-helpers')
 
 describe('bufferWhileBy', () => {
   describe('common', () => {
     it('should activate/deactivate sources', () => {
       let a = stream()
       let b = stream()
-      expect(a.bufferWhileBy(b)).toActivate(a, b)
+      expect(a.bufferWhileBy(b)).to.activate(a, b)
       a = stream()
       b = prop()
-      expect(a.bufferWhileBy(b)).toActivate(a, b)
+      expect(a.bufferWhileBy(b)).to.activate(a, b)
       a = prop()
       b = stream()
-      expect(a.bufferWhileBy(b)).toActivate(a, b)
+      expect(a.bufferWhileBy(b)).to.activate(a, b)
       a = prop()
       b = prop()
-      expect(a.bufferWhileBy(b)).toActivate(a, b)
+      expect(a.bufferWhileBy(b)).to.activate(a, b)
     })
 
     it('should flush empty buffer and then end when primary ends', () => {
-      expect(send(stream(), ['<end>']).bufferWhileBy(stream())).toEmit([{current: []}, '<end:current>'])
+      expect(send(stream(), ['<end>']).bufferWhileBy(stream())).to.emit([{current: []}, '<end:current>'])
       const a = stream()
       const b = stream()
-      expect(a.bufferWhileBy(b)).toEmit([[], '<end>'], () => send(a, ['<end>']))
+      expect(a.bufferWhileBy(b)).to.emit([[], '<end>'], () => send(a, ['<end>']))
     })
 
     it('should flush empty buffer when secondary emits false (w/ {flushOnChange: true})', () => {
-      expect(stream().bufferWhileBy(send(prop(), [false]), {flushOnChange: true})).toEmit([{current: []}])
+      expect(stream().bufferWhileBy(send(prop(), [false]), {flushOnChange: true})).to.emit([{current: []}])
       const a = stream()
       const b = stream()
-      expect(a.bufferWhileBy(b, {flushOnChange: true})).toEmit([[]], () => send(b, [true, false]))
+      expect(a.bufferWhileBy(b, {flushOnChange: true})).to.emit([[]], () => send(b, [true, false]))
     })
 
     it('should flush buffer on end', () => {
-      expect(send(prop(), [1, '<end>']).bufferWhileBy(stream())).toEmit([{current: [1]}, '<end:current>'])
+      expect(send(prop(), [1, '<end>']).bufferWhileBy(stream())).to.emit([{current: [1]}, '<end:current>'])
       const a = stream()
       const b = stream()
-      expect(a.bufferWhileBy(b)).toEmit([[1, 2], '<end>'], () => send(a, [1, 2, '<end>']))
+      expect(a.bufferWhileBy(b)).to.emit([[1, 2], '<end>'], () => send(a, [1, 2, '<end>']))
     })
 
     it('should not flush buffer on end if {flushOnEnd: false}', () => {
-      expect(send(prop(), [1, '<end>']).bufferWhileBy(stream(), {flushOnEnd: false})).toEmit(['<end:current>'])
+      expect(send(prop(), [1, '<end>']).bufferWhileBy(stream(), {flushOnEnd: false})).to.emit(['<end:current>'])
       const a = stream()
       const b = stream()
-      expect(a.bufferWhileBy(b, {flushOnEnd: false})).toEmit(['<end>'], () => send(a, [1, 2, '<end>']))
+      expect(a.bufferWhileBy(b, {flushOnEnd: false})).to.emit(['<end>'], () => send(a, [1, 2, '<end>']))
     })
 
     it("should end when secondary ends, if it haven't emitted any value (w/ {flushOnEnd: false})", () => {
-      expect(stream().bufferWhileBy(send(stream(), ['<end>']), {flushOnEnd: false})).toEmit(['<end:current>'])
+      expect(stream().bufferWhileBy(send(stream(), ['<end>']), {flushOnEnd: false})).to.emit(['<end:current>'])
       const a = stream()
       const b = stream()
-      expect(a.bufferWhileBy(b, {flushOnEnd: false})).toEmit(['<end>'], () => send(b, ['<end>']))
+      expect(a.bufferWhileBy(b, {flushOnEnd: false})).to.emit(['<end>'], () => send(b, ['<end>']))
     })
 
     it('should end when secondary ends, if its last emitted value was truthy (w/ {flushOnEnd: false})', () => {
-      expect(stream().bufferWhileBy(send(prop(), [true, '<end>']), {flushOnEnd: false})).toEmit(['<end:current>'])
+      expect(stream().bufferWhileBy(send(prop(), [true, '<end>']), {flushOnEnd: false})).to.emit(['<end:current>'])
       const a = stream()
       const b = stream()
-      expect(a.bufferWhileBy(b, {flushOnEnd: false})).toEmit(['<end>'], () => send(b, [true, '<end>']))
+      expect(a.bufferWhileBy(b, {flushOnEnd: false})).to.emit(['<end>'], () => send(b, [true, '<end>']))
     })
 
     it('should not end when secondary ends, if its last emitted value was falsy (w/ {flushOnEnd: false})', () => {
-      expect(stream().bufferWhileBy(send(prop(), [false, '<end>']), {flushOnEnd: false})).toEmit([])
+      expect(stream().bufferWhileBy(send(prop(), [false, '<end>']), {flushOnEnd: false})).to.emit([])
       const a = stream()
       const b = stream()
-      expect(a.bufferWhileBy(b, {flushOnEnd: false})).toEmit([], () => send(b, [false, '<end>']))
+      expect(a.bufferWhileBy(b, {flushOnEnd: false})).to.emit([], () => send(b, [false, '<end>']))
     })
 
     it('should not end when secondary ends (w/o {flushOnEnd: false})', () => {
-      expect(stream().bufferWhileBy(send(prop(), ['<end>']))).toEmit([])
+      expect(stream().bufferWhileBy(send(prop(), ['<end>']))).to.emit([])
       let a = stream()
       let b = stream()
-      expect(a.bufferWhileBy(b)).toEmit([], () => send(b, ['<end>']))
-      expect(stream().bufferWhileBy(send(prop(), [true, '<end>']))).toEmit([])
+      expect(a.bufferWhileBy(b)).to.emit([], () => send(b, ['<end>']))
+      expect(stream().bufferWhileBy(send(prop(), [true, '<end>']))).to.emit([])
       a = stream()
       b = stream()
-      expect(a.bufferWhileBy(b)).toEmit([], () => send(b, [true, '<end>']))
-      expect(stream().bufferWhileBy(send(prop(), [false, '<end>']))).toEmit([])
+      expect(a.bufferWhileBy(b)).to.emit([], () => send(b, [true, '<end>']))
+      expect(stream().bufferWhileBy(send(prop(), [false, '<end>']))).to.emit([])
       a = stream()
       b = stream()
-      expect(a.bufferWhileBy(b)).toEmit([], () => send(b, [false, '<end>']))
+      expect(a.bufferWhileBy(b)).to.emit([], () => send(b, [false, '<end>']))
     })
 
     it('should flush buffer on each value from primary if last value form secondary was falsy', () => {
       const a = stream()
       const b = stream()
-      expect(a.bufferWhileBy(b)).toEmit([[1, 2, 3, 4], [5], [6, 7, 8]], () => {
+      expect(a.bufferWhileBy(b)).to.emit([[1, 2, 3, 4], [5], [6, 7, 8]], () => {
         send(a, [1, 2]) // buffering
         send(b, [true])
         send(a, [3]) // still buffering
@@ -101,34 +101,34 @@ describe('bufferWhileBy', () => {
     it('errors should flow', () => {
       let a = stream()
       let b = stream()
-      expect(a.bufferWhileBy(b)).errorsToFlow(a)
+      expect(a.bufferWhileBy(b)).to.flowErrors(a)
       a = stream()
       b = stream()
-      expect(a.bufferWhileBy(b)).errorsToFlow(b)
+      expect(a.bufferWhileBy(b)).to.flowErrors(b)
       a = prop()
       b = stream()
-      expect(a.bufferWhileBy(b)).errorsToFlow(a)
+      expect(a.bufferWhileBy(b)).to.flowErrors(a)
       a = prop()
       b = stream()
-      expect(a.bufferWhileBy(b)).errorsToFlow(b)
+      expect(a.bufferWhileBy(b)).to.flowErrors(b)
       a = stream()
       b = prop()
-      expect(a.bufferWhileBy(b)).errorsToFlow(a)
+      expect(a.bufferWhileBy(b)).to.flowErrors(a)
       a = stream()
       b = prop()
-      expect(a.bufferWhileBy(b)).errorsToFlow(b)
+      expect(a.bufferWhileBy(b)).to.flowErrors(b)
       a = prop()
       b = prop()
-      expect(a.bufferWhileBy(b)).errorsToFlow(a)
+      expect(a.bufferWhileBy(b)).to.flowErrors(a)
       a = prop()
       b = prop()
-      expect(a.bufferWhileBy(b)).errorsToFlow(b)
+      expect(a.bufferWhileBy(b)).to.flowErrors(b)
     })
 
     it('should flush on change if {flushOnChange === true}', () => {
       const a = stream()
       const b = stream()
-      expect(a.bufferWhileBy(b, {flushOnChange: true})).toEmit([[1, 2, 3]], () => {
+      expect(a.bufferWhileBy(b, {flushOnChange: true})).to.emit([[1, 2, 3]], () => {
         send(a, [1, 2]) // buffering
         send(b, [true])
         send(a, [3]) // still buffering
@@ -139,25 +139,25 @@ describe('bufferWhileBy', () => {
 
   describe('stream + stream', () => {
     it('returns stream', () => {
-      expect(stream().bufferWhileBy(stream())).toBeStream()
+      expect(stream().bufferWhileBy(stream())).to.be.observable.stream()
     })
   })
 
   describe('stream + property', () => {
     it('returns stream', () => {
-      expect(stream().bufferWhileBy(prop())).toBeStream()
+      expect(stream().bufferWhileBy(prop())).to.be.observable.stream()
     })
   })
 
   describe('property + stream', () => {
     it('returns property', () => {
-      expect(prop().bufferWhileBy(stream())).toBeProperty()
+      expect(prop().bufferWhileBy(stream())).to.be.observable.property()
     })
 
     it('includes current to buffer', () => {
       const a = send(prop(), [1])
       const b = stream()
-      expect(a.bufferWhileBy(b)).toEmit([[1, 2]], () => {
+      expect(a.bufferWhileBy(b)).to.emit([[1, 2]], () => {
         send(b, [false])
         send(a, [2])
       })
@@ -166,16 +166,16 @@ describe('bufferWhileBy', () => {
 
   describe('property + property', () => {
     it('returns property', () => {
-      expect(prop().bufferWhileBy(prop())).toBeProperty()
+      expect(prop().bufferWhileBy(prop())).to.be.observable.property()
     })
 
     it('both have current', () => {
       let a = send(prop(), [1])
       let b = send(prop(), [false])
-      expect(a.bufferWhileBy(b)).toEmit([{current: [1]}])
+      expect(a.bufferWhileBy(b)).to.emit([{current: [1]}])
       a = send(prop(), [1])
       b = send(prop(), [true])
-      expect(a.bufferWhileBy(b)).toEmit([])
+      expect(a.bufferWhileBy(b)).to.emit([])
     })
   })
 })

--- a/test/specs/buffer-while-by.js
+++ b/test/specs/buffer-while-by.js
@@ -1,4 +1,4 @@
-const {stream, prop, send, expect} = require('../test-helpers')
+const {stream, prop, send, value, end, expect} = require('../test-helpers')
 
 describe('bufferWhileBy', () => {
   describe('common', () => {
@@ -18,83 +18,95 @@ describe('bufferWhileBy', () => {
     })
 
     it('should flush empty buffer and then end when primary ends', () => {
-      expect(send(stream(), ['<end>']).bufferWhileBy(stream())).to.emit([{current: []}, '<end:current>'])
+      expect(send(stream(), [end()]).bufferWhileBy(stream())).to.emit([
+        value([], {current: true}),
+        end({current: true}),
+      ])
       const a = stream()
       const b = stream()
-      expect(a.bufferWhileBy(b)).to.emit([[], '<end>'], () => send(a, ['<end>']))
+      expect(a.bufferWhileBy(b)).to.emit([value([]), end()], () => send(a, [end()]))
     })
 
     it('should flush empty buffer when secondary emits false (w/ {flushOnChange: true})', () => {
-      expect(stream().bufferWhileBy(send(prop(), [false]), {flushOnChange: true})).to.emit([{current: []}])
+      expect(stream().bufferWhileBy(send(prop(), [value(false)]), {flushOnChange: true})).to.emit([
+        value([], {current: true}),
+      ])
       const a = stream()
       const b = stream()
-      expect(a.bufferWhileBy(b, {flushOnChange: true})).to.emit([[]], () => send(b, [true, false]))
+      expect(a.bufferWhileBy(b, {flushOnChange: true})).to.emit([value([])], () => send(b, [value(true), value(false)]))
     })
 
     it('should flush buffer on end', () => {
-      expect(send(prop(), [1, '<end>']).bufferWhileBy(stream())).to.emit([{current: [1]}, '<end:current>'])
+      expect(send(prop(), [value(1), end()]).bufferWhileBy(stream())).to.emit([
+        value([1], {current: true}),
+        end({current: true}),
+      ])
       const a = stream()
       const b = stream()
-      expect(a.bufferWhileBy(b)).to.emit([[1, 2], '<end>'], () => send(a, [1, 2, '<end>']))
+      expect(a.bufferWhileBy(b)).to.emit([value([1, 2]), end()], () => send(a, [value(1), value(2), end()]))
     })
 
     it('should not flush buffer on end if {flushOnEnd: false}', () => {
-      expect(send(prop(), [1, '<end>']).bufferWhileBy(stream(), {flushOnEnd: false})).to.emit(['<end:current>'])
+      expect(send(prop(), [value(1), end()]).bufferWhileBy(stream(), {flushOnEnd: false})).to.emit([
+        end({current: true}),
+      ])
       const a = stream()
       const b = stream()
-      expect(a.bufferWhileBy(b, {flushOnEnd: false})).to.emit(['<end>'], () => send(a, [1, 2, '<end>']))
+      expect(a.bufferWhileBy(b, {flushOnEnd: false})).to.emit([end()], () => send(a, [value(1), value(2), end()]))
     })
 
     it("should end when secondary ends, if it haven't emitted any value (w/ {flushOnEnd: false})", () => {
-      expect(stream().bufferWhileBy(send(stream(), ['<end>']), {flushOnEnd: false})).to.emit(['<end:current>'])
+      expect(stream().bufferWhileBy(send(stream(), [end()]), {flushOnEnd: false})).to.emit([end({current: true})])
       const a = stream()
       const b = stream()
-      expect(a.bufferWhileBy(b, {flushOnEnd: false})).to.emit(['<end>'], () => send(b, ['<end>']))
+      expect(a.bufferWhileBy(b, {flushOnEnd: false})).to.emit([end()], () => send(b, [end()]))
     })
 
     it('should end when secondary ends, if its last emitted value was truthy (w/ {flushOnEnd: false})', () => {
-      expect(stream().bufferWhileBy(send(prop(), [true, '<end>']), {flushOnEnd: false})).to.emit(['<end:current>'])
+      expect(stream().bufferWhileBy(send(prop(), [value(true), end()]), {flushOnEnd: false})).to.emit([
+        end({current: true}),
+      ])
       const a = stream()
       const b = stream()
-      expect(a.bufferWhileBy(b, {flushOnEnd: false})).to.emit(['<end>'], () => send(b, [true, '<end>']))
+      expect(a.bufferWhileBy(b, {flushOnEnd: false})).to.emit([end()], () => send(b, [value(true), end()]))
     })
 
     it('should not end when secondary ends, if its last emitted value was falsy (w/ {flushOnEnd: false})', () => {
-      expect(stream().bufferWhileBy(send(prop(), [false, '<end>']), {flushOnEnd: false})).to.emit([])
+      expect(stream().bufferWhileBy(send(prop(), [value(false), end()]), {flushOnEnd: false})).to.emit([])
       const a = stream()
       const b = stream()
-      expect(a.bufferWhileBy(b, {flushOnEnd: false})).to.emit([], () => send(b, [false, '<end>']))
+      expect(a.bufferWhileBy(b, {flushOnEnd: false})).to.emit([], () => send(b, [value(false), end()]))
     })
 
     it('should not end when secondary ends (w/o {flushOnEnd: false})', () => {
-      expect(stream().bufferWhileBy(send(prop(), ['<end>']))).to.emit([])
+      expect(stream().bufferWhileBy(send(prop(), [end()]))).to.emit([])
       let a = stream()
       let b = stream()
-      expect(a.bufferWhileBy(b)).to.emit([], () => send(b, ['<end>']))
-      expect(stream().bufferWhileBy(send(prop(), [true, '<end>']))).to.emit([])
+      expect(a.bufferWhileBy(b)).to.emit([], () => send(b, [end()]))
+      expect(stream().bufferWhileBy(send(prop(), [value(true), end()]))).to.emit([])
       a = stream()
       b = stream()
-      expect(a.bufferWhileBy(b)).to.emit([], () => send(b, [true, '<end>']))
-      expect(stream().bufferWhileBy(send(prop(), [false, '<end>']))).to.emit([])
+      expect(a.bufferWhileBy(b)).to.emit([], () => send(b, [value(true), end()]))
+      expect(stream().bufferWhileBy(send(prop(), [value(false), end()]))).to.emit([])
       a = stream()
       b = stream()
-      expect(a.bufferWhileBy(b)).to.emit([], () => send(b, [false, '<end>']))
+      expect(a.bufferWhileBy(b)).to.emit([], () => send(b, [value(false), end()]))
     })
 
     it('should flush buffer on each value from primary if last value form secondary was falsy', () => {
       const a = stream()
       const b = stream()
-      expect(a.bufferWhileBy(b)).to.emit([[1, 2, 3, 4], [5], [6, 7, 8]], () => {
-        send(a, [1, 2]) // buffering
-        send(b, [true])
-        send(a, [3]) // still buffering
-        send(b, [false])
-        send(a, [4]) // flushing 1,2,3,4
-        send(a, [5]) // flushing 5
-        send(b, [true])
-        send(a, [6, 7]) // buffering again
-        send(b, [false])
-        send(a, [8])
+      expect(a.bufferWhileBy(b)).to.emit([value([1, 2, 3, 4]), value([5]), value([6, 7, 8])], () => {
+        send(a, [value(1), value(2)]) // buffering
+        send(b, [value(true)])
+        send(a, [value(3)]) // still buffering
+        send(b, [value(false)])
+        send(a, [value(4)]) // flushing 1,2,3,4
+        send(a, [value(5)]) // flushing 5
+        send(b, [value(true)])
+        send(a, [value(6), value(7)]) // buffering again
+        send(b, [value(false)])
+        send(a, [value(8)])
       })
     }) // flushing 6,7,8
 
@@ -128,11 +140,11 @@ describe('bufferWhileBy', () => {
     it('should flush on change if {flushOnChange === true}', () => {
       const a = stream()
       const b = stream()
-      expect(a.bufferWhileBy(b, {flushOnChange: true})).to.emit([[1, 2, 3]], () => {
-        send(a, [1, 2]) // buffering
-        send(b, [true])
-        send(a, [3]) // still buffering
-        send(b, [false])
+      expect(a.bufferWhileBy(b, {flushOnChange: true})).to.emit([value([1, 2, 3])], () => {
+        send(a, [value(1), value(2)]) // buffering
+        send(b, [value(true)])
+        send(a, [value(3)]) // still buffering
+        send(b, [value(false)])
       })
     })
   }) // flush
@@ -155,11 +167,11 @@ describe('bufferWhileBy', () => {
     })
 
     it('includes current to buffer', () => {
-      const a = send(prop(), [1])
+      const a = send(prop(), [value(1)])
       const b = stream()
-      expect(a.bufferWhileBy(b)).to.emit([[1, 2]], () => {
-        send(b, [false])
-        send(a, [2])
+      expect(a.bufferWhileBy(b)).to.emit([value([1, 2])], () => {
+        send(b, [value(false)])
+        send(a, [value(2)])
       })
     })
   })
@@ -170,11 +182,11 @@ describe('bufferWhileBy', () => {
     })
 
     it('both have current', () => {
-      let a = send(prop(), [1])
-      let b = send(prop(), [false])
-      expect(a.bufferWhileBy(b)).to.emit([{current: [1]}])
-      a = send(prop(), [1])
-      b = send(prop(), [true])
+      let a = send(prop(), [value(1)])
+      let b = send(prop(), [value(false)])
+      expect(a.bufferWhileBy(b)).to.emit([value([1], {current: true})])
+      a = send(prop(), [value(1)])
+      b = send(prop(), [value(true)])
       expect(a.bufferWhileBy(b)).to.emit([])
     })
   })

--- a/test/specs/buffer-while.js
+++ b/test/specs/buffer-while.js
@@ -1,74 +1,74 @@
-const {stream, prop, send} = require('../test-helpers')
+const {stream, prop, send, expect} = require('../test-helpers')
 
 const not3 = x => x !== 3
 
 describe('bufferWhile', () => {
   describe('stream', () => {
     it('should stream', () => {
-      expect(stream().bufferWhile(not3)).toBeStream()
+      expect(stream().bufferWhile(not3)).to.be.observable.stream()
     })
 
     it('should activate/deactivate source', () => {
       const a = stream()
-      expect(a.bufferWhile(not3)).toActivate(a)
+      expect(a.bufferWhile(not3)).to.activate(a)
     })
 
     it('should be ended if source was ended', () =>
-      expect(send(stream(), ['<end>']).bufferWhile(not3)).toEmit(['<end:current>']))
+      expect(send(stream(), ['<end>']).bufferWhile(not3)).to.emit(['<end:current>']))
 
     it('should work correctly', () => {
       const a = stream()
-      expect(a.bufferWhile(not3)).toEmit([[3], [1, 2, 3], [4, 3], [3], [5, 6], '<end>'], () =>
+      expect(a.bufferWhile(not3)).to.emit([[3], [1, 2, 3], [4, 3], [3], [5, 6], '<end>'], () =>
         send(a, [3, 1, 2, 3, 4, 3, 3, 5, 6, '<end>'])
       )
     })
 
     it('should not flush buffer on end if {flushOnEnd: false}', () => {
       const a = stream()
-      expect(a.bufferWhile(not3, {flushOnEnd: false})).toEmit([[3], [1, 2, 3], [4, 3], [3], '<end>'], () =>
+      expect(a.bufferWhile(not3, {flushOnEnd: false})).to.emit([[3], [1, 2, 3], [4, 3], [3], '<end>'], () =>
         send(a, [3, 1, 2, 3, 4, 3, 3, 5, 6, '<end>'])
       )
     })
 
     it('errors should flow', () => {
       const a = stream()
-      expect(a.bufferWhile(not3)).errorsToFlow(a)
+      expect(a.bufferWhile(not3)).to.flowErrors(a)
     })
   })
 
   describe('property', () => {
     it('should property', () => {
-      expect(prop().bufferWhile(not3)).toBeProperty()
+      expect(prop().bufferWhile(not3)).to.be.observable.property()
     })
 
     it('should activate/deactivate source', () => {
       const a = prop()
-      expect(a.bufferWhile(not3)).toActivate(a)
+      expect(a.bufferWhile(not3)).to.activate(a)
     })
 
     it('should be ended if source was ended', () => {
-      expect(send(prop(), ['<end>']).bufferWhile(not3)).toEmit(['<end:current>'])
-      expect(send(prop(), [3, '<end>']).bufferWhile(not3)).toEmit([{current: [3]}, '<end:current>'])
-      expect(send(prop(), [2, '<end>']).bufferWhile(not3)).toEmit([{current: [2]}, '<end:current>'])
-      expect(send(prop(), [3, '<end>']).bufferWhile(not3, {flushOnEnd: false})).toEmit([
+      expect(send(prop(), ['<end>']).bufferWhile(not3)).to.emit(['<end:current>'])
+      expect(send(prop(), [3, '<end>']).bufferWhile(not3)).to.emit([{current: [3]}, '<end:current>'])
+      expect(send(prop(), [2, '<end>']).bufferWhile(not3)).to.emit([{current: [2]}, '<end:current>'])
+      expect(send(prop(), [3, '<end>']).bufferWhile(not3, {flushOnEnd: false})).to.emit([
         {current: [3]},
         '<end:current>',
       ])
-      expect(send(prop(), [2, '<end>']).bufferWhile(not3, {flushOnEnd: false})).toEmit(['<end:current>'])
+      expect(send(prop(), [2, '<end>']).bufferWhile(not3, {flushOnEnd: false})).to.emit(['<end:current>'])
     })
 
     it('should work correctly', () => {
       let a = send(prop(), [3])
-      expect(a.bufferWhile(not3)).toEmit([{current: [3]}, [1, 2, 3], [4, 3], [3], [5, 6], '<end>'], () =>
+      expect(a.bufferWhile(not3)).to.emit([{current: [3]}, [1, 2, 3], [4, 3], [3], [5, 6], '<end>'], () =>
         send(a, [1, 2, 3, 4, 3, 3, 5, 6, '<end>'])
       )
       a = send(prop(), [1])
-      expect(a.bufferWhile(not3)).toEmit([[1, 2, 3], [5, 6], '<end>'], () => send(a, [2, 3, 5, 6, '<end>']))
+      expect(a.bufferWhile(not3)).to.emit([[1, 2, 3], [5, 6], '<end>'], () => send(a, [2, 3, 5, 6, '<end>']))
     })
 
     it('errors should flow', () => {
       const a = prop()
-      expect(a.bufferWhile(not3)).errorsToFlow(a)
+      expect(a.bufferWhile(not3)).to.flowErrors(a)
     })
   })
 })

--- a/test/specs/buffer-while.js
+++ b/test/specs/buffer-while.js
@@ -1,4 +1,4 @@
-const {stream, prop, send, expect} = require('../test-helpers')
+const {stream, prop, send, value, end, expect} = require('../test-helpers')
 
 const not3 = x => x !== 3
 
@@ -14,19 +14,21 @@ describe('bufferWhile', () => {
     })
 
     it('should be ended if source was ended', () =>
-      expect(send(stream(), ['<end>']).bufferWhile(not3)).to.emit(['<end:current>']))
+      expect(send(stream(), [end()]).bufferWhile(not3)).to.emit([end({current: true})]))
 
     it('should work correctly', () => {
       const a = stream()
-      expect(a.bufferWhile(not3)).to.emit([[3], [1, 2, 3], [4, 3], [3], [5, 6], '<end>'], () =>
-        send(a, [3, 1, 2, 3, 4, 3, 3, 5, 6, '<end>'])
+      expect(a.bufferWhile(not3)).to.emit(
+        [value([3]), value([1, 2, 3]), value([4, 3]), value([3]), value([5, 6]), end()],
+        () => send(a, [value(3), value(1), value(2), value(3), value(4), value(3), value(3), value(5), value(6), end()])
       )
     })
 
     it('should not flush buffer on end if {flushOnEnd: false}', () => {
       const a = stream()
-      expect(a.bufferWhile(not3, {flushOnEnd: false})).to.emit([[3], [1, 2, 3], [4, 3], [3], '<end>'], () =>
-        send(a, [3, 1, 2, 3, 4, 3, 3, 5, 6, '<end>'])
+      expect(a.bufferWhile(not3, {flushOnEnd: false})).to.emit(
+        [value([3]), value([1, 2, 3]), value([4, 3]), value([3]), end()],
+        () => send(a, [value(3), value(1), value(2), value(3), value(4), value(3), value(3), value(5), value(6), end()])
       )
     })
 
@@ -47,23 +49,32 @@ describe('bufferWhile', () => {
     })
 
     it('should be ended if source was ended', () => {
-      expect(send(prop(), ['<end>']).bufferWhile(not3)).to.emit(['<end:current>'])
-      expect(send(prop(), [3, '<end>']).bufferWhile(not3)).to.emit([{current: [3]}, '<end:current>'])
-      expect(send(prop(), [2, '<end>']).bufferWhile(not3)).to.emit([{current: [2]}, '<end:current>'])
-      expect(send(prop(), [3, '<end>']).bufferWhile(not3, {flushOnEnd: false})).to.emit([
-        {current: [3]},
-        '<end:current>',
+      expect(send(prop(), [end()]).bufferWhile(not3)).to.emit([end({current: true})])
+      expect(send(prop(), [value(3), end()]).bufferWhile(not3)).to.emit([
+        value([3], {current: true}),
+        end({current: true}),
       ])
-      expect(send(prop(), [2, '<end>']).bufferWhile(not3, {flushOnEnd: false})).to.emit(['<end:current>'])
+      expect(send(prop(), [value(2), end()]).bufferWhile(not3)).to.emit([
+        value([2], {current: true}),
+        end({current: true}),
+      ])
+      expect(send(prop(), [value(3), end()]).bufferWhile(not3, {flushOnEnd: false})).to.emit([
+        value([3], {current: true}),
+        end({current: true}),
+      ])
+      expect(send(prop(), [value(2), end()]).bufferWhile(not3, {flushOnEnd: false})).to.emit([end({current: true})])
     })
 
     it('should work correctly', () => {
-      let a = send(prop(), [3])
-      expect(a.bufferWhile(not3)).to.emit([{current: [3]}, [1, 2, 3], [4, 3], [3], [5, 6], '<end>'], () =>
-        send(a, [1, 2, 3, 4, 3, 3, 5, 6, '<end>'])
+      let a = send(prop(), [value(3)])
+      expect(a.bufferWhile(not3)).to.emit(
+        [value([3], {current: true}), value([1, 2, 3]), value([4, 3]), value([3]), value([5, 6]), end()],
+        () => send(a, [value(1), value(2), value(3), value(4), value(3), value(3), value(5), value(6), end()])
       )
-      a = send(prop(), [1])
-      expect(a.bufferWhile(not3)).to.emit([[1, 2, 3], [5, 6], '<end>'], () => send(a, [2, 3, 5, 6, '<end>']))
+      a = send(prop(), [value(1)])
+      expect(a.bufferWhile(not3)).to.emit([value([1, 2, 3]), value([5, 6]), end()], () =>
+        send(a, [value(2), value(3), value(5), value(6), end()])
+      )
     })
 
     it('errors should flow', () => {

--- a/test/specs/buffer-with-count.js
+++ b/test/specs/buffer-with-count.js
@@ -1,89 +1,89 @@
-const {stream, prop, send} = require('../test-helpers')
+const {stream, prop, send, expect} = require('../test-helpers')
 
 describe('bufferWithCount', () => {
   describe('stream', () => {
     it('should stream', () => {
-      expect(stream().bufferWithCount(1)).toBeStream()
+      expect(stream().bufferWithCount(1)).to.be.observable.stream()
     })
 
     it('should activate/deactivate source', () => {
       const a = stream()
-      expect(a.bufferWithCount(1)).toActivate(a)
+      expect(a.bufferWithCount(1)).to.activate(a)
     })
 
     it('should be ended if source was ended', () => {
-      expect(send(stream(), ['<end>']).bufferWithCount(1)).toEmit(['<end:current>'])
+      expect(send(stream(), ['<end>']).bufferWithCount(1)).to.emit(['<end:current>'])
     })
 
     it('.bufferWithCount(1) should work correctly', () => {
       const a = stream()
-      expect(a.bufferWithCount(1)).toEmit([[1], [2], [3], [4], [5], '<end>'], () => send(a, [1, 2, 3, 4, 5, '<end>']))
+      expect(a.bufferWithCount(1)).to.emit([[1], [2], [3], [4], [5], '<end>'], () => send(a, [1, 2, 3, 4, 5, '<end>']))
     })
 
     it('.bufferWithCount(2) should work correctly', () => {
       const a = stream()
-      expect(a.bufferWithCount(2)).toEmit([[1, 2], [3, 4], [5], '<end>'], () => send(a, [1, 2, 3, 4, 5, '<end>']))
+      expect(a.bufferWithCount(2)).to.emit([[1, 2], [3, 4], [5], '<end>'], () => send(a, [1, 2, 3, 4, 5, '<end>']))
     })
 
     it('.bufferWithCount(3) should work correctly', () => {
       const a = stream()
-      expect(a.bufferWithCount(3)).toEmit([[1, 2, 3], [4, 5], '<end>'], () => send(a, [1, 2, 3, 4, 5, '<end>']))
+      expect(a.bufferWithCount(3)).to.emit([[1, 2, 3], [4, 5], '<end>'], () => send(a, [1, 2, 3, 4, 5, '<end>']))
     })
 
     it('should not flush buffer on end if {flushOnEnd: false}', () => {
       const a = stream()
-      expect(a.bufferWithCount(3, {flushOnEnd: false})).toEmit([[1, 2, 3], '<end>'], () =>
+      expect(a.bufferWithCount(3, {flushOnEnd: false})).to.emit([[1, 2, 3], '<end>'], () =>
         send(a, [1, 2, 3, 4, 5, '<end>'])
       )
     })
 
     it('errors should flow', () => {
       const a = stream()
-      expect(a.bufferWithCount(3)).errorsToFlow(a)
+      expect(a.bufferWithCount(3)).to.flowErrors(a)
     })
   })
 
   describe('property', () => {
     it('should property', () => {
-      expect(prop().bufferWithCount(1)).toBeProperty()
+      expect(prop().bufferWithCount(1)).to.be.observable.property()
     })
 
     it('should activate/deactivate source', () => {
       const a = prop()
-      expect(a.bufferWithCount(1)).toActivate(a)
+      expect(a.bufferWithCount(1)).to.activate(a)
     })
 
     it('should be ended if source was ended', () => {
-      expect(send(prop(), ['<end>']).bufferWithCount(1)).toEmit(['<end:current>'])
+      expect(send(prop(), ['<end>']).bufferWithCount(1)).to.emit(['<end:current>'])
     })
 
     it('.bufferWithCount(1) should work correctly', () => {
       const a = send(prop(), [1])
-      expect(a.bufferWithCount(1)).toEmit([{current: [1]}, [2], [3], [4], [5], '<end>'], () =>
+      expect(a.bufferWithCount(1)).to.emit([{current: [1]}, [2], [3], [4], [5], '<end>'], () =>
         send(a, [2, 3, 4, 5, '<end>'])
       )
     })
 
     it('.bufferWithCount(2) should work correctly', () => {
       const a = send(prop(), [1])
-      expect(a.bufferWithCount(2)).toEmit([[1, 2], [3, 4], [5], '<end>'], () => send(a, [2, 3, 4, 5, '<end>']))
+      expect(a.bufferWithCount(2)).to.emit([[1, 2], [3, 4], [5], '<end>'], () => send(a, [2, 3, 4, 5, '<end>']))
     })
 
     it('.bufferWithCount(3) should work correctly', () => {
       const a = send(prop(), [1])
-      expect(a.bufferWithCount(3)).toEmit([[1, 2, 3], [4, 5], '<end>'], () => send(a, [2, 3, 4, 5, '<end>']))
+      expect(a.bufferWithCount(3)).to.emit([[1, 2, 3], [4, 5], '<end>'], () => send(a, [2, 3, 4, 5, '<end>']))
     })
 
     it('should not flush buffer on end if {flushOnEnd: false}', () => {
       const a = send(prop(), [1])
-      expect(a.bufferWithCount(3, {flushOnEnd: false})).toEmit([[1, 2, 3], '<end>'], () =>
+      expect(a.bufferWithCount(3, {flushOnEnd: false})).to.emit([[1, 2, 3], '<end>'], () =>
         send(a, [2, 3, 4, 5, '<end>'])
       )
     })
 
     it('errors should flow', () => {
       const a = prop()
-      expect(a.bufferWithCount(3)).errorsToFlow(a)
+      expect(a.bufferWithCount(3)).to.flowErrors(a)
     })
   })
 })

--- a/test/specs/buffer-with-count.js
+++ b/test/specs/buffer-with-count.js
@@ -1,4 +1,4 @@
-const {stream, prop, send, expect} = require('../test-helpers')
+const {stream, prop, send, value, end, expect} = require('../test-helpers')
 
 describe('bufferWithCount', () => {
   describe('stream', () => {
@@ -12,28 +12,34 @@ describe('bufferWithCount', () => {
     })
 
     it('should be ended if source was ended', () => {
-      expect(send(stream(), ['<end>']).bufferWithCount(1)).to.emit(['<end:current>'])
+      expect(send(stream(), [end()]).bufferWithCount(1)).to.emit([end({current: true})])
     })
 
     it('.bufferWithCount(1) should work correctly', () => {
       const a = stream()
-      expect(a.bufferWithCount(1)).to.emit([[1], [2], [3], [4], [5], '<end>'], () => send(a, [1, 2, 3, 4, 5, '<end>']))
+      expect(a.bufferWithCount(1)).to.emit([value([1]), value([2]), value([3]), value([4]), value([5]), end()], () =>
+        send(a, [value(1), value(2), value(3), value(4), value(5), end()])
+      )
     })
 
     it('.bufferWithCount(2) should work correctly', () => {
       const a = stream()
-      expect(a.bufferWithCount(2)).to.emit([[1, 2], [3, 4], [5], '<end>'], () => send(a, [1, 2, 3, 4, 5, '<end>']))
+      expect(a.bufferWithCount(2)).to.emit([value([1, 2]), value([3, 4]), value([5]), end()], () =>
+        send(a, [value(1), value(2), value(3), value(4), value(5), end()])
+      )
     })
 
     it('.bufferWithCount(3) should work correctly', () => {
       const a = stream()
-      expect(a.bufferWithCount(3)).to.emit([[1, 2, 3], [4, 5], '<end>'], () => send(a, [1, 2, 3, 4, 5, '<end>']))
+      expect(a.bufferWithCount(3)).to.emit([value([1, 2, 3]), value([4, 5]), end()], () =>
+        send(a, [value(1), value(2), value(3), value(4), value(5), end()])
+      )
     })
 
     it('should not flush buffer on end if {flushOnEnd: false}', () => {
       const a = stream()
-      expect(a.bufferWithCount(3, {flushOnEnd: false})).to.emit([[1, 2, 3], '<end>'], () =>
-        send(a, [1, 2, 3, 4, 5, '<end>'])
+      expect(a.bufferWithCount(3, {flushOnEnd: false})).to.emit([value([1, 2, 3]), end()], () =>
+        send(a, [value(1), value(2), value(3), value(4), value(5), end()])
       )
     })
 
@@ -54,30 +60,35 @@ describe('bufferWithCount', () => {
     })
 
     it('should be ended if source was ended', () => {
-      expect(send(prop(), ['<end>']).bufferWithCount(1)).to.emit(['<end:current>'])
+      expect(send(prop(), [end()]).bufferWithCount(1)).to.emit([end({current: true})])
     })
 
     it('.bufferWithCount(1) should work correctly', () => {
-      const a = send(prop(), [1])
-      expect(a.bufferWithCount(1)).to.emit([{current: [1]}, [2], [3], [4], [5], '<end>'], () =>
-        send(a, [2, 3, 4, 5, '<end>'])
+      const a = send(prop(), [value(1)])
+      expect(a.bufferWithCount(1)).to.emit(
+        [value([1], {current: true}), value([2]), value([3]), value([4]), value([5]), end()],
+        () => send(a, [value(2), value(3), value(4), value(5), end()])
       )
     })
 
     it('.bufferWithCount(2) should work correctly', () => {
-      const a = send(prop(), [1])
-      expect(a.bufferWithCount(2)).to.emit([[1, 2], [3, 4], [5], '<end>'], () => send(a, [2, 3, 4, 5, '<end>']))
+      const a = send(prop(), [value(1)])
+      expect(a.bufferWithCount(2)).to.emit([value([1, 2]), value([3, 4]), value([5]), end()], () =>
+        send(a, [value(2), value(3), value(4), value(5), end()])
+      )
     })
 
     it('.bufferWithCount(3) should work correctly', () => {
-      const a = send(prop(), [1])
-      expect(a.bufferWithCount(3)).to.emit([[1, 2, 3], [4, 5], '<end>'], () => send(a, [2, 3, 4, 5, '<end>']))
+      const a = send(prop(), [value(1)])
+      expect(a.bufferWithCount(3)).to.emit([value([1, 2, 3]), value([4, 5]), end()], () =>
+        send(a, [value(2), value(3), value(4), value(5), end()])
+      )
     })
 
     it('should not flush buffer on end if {flushOnEnd: false}', () => {
-      const a = send(prop(), [1])
-      expect(a.bufferWithCount(3, {flushOnEnd: false})).to.emit([[1, 2, 3], '<end>'], () =>
-        send(a, [2, 3, 4, 5, '<end>'])
+      const a = send(prop(), [value(1)])
+      expect(a.bufferWithCount(3, {flushOnEnd: false})).to.emit([value([1, 2, 3]), end()], () =>
+        send(a, [value(2), value(3), value(4), value(5), end()])
       )
     })
 

--- a/test/specs/buffer-with-time-or-count.js
+++ b/test/specs/buffer-with-time-or-count.js
@@ -1,4 +1,4 @@
-const {stream, prop, send, expect} = require('../test-helpers')
+const {stream, prop, send, value, end, expect} = require('../test-helpers')
 
 const intv = 300
 const cnt = 4
@@ -15,32 +15,32 @@ describe('bufferWithTimeOrCount', () => {
     })
 
     it('should be ended if source was ended', () => {
-      expect(send(stream(), ['<end>']).bufferWithTimeOrCount(intv, cnt)).to.emit(['<end:current>'])
+      expect(send(stream(), [end()]).bufferWithTimeOrCount(intv, cnt)).to.emit([end({current: true})])
     })
 
     it('should flush buffer when either interval or count is reached', () => {
       const a = stream()
       expect(a.bufferWithTimeOrCount(intv, cnt)).to.emitInTime(
-        [[300, [1, 2, 3]], [500, [4, 5, 6, 7]], [800, []], [900, [8, 9]], [900, '<end>']],
+        [[300, value([1, 2, 3])], [500, value([4, 5, 6, 7])], [800, value([])], [900, value([8, 9])], [900, end()]],
         tick => {
           tick(100)
-          send(a, [1])
+          send(a, [value(1)])
           tick(100)
-          send(a, [2])
+          send(a, [value(2)])
           tick(99)
-          send(a, [3])
+          send(a, [value(3)])
           tick(51)
-          send(a, [4])
+          send(a, [value(4)])
           tick(50)
-          send(a, [5])
+          send(a, [value(5)])
           tick(50)
-          send(a, [6])
+          send(a, [value(6)])
           tick(50)
-          send(a, [7])
+          send(a, [value(7)])
           tick(301)
-          send(a, [8])
+          send(a, [value(8)])
           tick(99)
-          send(a, [9, '<end>'])
+          send(a, [value(9), end()])
         }
       )
     })
@@ -48,26 +48,26 @@ describe('bufferWithTimeOrCount', () => {
     it('should not flush buffer on end if {flushOnEnd: false}', () => {
       const a = stream()
       expect(a.bufferWithTimeOrCount(intv, cnt, {flushOnEnd: false})).to.emitInTime(
-        [[300, [1, 2, 3]], [500, [4, 5, 6, 7]], [700, '<end>']],
+        [[300, value([1, 2, 3])], [500, value([4, 5, 6, 7])], [700, end()]],
         tick => {
           tick(100)
-          send(a, [1])
+          send(a, [value(1)])
           tick(100)
-          send(a, [2])
+          send(a, [value(2)])
           tick(99)
-          send(a, [3])
+          send(a, [value(3)])
           tick(51)
-          send(a, [4])
+          send(a, [value(4)])
           tick(50)
-          send(a, [5])
+          send(a, [value(5)])
           tick(50)
-          send(a, [6])
+          send(a, [value(6)])
           tick(50)
-          send(a, [7])
+          send(a, [value(7)])
           tick(100)
-          send(a, [8])
+          send(a, [value(8)])
           tick(100)
-          send(a, [9, '<end>'])
+          send(a, [value(9), end()])
         }
       )
     })
@@ -89,59 +89,62 @@ describe('bufferWithTimeOrCount', () => {
     })
 
     it('should be ended if source was ended', () => {
-      expect(send(prop(), ['<end>']).bufferWithTimeOrCount(intv, cnt)).to.emit(['<end:current>'])
-      expect(send(prop(), [1, '<end>']).bufferWithTimeOrCount(intv, cnt)).to.emit([{current: [1]}, '<end:current>'])
-      expect(send(prop(), [1, '<end>']).bufferWithTimeOrCount(intv, cnt, {flushOnEnd: false})).to.emit([
-        '<end:current>',
+      expect(send(prop(), [end()]).bufferWithTimeOrCount(intv, cnt)).to.emit([end({current: true})])
+      expect(send(prop(), [value(1), end()]).bufferWithTimeOrCount(intv, cnt)).to.emit([
+        value([1], {current: true}),
+        end({current: true}),
+      ])
+      expect(send(prop(), [value(1), end()]).bufferWithTimeOrCount(intv, cnt, {flushOnEnd: false})).to.emit([
+        end({current: true}),
       ])
     })
 
     it('should flush buffer when either interval or count is reached', () => {
-      const a = send(prop(), [0])
+      const a = send(prop(), [value(0)])
       expect(a.bufferWithTimeOrCount(intv, cnt)).to.emitInTime(
-        [[300, [0, 1, 2]], [500, [3, 4, 5, 6]], [800, []], [900, [7, 8]], [900, '<end>']],
+        [[300, value([0, 1, 2])], [500, value([3, 4, 5, 6])], [800, value([])], [900, value([7, 8])], [900, end()]],
         tick => {
           tick(100)
-          send(a, [1])
+          send(a, [value(1)])
           tick(100)
-          send(a, [2])
+          send(a, [value(2)])
           tick(150)
-          send(a, [3])
+          send(a, [value(3)])
           tick(50)
-          send(a, [4])
+          send(a, [value(4)])
           tick(50)
-          send(a, [5])
+          send(a, [value(5)])
           tick(50)
-          send(a, [6])
+          send(a, [value(6)])
           tick(301)
-          send(a, [7])
+          send(a, [value(7)])
           tick(99)
-          send(a, [8, '<end>'])
+          send(a, [value(8), end()])
         }
       )
     })
 
     it('should not flush buffer on end if {flushOnEnd: false}', () => {
-      const a = send(prop(), [0])
+      const a = send(prop(), [value(0)])
       expect(a.bufferWithTimeOrCount(intv, cnt, {flushOnEnd: false})).to.emitInTime(
-        [[300, [0, 1, 2]], [500, [3, 4, 5, 6]], [700, '<end>']],
+        [[300, value([0, 1, 2])], [500, value([3, 4, 5, 6])], [700, end()]],
         tick => {
           tick(100)
-          send(a, [1])
+          send(a, [value(1)])
           tick(100)
-          send(a, [2])
+          send(a, [value(2)])
           tick(150)
-          send(a, [3])
+          send(a, [value(3)])
           tick(50)
-          send(a, [4])
+          send(a, [value(4)])
           tick(50)
-          send(a, [5])
+          send(a, [value(5)])
           tick(50)
-          send(a, [6])
+          send(a, [value(6)])
           tick(100)
-          send(a, [7])
+          send(a, [value(7)])
           tick(100)
-          send(a, [8, '<end>'])
+          send(a, [value(8), end()])
         }
       )
     })

--- a/test/specs/buffer-with-time-or-count.js
+++ b/test/specs/buffer-with-time-or-count.js
@@ -1,4 +1,4 @@
-const {stream, prop, send} = require('../test-helpers')
+const {stream, prop, send, expect} = require('../test-helpers')
 
 const intv = 300
 const cnt = 4
@@ -6,21 +6,21 @@ const cnt = 4
 describe('bufferWithTimeOrCount', () => {
   describe('stream', () => {
     it('should stream', () => {
-      expect(stream().bufferWithTimeOrCount(intv, cnt)).toBeStream()
+      expect(stream().bufferWithTimeOrCount(intv, cnt)).to.be.observable.stream()
     })
 
     it('should activate/deactivate source', () => {
       const a = stream()
-      expect(a.bufferWithTimeOrCount(intv, cnt)).toActivate(a)
+      expect(a.bufferWithTimeOrCount(intv, cnt)).to.activate(a)
     })
 
     it('should be ended if source was ended', () => {
-      expect(send(stream(), ['<end>']).bufferWithTimeOrCount(intv, cnt)).toEmit(['<end:current>'])
+      expect(send(stream(), ['<end>']).bufferWithTimeOrCount(intv, cnt)).to.emit(['<end:current>'])
     })
 
     it('should flush buffer when either interval or count is reached', () => {
       const a = stream()
-      expect(a.bufferWithTimeOrCount(intv, cnt)).toEmitInTime(
+      expect(a.bufferWithTimeOrCount(intv, cnt)).to.emitInTime(
         [[300, [1, 2, 3]], [500, [4, 5, 6, 7]], [800, []], [900, [8, 9]], [900, '<end>']],
         tick => {
           tick(100)
@@ -47,7 +47,7 @@ describe('bufferWithTimeOrCount', () => {
 
     it('should not flush buffer on end if {flushOnEnd: false}', () => {
       const a = stream()
-      expect(a.bufferWithTimeOrCount(intv, cnt, {flushOnEnd: false})).toEmitInTime(
+      expect(a.bufferWithTimeOrCount(intv, cnt, {flushOnEnd: false})).to.emitInTime(
         [[300, [1, 2, 3]], [500, [4, 5, 6, 7]], [700, '<end>']],
         tick => {
           tick(100)
@@ -74,29 +74,31 @@ describe('bufferWithTimeOrCount', () => {
 
     it('errors should flow', () => {
       const a = stream()
-      expect(a.bufferWithTimeOrCount(intv, cnt)).errorsToFlow(a)
+      expect(a.bufferWithTimeOrCount(intv, cnt)).to.flowErrors(a)
     })
   })
 
   describe('property', () => {
     it('should property', () => {
-      expect(prop().bufferWithTimeOrCount(intv, cnt)).toBeProperty()
+      expect(prop().bufferWithTimeOrCount(intv, cnt)).to.be.observable.property()
     })
 
     it('should activate/deactivate source', () => {
       const a = prop()
-      expect(a.bufferWithTimeOrCount(intv, cnt)).toActivate(a)
+      expect(a.bufferWithTimeOrCount(intv, cnt)).to.activate(a)
     })
 
     it('should be ended if source was ended', () => {
-      expect(send(prop(), ['<end>']).bufferWithTimeOrCount(intv, cnt)).toEmit(['<end:current>'])
-      expect(send(prop(), [1, '<end>']).bufferWithTimeOrCount(intv, cnt)).toEmit([{current: [1]}, '<end:current>'])
-      expect(send(prop(), [1, '<end>']).bufferWithTimeOrCount(intv, cnt, {flushOnEnd: false})).toEmit(['<end:current>'])
+      expect(send(prop(), ['<end>']).bufferWithTimeOrCount(intv, cnt)).to.emit(['<end:current>'])
+      expect(send(prop(), [1, '<end>']).bufferWithTimeOrCount(intv, cnt)).to.emit([{current: [1]}, '<end:current>'])
+      expect(send(prop(), [1, '<end>']).bufferWithTimeOrCount(intv, cnt, {flushOnEnd: false})).to.emit([
+        '<end:current>',
+      ])
     })
 
     it('should flush buffer when either interval or count is reached', () => {
       const a = send(prop(), [0])
-      expect(a.bufferWithTimeOrCount(intv, cnt)).toEmitInTime(
+      expect(a.bufferWithTimeOrCount(intv, cnt)).to.emitInTime(
         [[300, [0, 1, 2]], [500, [3, 4, 5, 6]], [800, []], [900, [7, 8]], [900, '<end>']],
         tick => {
           tick(100)
@@ -121,7 +123,7 @@ describe('bufferWithTimeOrCount', () => {
 
     it('should not flush buffer on end if {flushOnEnd: false}', () => {
       const a = send(prop(), [0])
-      expect(a.bufferWithTimeOrCount(intv, cnt, {flushOnEnd: false})).toEmitInTime(
+      expect(a.bufferWithTimeOrCount(intv, cnt, {flushOnEnd: false})).to.emitInTime(
         [[300, [0, 1, 2]], [500, [3, 4, 5, 6]], [700, '<end>']],
         tick => {
           tick(100)
@@ -146,7 +148,7 @@ describe('bufferWithTimeOrCount', () => {
 
     it('errors should flow', () => {
       const a = prop()
-      expect(a.bufferWithTimeOrCount(intv, cnt)).errorsToFlow(a)
+      expect(a.bufferWithTimeOrCount(intv, cnt)).to.flowErrors(a)
     })
   })
 })

--- a/test/specs/changes.js
+++ b/test/specs/changes.js
@@ -1,52 +1,52 @@
-const {stream, prop, send, Kefir} = require('../test-helpers')
+const {stream, prop, send, Kefir, expect} = require('../test-helpers')
 
 const streamWithCurrent = event => Kefir.stream(emitter => emitter.emitEvent(event))
 
 describe('changes', () => {
   describe('stream', () => {
     it('should stream', () => {
-      expect(stream().changes()).toBeStream()
+      expect(stream().changes()).to.be.observable.stream()
     })
 
     it('should activate/deactivate source', () => {
       const a = stream()
-      expect(a.changes()).toActivate(a)
+      expect(a.changes()).to.activate(a)
     })
 
     it('should be ended if source was ended', () => {
-      expect(send(stream(), ['<end>']).changes()).toEmit(['<end:current>'])
+      expect(send(stream(), ['<end>']).changes()).to.emit(['<end:current>'])
     })
 
     it('test `streamWithCurrent` helper', () => {
-      expect(streamWithCurrent({type: 'value', value: 1})).toEmit([{current: 1}])
-      expect(streamWithCurrent({type: 'error', value: 1})).toEmit([{currentError: 1}])
+      expect(streamWithCurrent({type: 'value', value: 1})).to.emit([{current: 1}])
+      expect(streamWithCurrent({type: 'error', value: 1})).to.emit([{currentError: 1}])
     })
 
     it('should handle events and current', () => {
       let a = streamWithCurrent({type: 'value', value: 1})
-      expect(a.changes()).toEmit([2, {error: 5}, 3, '<end>'], () => send(a, [2, {error: 5}, 3, '<end>']))
+      expect(a.changes()).to.emit([2, {error: 5}, 3, '<end>'], () => send(a, [2, {error: 5}, 3, '<end>']))
       a = streamWithCurrent({type: 'error', value: 1})
-      expect(a.changes()).toEmit([2, {error: 5}, 3, '<end>'], () => send(a, [2, {error: 5}, 3, '<end>']))
+      expect(a.changes()).to.emit([2, {error: 5}, 3, '<end>'], () => send(a, [2, {error: 5}, 3, '<end>']))
     })
   })
 
   describe('property', () => {
     it('should stream', () => {
-      expect(prop().changes()).toBeStream()
+      expect(prop().changes()).to.be.observable.stream()
     })
 
     it('should activate/deactivate source', () => {
       const a = prop()
-      expect(a.changes()).toActivate(a)
+      expect(a.changes()).to.activate(a)
     })
 
     it('should be ended if source was ended', () => {
-      expect(send(prop(), ['<end>']).changes()).toEmit(['<end:current>'])
+      expect(send(prop(), ['<end>']).changes()).to.emit(['<end:current>'])
     })
 
     it('should handle events and current', () => {
       const a = send(prop(), [1, {error: 4}])
-      expect(a.changes()).toEmit([2, {error: 5}, 3, '<end>'], () => send(a, [2, {error: 5}, 3, '<end>']))
+      expect(a.changes()).to.emit([2, {error: 5}, 3, '<end>'], () => send(a, [2, {error: 5}, 3, '<end>']))
     })
   })
 })

--- a/test/specs/combine.js
+++ b/test/specs/combine.js
@@ -1,47 +1,47 @@
-const {stream, prop, send, activate, deactivate, Kefir} = require('../test-helpers')
+const {stream, prop, send, activate, deactivate, Kefir, expect} = require('../test-helpers')
 
 describe('combine', () => {
   describe('array', () => {
     it('should stream', () => {
-      expect(Kefir.combine([])).toBeStream()
-      expect(Kefir.combine([stream(), prop()])).toBeStream()
-      expect(stream().combine(stream())).toBeStream()
-      expect(prop().combine(prop())).toBeStream()
+      expect(Kefir.combine([])).to.be.observable.stream()
+      expect(Kefir.combine([stream(), prop()])).to.be.observable.stream()
+      expect(stream().combine(stream())).to.be.observable.stream()
+      expect(prop().combine(prop())).to.be.observable.stream()
     })
 
     it('should be ended if empty array provided', () => {
-      expect(Kefir.combine([])).toEmit(['<end:current>'])
+      expect(Kefir.combine([])).to.emit(['<end:current>'])
     })
 
     it('should be ended if array of ended observables provided', () => {
       const a = send(stream(), ['<end>'])
       const b = send(prop(), ['<end>'])
       const c = send(stream(), ['<end>'])
-      expect(Kefir.combine([a, b, c])).toEmit(['<end:current>'])
-      expect(a.combine(b)).toEmit(['<end:current>'])
+      expect(Kefir.combine([a, b, c])).to.emit(['<end:current>'])
+      expect(a.combine(b)).to.emit(['<end:current>'])
     })
 
     it('should be ended and has current if array of ended properties provided and each of them has current', () => {
       const a = send(prop(), [1, '<end>'])
       const b = send(prop(), [2, '<end>'])
       const c = send(prop(), [3, '<end>'])
-      expect(Kefir.combine([a, b, c])).toEmit([{current: [1, 2, 3]}, '<end:current>'])
-      expect(a.combine(b)).toEmit([{current: [1, 2]}, '<end:current>'])
+      expect(Kefir.combine([a, b, c])).to.emit([{current: [1, 2, 3]}, '<end:current>'])
+      expect(a.combine(b)).to.emit([{current: [1, 2]}, '<end:current>'])
     })
 
     it('should activate sources', () => {
       const a = stream()
       const b = prop()
       const c = stream()
-      expect(Kefir.combine([a, b, c])).toActivate(a, b, c)
-      expect(a.combine(b)).toActivate(a, b)
+      expect(Kefir.combine([a, b, c])).to.activate(a, b, c)
+      expect(a.combine(b)).to.activate(a, b)
     })
 
     it('should handle events and current from observables', () => {
       let a = stream()
       let b = send(prop(), [0])
       const c = stream()
-      expect(Kefir.combine([a, b, c])).toEmit([[1, 0, 2], [1, 3, 2], [1, 4, 2], [1, 4, 5], [1, 4, 6], '<end>'], () => {
+      expect(Kefir.combine([a, b, c])).to.emit([[1, 0, 2], [1, 3, 2], [1, 4, 2], [1, 4, 5], [1, 4, 6], '<end>'], () => {
         send(a, [1])
         send(c, [2])
         send(b, [3])
@@ -51,7 +51,7 @@ describe('combine', () => {
       })
       a = stream()
       b = send(prop(), [0])
-      expect(a.combine(b)).toEmit([[1, 0], [1, 2], [1, 3], '<end>'], () => {
+      expect(a.combine(b)).to.emit([[1, 0], [1, 2], [1, 3], '<end>'], () => {
         send(a, [1])
         send(b, [2])
         send(a, ['<end>'])
@@ -64,7 +64,7 @@ describe('combine', () => {
       let b = send(prop(), [0])
       const c = stream()
       const join = (...args) => args.join('+')
-      expect(Kefir.combine([a, b, c], join)).toEmit(['1+0+2', '1+3+2', '1+4+2', '1+4+5', '1+4+6', '<end>'], () => {
+      expect(Kefir.combine([a, b, c], join)).to.emit(['1+0+2', '1+3+2', '1+4+2', '1+4+5', '1+4+6', '<end>'], () => {
         send(a, [1])
         send(c, [2])
         send(b, [3])
@@ -74,7 +74,7 @@ describe('combine', () => {
       })
       a = stream()
       b = send(prop(), [0])
-      expect(a.combine(b, join)).toEmit(['1+0', '1+2', '1+3', '<end>'], () => {
+      expect(a.combine(b, join)).to.emit(['1+0', '1+2', '1+3', '<end>'], () => {
         send(a, [1])
         send(b, [2])
         send(a, ['<end>'])
@@ -88,22 +88,22 @@ describe('combine', () => {
       const cb = Kefir.combine([a, b])
       activate(cb)
       deactivate(cb)
-      expect(cb).toEmit([{current: [0, 1]}])
+      expect(cb).to.emit([{current: [0, 1]}])
     })
 
     it('errors should flow', () => {
       let a = stream()
       let b = prop()
       let c = stream()
-      expect(Kefir.combine([a, b, c])).errorsToFlow(a)
+      expect(Kefir.combine([a, b, c])).to.flowErrors(a)
       a = stream()
       b = prop()
       c = stream()
-      expect(Kefir.combine([a, b, c])).errorsToFlow(b)
+      expect(Kefir.combine([a, b, c])).to.flowErrors(b)
       a = stream()
       b = prop()
       c = stream()
-      expect(Kefir.combine([a, b, c])).errorsToFlow(c)
+      expect(Kefir.combine([a, b, c])).to.flowErrors(c)
     })
 
     it('should handle errors correctly', () => {
@@ -119,7 +119,7 @@ describe('combine', () => {
       const a = stream()
       const b = stream()
       const c = stream()
-      expect(Kefir.combine([a, b, c])).toEmit(
+      expect(Kefir.combine([a, b, c])).to.emit(
         [
           {error: -1},
           {error: -1},
@@ -147,20 +147,20 @@ describe('combine', () => {
 
     describe('sampledBy al =>ity (3 arity combine)', () => {
       it('should stream', () => {
-        expect(Kefir.combine([], [])).toBeStream()
-        expect(Kefir.combine([stream(), prop()], [stream(), prop()])).toBeStream()
+        expect(Kefir.combine([], [])).to.be.observable.stream()
+        expect(Kefir.combine([stream(), prop()], [stream(), prop()])).to.be.observable.stream()
       })
 
       it('should be ended if empty array provided', () => {
-        expect(Kefir.combine([stream(), prop()], [])).toEmit([])
-        expect(Kefir.combine([], [stream(), prop()])).toEmit(['<end:current>'])
+        expect(Kefir.combine([stream(), prop()], [])).to.emit([])
+        expect(Kefir.combine([], [stream(), prop()])).to.emit(['<end:current>'])
       })
 
       it('should be ended if array of ended observables provided', () => {
         const a = send(stream(), ['<end>'])
         const b = send(prop(), ['<end>'])
         const c = send(stream(), ['<end>'])
-        expect(Kefir.combine([a, b, c], [stream(), prop()])).toEmit(['<end:current>'])
+        expect(Kefir.combine([a, b, c], [stream(), prop()])).to.emit(['<end:current>'])
       })
 
       it('should be ended and emmit current (once) if array of ended properties provided and each of them has current', () => {
@@ -168,15 +168,15 @@ describe('combine', () => {
         const b = send(prop(), [2, '<end>'])
         const c = send(prop(), [3, '<end>'])
         const s1 = Kefir.combine([a, b], [c])
-        expect(s1).toEmit([{current: [1, 2, 3]}, '<end:current>'])
-        expect(s1).toEmit(['<end:current>'])
+        expect(s1).to.emit([{current: [1, 2, 3]}, '<end:current>'])
+        expect(s1).to.emit(['<end:current>'])
       })
 
       it('should activate sources', () => {
         const a = stream()
         const b = prop()
         const c = stream()
-        expect(Kefir.combine([a, b], [c])).toActivate(a, b, c)
+        expect(Kefir.combine([a, b], [c])).to.activate(a, b, c)
       })
 
       it('should handle events and current from observables', () => {
@@ -184,7 +184,7 @@ describe('combine', () => {
         const b = send(prop(), [0])
         const c = stream()
         const d = stream()
-        expect(Kefir.combine([c, d], [a, b])).toEmit(
+        expect(Kefir.combine([c, d], [a, b])).to.emit(
           [[2, 3, 1, 0], [5, 3, 1, 4], [6, 3, 1, 4], [6, 7, 1, 4], '<end>'],
           () => {
             send(a, [1])
@@ -203,7 +203,7 @@ describe('combine', () => {
         const b = send(prop(), [0])
         const c = stream()
         const d = stream()
-        expect(Kefir.combine([c, d], [a, b], join)).toEmit(
+        expect(Kefir.combine([c, d], [a, b], join)).to.emit(
           ['2+3+1+0', '5+3+1+4', '6+3+1+4', '6+7+1+4', '<end>'],
           () => {
             send(a, [1])
@@ -223,7 +223,7 @@ describe('combine', () => {
         const sb = Kefir.combine([a, b], [c])
         activate(sb)
         deactivate(sb)
-        expect(sb).toEmit([{current: [0, 1, 2]}])
+        expect(sb).to.emit([{current: [0, 1, 2]}])
       })
 
       it('errors should flow', () => {
@@ -231,12 +231,12 @@ describe('combine', () => {
         let b = prop()
         let c = stream()
         let d = prop()
-        expect(Kefir.combine([a, b], [c, d])).errorsToFlow(a)
+        expect(Kefir.combine([a, b], [c, d])).to.flowErrors(a)
         a = stream()
         b = prop()
         c = stream()
         d = prop()
-        expect(Kefir.combine([a, b], [c, d])).errorsToFlow(b)
+        expect(Kefir.combine([a, b], [c, d])).to.flowErrors(b)
       })
 
       // https://github.com/rpominov/kefir/issues/98
@@ -244,47 +244,47 @@ describe('combine', () => {
         const a = stream()
         const b = a.map(x => x + 2)
         const c = a.map(x => x * 2)
-        expect(Kefir.combine([b], [c])).toEmit([[3, 2], [4, 4], [5, 6]], () => send(a, [1, 2, 3]))
+        expect(Kefir.combine([b], [c])).to.emit([[3, 2], [4, 4], [5, 6]], () => send(a, [1, 2, 3]))
       })
     })
   })
 
   describe('object', () => {
     it('should stream', () => {
-      expect(Kefir.combine({})).toBeStream()
-      expect(Kefir.combine({s: stream(), p: prop()})).toBeStream()
+      expect(Kefir.combine({})).to.be.observable.stream()
+      expect(Kefir.combine({s: stream(), p: prop()})).to.be.observable.stream()
     })
 
     it('should be ended if empty array provided', () => {
-      expect(Kefir.combine({})).toEmit(['<end:current>'])
+      expect(Kefir.combine({})).to.emit(['<end:current>'])
     })
 
     it('should be ended if array of ended observables provided', () => {
       const a = send(stream(), ['<end>'])
       const b = send(prop(), ['<end>'])
       const c = send(stream(), ['<end>'])
-      expect(Kefir.combine({a, b, c})).toEmit(['<end:current>'])
+      expect(Kefir.combine({a, b, c})).to.emit(['<end:current>'])
     })
 
     it('should be ended and has current if array of ended properties provided and each of them has current', () => {
       const a = send(prop(), [1, '<end>'])
       const b = send(prop(), [2, '<end>'])
       const c = send(prop(), [3, '<end>'])
-      expect(Kefir.combine({a, b, c})).toEmit([{current: {a: 1, b: 2, c: 3}}, '<end:current>'])
+      expect(Kefir.combine({a, b, c})).to.emit([{current: {a: 1, b: 2, c: 3}}, '<end:current>'])
     })
 
     it('should activate sources', () => {
       const a = stream()
       const b = prop()
       const c = stream()
-      expect(Kefir.combine({a, b, c})).toActivate(a, b, c)
+      expect(Kefir.combine({a, b, c})).to.activate(a, b, c)
     })
 
     it('should handle events and current from observables', () => {
       const a = stream()
       const b = send(prop(), [0])
       const c = stream()
-      expect(Kefir.combine({a, b, c})).toEmit(
+      expect(Kefir.combine({a, b, c})).to.emit(
         [{a: 1, b: 0, c: 2}, {a: 1, b: 3, c: 2}, {a: 1, b: 4, c: 2}, {a: 1, b: 4, c: 5}, {a: 1, b: 4, c: 6}, '<end>'],
         () => {
           send(a, [1])
@@ -302,7 +302,7 @@ describe('combine', () => {
       const b = send(prop(), [0])
       const c = stream()
       const join = ev => ev.a + '+' + ev.b + '+' + ev.c
-      expect(Kefir.combine({a, b, c}, join)).toEmit(['1+0+2', '1+3+2', '1+4+2', '1+4+5', '1+4+6', '<end>'], () => {
+      expect(Kefir.combine({a, b, c}, join)).to.emit(['1+0+2', '1+3+2', '1+4+2', '1+4+5', '1+4+6', '<end>'], () => {
         send(a, [1])
         send(c, [2])
         send(b, [3])
@@ -318,22 +318,22 @@ describe('combine', () => {
       const cb = Kefir.combine({a, b})
       activate(cb)
       deactivate(cb)
-      expect(cb).toEmit([{current: {a: 0, b: 1}}])
+      expect(cb).to.emit([{current: {a: 0, b: 1}}])
     })
 
     it('errors should flow', () => {
       let a = stream()
       let b = prop()
       let c = stream()
-      expect(Kefir.combine({a, b, c})).errorsToFlow(a)
+      expect(Kefir.combine({a, b, c})).to.flowErrors(a)
       a = stream()
       b = prop()
       c = stream()
-      expect(Kefir.combine({a, b, c})).errorsToFlow(b)
+      expect(Kefir.combine({a, b, c})).to.flowErrors(b)
       a = stream()
       b = prop()
       c = stream()
-      expect(Kefir.combine({a, b, c})).errorsToFlow(c)
+      expect(Kefir.combine({a, b, c})).to.flowErrors(c)
     })
 
     it('should handle errors correctly', () => {
@@ -349,7 +349,7 @@ describe('combine', () => {
       const a = stream()
       const b = stream()
       const c = stream()
-      expect(Kefir.combine({a, b, c})).toEmit(
+      expect(Kefir.combine({a, b, c})).to.emit(
         [
           {error: -1},
           {error: -1},
@@ -377,20 +377,20 @@ describe('combine', () => {
 
     describe('sampledBy al =>ity (3 arity combine)', () => {
       it('should stream', () => {
-        expect(Kefir.combine({}, {})).toBeStream()
-        expect(Kefir.combine({s1: stream(), p1: prop()}, {s2: stream(), p2: prop()})).toBeStream()
+        expect(Kefir.combine({}, {})).to.be.observable.stream()
+        expect(Kefir.combine({s1: stream(), p1: prop()}, {s2: stream(), p2: prop()})).to.be.observable.stream()
       })
 
       it('should be ended if empty array provided', () => {
-        expect(Kefir.combine({s1: stream(), p1: prop()}, {})).toEmit([])
-        expect(Kefir.combine({}, {s2: stream(), p2: prop()})).toEmit(['<end:current>'])
+        expect(Kefir.combine({s1: stream(), p1: prop()}, {})).to.emit([])
+        expect(Kefir.combine({}, {s2: stream(), p2: prop()})).to.emit(['<end:current>'])
       })
 
       it('should be ended if array of ended observables provided', () => {
         const a = send(stream(), ['<end>'])
         const b = send(prop(), ['<end>'])
         const c = send(stream(), ['<end>'])
-        expect(Kefir.combine({a, b, c}, {d: stream(), e: prop()})).toEmit(['<end:current>'])
+        expect(Kefir.combine({a, b, c}, {d: stream(), e: prop()})).to.emit(['<end:current>'])
       })
 
       it('should be ended and emmit current (once) if array of ended properties provided and each of them has current', () => {
@@ -398,15 +398,15 @@ describe('combine', () => {
         const b = send(prop(), [2, '<end>'])
         const c = send(prop(), [3, '<end>'])
         const s1 = Kefir.combine({a, b}, {c})
-        expect(s1).toEmit([{current: {a: 1, b: 2, c: 3}}, '<end:current>'])
-        expect(s1).toEmit(['<end:current>'])
+        expect(s1).to.emit([{current: {a: 1, b: 2, c: 3}}, '<end:current>'])
+        expect(s1).to.emit(['<end:current>'])
       })
 
       it('should activate sources', () => {
         const a = stream()
         const b = prop()
         const c = stream()
-        expect(Kefir.combine({a, b}, {c})).toActivate(a, b, c)
+        expect(Kefir.combine({a, b}, {c})).to.activate(a, b, c)
       })
 
       it('should handle events and current from observables', () => {
@@ -414,7 +414,7 @@ describe('combine', () => {
         const b = send(prop(), [0])
         const c = stream()
         const d = stream()
-        expect(Kefir.combine({c, d}, {a, b})).toEmit(
+        expect(Kefir.combine({c, d}, {a, b})).to.emit(
           [
             {a: 1, b: 0, c: 2, d: 3},
             {a: 1, b: 4, c: 5, d: 3},
@@ -439,7 +439,7 @@ describe('combine', () => {
         const b = send(prop(), [0])
         const c = stream()
         const d = stream()
-        expect(Kefir.combine({c, d}, {a, b}, join)).toEmit(
+        expect(Kefir.combine({c, d}, {a, b}, join)).to.emit(
           ['2+3+1+0', '5+3+1+4', '6+3+1+4', '6+7+1+4', '<end>'],
           () => {
             send(a, [1])
@@ -459,7 +459,7 @@ describe('combine', () => {
         const sb = Kefir.combine({a, b}, {c})
         activate(sb)
         deactivate(sb)
-        expect(sb).toEmit([{current: {a: 0, b: 1, c: 2}}])
+        expect(sb).to.emit([{current: {a: 0, b: 1, c: 2}}])
       })
 
       it('errors should flow', () => {
@@ -467,12 +467,12 @@ describe('combine', () => {
         let b = prop()
         let c = stream()
         let d = prop()
-        expect(Kefir.combine({a, b}, {c, d})).errorsToFlow(a)
+        expect(Kefir.combine({a, b}, {c, d})).to.flowErrors(a)
         a = stream()
         b = prop()
         c = stream()
         d = prop()
-        expect(Kefir.combine({a, b}, {c, d})).errorsToFlow(b)
+        expect(Kefir.combine({a, b}, {c, d})).to.flowErrors(b)
       })
 
       // https://github.com/rpominov/kefir/issues/98
@@ -480,7 +480,7 @@ describe('combine', () => {
         const a = stream()
         const b = a.map(x => x + 2)
         const c = a.map(x => x * 2)
-        expect(Kefir.combine({b}, {c})).toEmit([{b: 3, c: 2}, {b: 4, c: 4}, {b: 5, c: 6}], () => send(a, [1, 2, 3]))
+        expect(Kefir.combine({b}, {c})).to.emit([{b: 3, c: 2}, {b: 4, c: 4}, {b: 5, c: 6}], () => send(a, [1, 2, 3]))
       })
 
       it('should prefer active keys over passive keys', () => {
@@ -488,7 +488,7 @@ describe('combine', () => {
         const b = stream()
         const _a = stream()
 
-        expect(Kefir.combine({a, b}, {a: _a})).toEmit([{a: 1, b: 4}, {a: 2, b: 4}, {a: 3, b: 4}], () => {
+        expect(Kefir.combine({a, b}, {a: _a})).to.emit([{a: 1, b: 4}, {a: 2, b: 4}, {a: 3, b: 4}], () => {
           send(_a, [-1])
           send(a, [1])
           send(b, [4])
@@ -507,7 +507,7 @@ describe('combine', () => {
       const b = stream()
       const arrayAndObject = () => Kefir.combine([a], {b})
       const objectAndArray = () => Kefir.combine({a}, [b])
-      expect(arrayAndObject).toThrow()
-      expect(objectAndArray).toThrow()
+      expect(arrayAndObject).to.throw()
+      expect(objectAndArray).to.throw()
     }))
 })

--- a/test/specs/combine.js
+++ b/test/specs/combine.js
@@ -1,4 +1,4 @@
-const {stream, prop, send, activate, deactivate, Kefir, expect} = require('../test-helpers')
+const {stream, prop, send, value, error, end, activate, deactivate, Kefir, expect} = require('../test-helpers')
 
 describe('combine', () => {
   describe('array', () => {
@@ -10,23 +10,23 @@ describe('combine', () => {
     })
 
     it('should be ended if empty array provided', () => {
-      expect(Kefir.combine([])).to.emit(['<end:current>'])
+      expect(Kefir.combine([])).to.emit([end({current: true})])
     })
 
     it('should be ended if array of ended observables provided', () => {
-      const a = send(stream(), ['<end>'])
-      const b = send(prop(), ['<end>'])
-      const c = send(stream(), ['<end>'])
-      expect(Kefir.combine([a, b, c])).to.emit(['<end:current>'])
-      expect(a.combine(b)).to.emit(['<end:current>'])
+      const a = send(stream(), [end()])
+      const b = send(prop(), [end()])
+      const c = send(stream(), [end()])
+      expect(Kefir.combine([a, b, c])).to.emit([end({current: true})])
+      expect(a.combine(b)).to.emit([end({current: true})])
     })
 
     it('should be ended and has current if array of ended properties provided and each of them has current', () => {
-      const a = send(prop(), [1, '<end>'])
-      const b = send(prop(), [2, '<end>'])
-      const c = send(prop(), [3, '<end>'])
-      expect(Kefir.combine([a, b, c])).to.emit([{current: [1, 2, 3]}, '<end:current>'])
-      expect(a.combine(b)).to.emit([{current: [1, 2]}, '<end:current>'])
+      const a = send(prop(), [value(1), end()])
+      const b = send(prop(), [value(2), end()])
+      const c = send(prop(), [value(3), end()])
+      expect(Kefir.combine([a, b, c])).to.emit([value([1, 2, 3], {current: true}), end({current: true})])
+      expect(a.combine(b)).to.emit([value([1, 2], {current: true}), end({current: true})])
     })
 
     it('should activate sources', () => {
@@ -39,56 +39,62 @@ describe('combine', () => {
 
     it('should handle events and current from observables', () => {
       let a = stream()
-      let b = send(prop(), [0])
+      let b = send(prop(), [value(0)])
       const c = stream()
-      expect(Kefir.combine([a, b, c])).to.emit([[1, 0, 2], [1, 3, 2], [1, 4, 2], [1, 4, 5], [1, 4, 6], '<end>'], () => {
-        send(a, [1])
-        send(c, [2])
-        send(b, [3])
-        send(a, ['<end>'])
-        send(b, [4, '<end>'])
-        send(c, [5, 6, '<end>'])
-      })
+      expect(Kefir.combine([a, b, c])).to.emit(
+        [value([1, 0, 2]), value([1, 3, 2]), value([1, 4, 2]), value([1, 4, 5]), value([1, 4, 6]), end()],
+        () => {
+          send(a, [value(1)])
+          send(c, [value(2)])
+          send(b, [value(3)])
+          send(a, [end()])
+          send(b, [value(4), end()])
+          send(c, [value(5), value(6), end()])
+        }
+      )
       a = stream()
-      b = send(prop(), [0])
-      expect(a.combine(b)).to.emit([[1, 0], [1, 2], [1, 3], '<end>'], () => {
-        send(a, [1])
-        send(b, [2])
-        send(a, ['<end>'])
-        send(b, [3, '<end>'])
+      b = send(prop(), [value(0)])
+      expect(a.combine(b)).to.emit([value([1, 0]), value([1, 2]), value([1, 3]), end()], () => {
+        send(a, [value(1)])
+        send(b, [value(2)])
+        send(a, [end()])
+        send(b, [value(3), end()])
       })
     })
 
     it('should accept optional combinator function', () => {
       let a = stream()
-      let b = send(prop(), [0])
+      let b = send(prop(), [value(0)])
       const c = stream()
       const join = (...args) => args.join('+')
-      expect(Kefir.combine([a, b, c], join)).to.emit(['1+0+2', '1+3+2', '1+4+2', '1+4+5', '1+4+6', '<end>'], () => {
-        send(a, [1])
-        send(c, [2])
-        send(b, [3])
-        send(a, ['<end>'])
-        send(b, [4, '<end>'])
-        send(c, [5, 6, '<end>'])
-      })
+      expect(Kefir.combine([a, b, c], join)).to.emit(
+        [value('1+0+2'), value('1+3+2'), value('1+4+2'), value('1+4+5'), value('1+4+6'), end()],
+        () => {
+          send(a, [value(1)])
+          send(c, [value(2)])
+          send(b, [value(3)])
+          send(a, [end()])
+          send(b, [value(4), end()])
+          send(c, [value(5), value(6), end()])
+        }
+      )
       a = stream()
-      b = send(prop(), [0])
-      expect(a.combine(b, join)).to.emit(['1+0', '1+2', '1+3', '<end>'], () => {
-        send(a, [1])
-        send(b, [2])
-        send(a, ['<end>'])
-        send(b, [3, '<end>'])
+      b = send(prop(), [value(0)])
+      expect(a.combine(b, join)).to.emit([value('1+0'), value('1+2'), value('1+3'), end()], () => {
+        send(a, [value(1)])
+        send(b, [value(2)])
+        send(a, [end()])
+        send(b, [value(3), end()])
       })
     })
 
     it('when activating second time and has 2+ properties in sources, should emit current value at most once', () => {
-      const a = send(prop(), [0])
-      const b = send(prop(), [1])
+      const a = send(prop(), [value(0)])
+      const b = send(prop(), [value(1)])
       const cb = Kefir.combine([a, b])
       activate(cb)
       deactivate(cb)
-      expect(cb).to.emit([{current: [0, 1]}])
+      expect(cb).to.emit([value([0, 1], {current: true})])
     })
 
     it('errors should flow', () => {
@@ -121,26 +127,26 @@ describe('combine', () => {
       const c = stream()
       expect(Kefir.combine([a, b, c])).to.emit(
         [
-          {error: -1},
-          {error: -1},
-          {error: -1},
-          [3, 1, 2],
-          {error: -2},
-          {error: -3},
-          {error: -3},
-          {error: -2},
-          [4, 6, 5],
+          error(-1),
+          error(-1),
+          error(-1),
+          value([3, 1, 2]),
+          error(-2),
+          error(-3),
+          error(-3),
+          error(-2),
+          value([4, 6, 5]),
         ],
         () => {
-          send(a, [{error: -1}])
-          send(b, [1])
-          send(c, [2])
-          send(a, [3])
-          send(b, [{error: -2}])
-          send(c, [{error: -3}])
-          send(a, [4])
-          send(c, [5])
-          send(b, [6])
+          send(a, [error(-1)])
+          send(b, [value(1)])
+          send(c, [value(2)])
+          send(a, [value(3)])
+          send(b, [error(-2)])
+          send(c, [error(-3)])
+          send(a, [value(4)])
+          send(c, [value(5)])
+          send(b, [value(6)])
         }
       )
     })
@@ -153,23 +159,23 @@ describe('combine', () => {
 
       it('should be ended if empty array provided', () => {
         expect(Kefir.combine([stream(), prop()], [])).to.emit([])
-        expect(Kefir.combine([], [stream(), prop()])).to.emit(['<end:current>'])
+        expect(Kefir.combine([], [stream(), prop()])).to.emit([end({current: true})])
       })
 
       it('should be ended if array of ended observables provided', () => {
-        const a = send(stream(), ['<end>'])
-        const b = send(prop(), ['<end>'])
-        const c = send(stream(), ['<end>'])
-        expect(Kefir.combine([a, b, c], [stream(), prop()])).to.emit(['<end:current>'])
+        const a = send(stream(), [end()])
+        const b = send(prop(), [end()])
+        const c = send(stream(), [end()])
+        expect(Kefir.combine([a, b, c], [stream(), prop()])).to.emit([end({current: true})])
       })
 
       it('should be ended and emmit current (once) if array of ended properties provided and each of them has current', () => {
-        const a = send(prop(), [1, '<end>'])
-        const b = send(prop(), [2, '<end>'])
-        const c = send(prop(), [3, '<end>'])
+        const a = send(prop(), [value(1), end()])
+        const b = send(prop(), [value(2), end()])
+        const c = send(prop(), [value(3), end()])
         const s1 = Kefir.combine([a, b], [c])
-        expect(s1).to.emit([{current: [1, 2, 3]}, '<end:current>'])
-        expect(s1).to.emit(['<end:current>'])
+        expect(s1).to.emit([value([1, 2, 3], {current: true}), end({current: true})])
+        expect(s1).to.emit([end({current: true})])
       })
 
       it('should activate sources', () => {
@@ -181,18 +187,18 @@ describe('combine', () => {
 
       it('should handle events and current from observables', () => {
         const a = stream()
-        const b = send(prop(), [0])
+        const b = send(prop(), [value(0)])
         const c = stream()
         const d = stream()
         expect(Kefir.combine([c, d], [a, b])).to.emit(
-          [[2, 3, 1, 0], [5, 3, 1, 4], [6, 3, 1, 4], [6, 7, 1, 4], '<end>'],
+          [value([2, 3, 1, 0]), value([5, 3, 1, 4]), value([6, 3, 1, 4]), value([6, 7, 1, 4]), end()],
           () => {
-            send(a, [1])
-            send(c, [2])
-            send(d, [3])
-            send(b, [4, '<end>'])
-            send(c, [5, 6, '<end>'])
-            send(d, [7, '<end>'])
+            send(a, [value(1)])
+            send(c, [value(2)])
+            send(d, [value(3)])
+            send(b, [value(4), end()])
+            send(c, [value(5), value(6), end()])
+            send(d, [value(7), end()])
           }
         )
       })
@@ -200,30 +206,30 @@ describe('combine', () => {
       it('should accept optional combinator function', () => {
         const join = (...args) => args.join('+')
         const a = stream()
-        const b = send(prop(), [0])
+        const b = send(prop(), [value(0)])
         const c = stream()
         const d = stream()
         expect(Kefir.combine([c, d], [a, b], join)).to.emit(
-          ['2+3+1+0', '5+3+1+4', '6+3+1+4', '6+7+1+4', '<end>'],
+          [value('2+3+1+0'), value('5+3+1+4'), value('6+3+1+4'), value('6+7+1+4'), end()],
           () => {
-            send(a, [1])
-            send(c, [2])
-            send(d, [3])
-            send(b, [4, '<end>'])
-            send(c, [5, 6, '<end>'])
-            send(d, [7, '<end>'])
+            send(a, [value(1)])
+            send(c, [value(2)])
+            send(d, [value(3)])
+            send(b, [value(4), end()])
+            send(c, [value(5), value(6), end()])
+            send(d, [value(7), end()])
           }
         )
       })
 
       it('when activating second time and has 2+ properties in sources, should emit current value at most once', () => {
-        const a = send(prop(), [0])
-        const b = send(prop(), [1])
-        const c = send(prop(), [2])
+        const a = send(prop(), [value(0)])
+        const b = send(prop(), [value(1)])
+        const c = send(prop(), [value(2)])
         const sb = Kefir.combine([a, b], [c])
         activate(sb)
         deactivate(sb)
-        expect(sb).to.emit([{current: [0, 1, 2]}])
+        expect(sb).to.emit([value([0, 1, 2], {current: true})])
       })
 
       it('errors should flow', () => {
@@ -244,7 +250,9 @@ describe('combine', () => {
         const a = stream()
         const b = a.map(x => x + 2)
         const c = a.map(x => x * 2)
-        expect(Kefir.combine([b], [c])).to.emit([[3, 2], [4, 4], [5, 6]], () => send(a, [1, 2, 3]))
+        expect(Kefir.combine([b], [c])).to.emit([value([3, 2]), value([4, 4]), value([5, 6])], () =>
+          send(a, [value(1), value(2), value(3)])
+        )
       })
     })
   })
@@ -256,21 +264,21 @@ describe('combine', () => {
     })
 
     it('should be ended if empty array provided', () => {
-      expect(Kefir.combine({})).to.emit(['<end:current>'])
+      expect(Kefir.combine({})).to.emit([end({current: true})])
     })
 
     it('should be ended if array of ended observables provided', () => {
-      const a = send(stream(), ['<end>'])
-      const b = send(prop(), ['<end>'])
-      const c = send(stream(), ['<end>'])
-      expect(Kefir.combine({a, b, c})).to.emit(['<end:current>'])
+      const a = send(stream(), [end()])
+      const b = send(prop(), [end()])
+      const c = send(stream(), [end()])
+      expect(Kefir.combine({a, b, c})).to.emit([end({current: true})])
     })
 
     it('should be ended and has current if array of ended properties provided and each of them has current', () => {
-      const a = send(prop(), [1, '<end>'])
-      const b = send(prop(), [2, '<end>'])
-      const c = send(prop(), [3, '<end>'])
-      expect(Kefir.combine({a, b, c})).to.emit([{current: {a: 1, b: 2, c: 3}}, '<end:current>'])
+      const a = send(prop(), [value(1), end()])
+      const b = send(prop(), [value(2), end()])
+      const c = send(prop(), [value(3), end()])
+      expect(Kefir.combine({a, b, c})).to.emit([value({a: 1, b: 2, c: 3}, {current: true}), end({current: true})])
     })
 
     it('should activate sources', () => {
@@ -282,43 +290,53 @@ describe('combine', () => {
 
     it('should handle events and current from observables', () => {
       const a = stream()
-      const b = send(prop(), [0])
+      const b = send(prop(), [value(0)])
       const c = stream()
       expect(Kefir.combine({a, b, c})).to.emit(
-        [{a: 1, b: 0, c: 2}, {a: 1, b: 3, c: 2}, {a: 1, b: 4, c: 2}, {a: 1, b: 4, c: 5}, {a: 1, b: 4, c: 6}, '<end>'],
+        [
+          value({a: 1, b: 0, c: 2}),
+          value({a: 1, b: 3, c: 2}),
+          value({a: 1, b: 4, c: 2}),
+          value({a: 1, b: 4, c: 5}),
+          value({a: 1, b: 4, c: 6}),
+          end(),
+        ],
         () => {
-          send(a, [1])
-          send(c, [2])
-          send(b, [3])
-          send(a, ['<end>'])
-          send(b, [4, '<end>'])
-          send(c, [5, 6, '<end>'])
+          send(a, [value(1)])
+          send(c, [value(2)])
+          send(b, [value(3)])
+          send(a, [end()])
+          send(b, [value(4), end()])
+          send(c, [value(5), value(6), end()])
         }
       )
     })
 
     it('should accept optional combinator function', () => {
       const a = stream()
-      const b = send(prop(), [0])
+      const b = send(prop(), [value(0)])
       const c = stream()
       const join = ev => ev.a + '+' + ev.b + '+' + ev.c
-      expect(Kefir.combine({a, b, c}, join)).to.emit(['1+0+2', '1+3+2', '1+4+2', '1+4+5', '1+4+6', '<end>'], () => {
-        send(a, [1])
-        send(c, [2])
-        send(b, [3])
-        send(a, ['<end>'])
-        send(b, [4, '<end>'])
-        send(c, [5, 6, '<end>'])
-      })
+      expect(Kefir.combine({a, b, c}, join)).to.emit(
+        [value('1+0+2'), value('1+3+2'), value('1+4+2'), value('1+4+5'), value('1+4+6'), end()],
+        () => {
+          send(a, [value(1)])
+          send(c, [value(2)])
+          send(b, [value(3)])
+          send(a, [end()])
+          send(b, [value(4), end()])
+          send(c, [value(5), value(6), end()])
+        }
+      )
     })
 
     it('when activating second time and has 2+ properties in sources, should emit current value at most once', () => {
-      const a = send(prop(), [0])
-      const b = send(prop(), [1])
+      const a = send(prop(), [value(0)])
+      const b = send(prop(), [value(1)])
       const cb = Kefir.combine({a, b})
       activate(cb)
       deactivate(cb)
-      expect(cb).to.emit([{current: {a: 0, b: 1}}])
+      expect(cb).to.emit([value({a: 0, b: 1}, {current: true})])
     })
 
     it('errors should flow', () => {
@@ -351,26 +369,26 @@ describe('combine', () => {
       const c = stream()
       expect(Kefir.combine({a, b, c})).to.emit(
         [
-          {error: -1},
-          {error: -1},
-          {error: -1},
-          {a: 3, b: 1, c: 2},
-          {error: -2},
-          {error: -3},
-          {error: -3},
-          {error: -2},
-          {a: 4, b: 6, c: 5},
+          error(-1),
+          error(-1),
+          error(-1),
+          value({a: 3, b: 1, c: 2}),
+          error(-2),
+          error(-3),
+          error(-3),
+          error(-2),
+          value({a: 4, b: 6, c: 5}),
         ],
         () => {
-          send(a, [{error: -1}])
-          send(b, [1])
-          send(c, [2])
-          send(a, [3])
-          send(b, [{error: -2}])
-          send(c, [{error: -3}])
-          send(a, [4])
-          send(c, [5])
-          send(b, [6])
+          send(a, [error(-1)])
+          send(b, [value(1)])
+          send(c, [value(2)])
+          send(a, [value(3)])
+          send(b, [error(-2)])
+          send(c, [error(-3)])
+          send(a, [value(4)])
+          send(c, [value(5)])
+          send(b, [value(6)])
         }
       )
     })
@@ -383,23 +401,23 @@ describe('combine', () => {
 
       it('should be ended if empty array provided', () => {
         expect(Kefir.combine({s1: stream(), p1: prop()}, {})).to.emit([])
-        expect(Kefir.combine({}, {s2: stream(), p2: prop()})).to.emit(['<end:current>'])
+        expect(Kefir.combine({}, {s2: stream(), p2: prop()})).to.emit([end({current: true})])
       })
 
       it('should be ended if array of ended observables provided', () => {
-        const a = send(stream(), ['<end>'])
-        const b = send(prop(), ['<end>'])
-        const c = send(stream(), ['<end>'])
-        expect(Kefir.combine({a, b, c}, {d: stream(), e: prop()})).to.emit(['<end:current>'])
+        const a = send(stream(), [end()])
+        const b = send(prop(), [end()])
+        const c = send(stream(), [end()])
+        expect(Kefir.combine({a, b, c}, {d: stream(), e: prop()})).to.emit([end({current: true})])
       })
 
       it('should be ended and emmit current (once) if array of ended properties provided and each of them has current', () => {
-        const a = send(prop(), [1, '<end>'])
-        const b = send(prop(), [2, '<end>'])
-        const c = send(prop(), [3, '<end>'])
+        const a = send(prop(), [value(1), end()])
+        const b = send(prop(), [value(2), end()])
+        const c = send(prop(), [value(3), end()])
         const s1 = Kefir.combine({a, b}, {c})
-        expect(s1).to.emit([{current: {a: 1, b: 2, c: 3}}, '<end:current>'])
-        expect(s1).to.emit(['<end:current>'])
+        expect(s1).to.emit([value({a: 1, b: 2, c: 3}, {current: true}), end({current: true})])
+        expect(s1).to.emit([end({current: true})])
       })
 
       it('should activate sources', () => {
@@ -411,24 +429,24 @@ describe('combine', () => {
 
       it('should handle events and current from observables', () => {
         const a = stream()
-        const b = send(prop(), [0])
+        const b = send(prop(), [value(0)])
         const c = stream()
         const d = stream()
         expect(Kefir.combine({c, d}, {a, b})).to.emit(
           [
-            {a: 1, b: 0, c: 2, d: 3},
-            {a: 1, b: 4, c: 5, d: 3},
-            {a: 1, b: 4, c: 6, d: 3},
-            {a: 1, b: 4, c: 6, d: 7},
-            '<end>',
+            value({a: 1, b: 0, c: 2, d: 3}),
+            value({a: 1, b: 4, c: 5, d: 3}),
+            value({a: 1, b: 4, c: 6, d: 3}),
+            value({a: 1, b: 4, c: 6, d: 7}),
+            end(),
           ],
           () => {
-            send(a, [1])
-            send(c, [2])
-            send(d, [3])
-            send(b, [4, '<end>'])
-            send(c, [5, 6, '<end>'])
-            send(d, [7, '<end>'])
+            send(a, [value(1)])
+            send(c, [value(2)])
+            send(d, [value(3)])
+            send(b, [value(4), end()])
+            send(c, [value(5), value(6), end()])
+            send(d, [value(7), end()])
           }
         )
       })
@@ -436,30 +454,30 @@ describe('combine', () => {
       it('should accept optional combinator function', () => {
         const join = msg => msg.c + '+' + msg.d + '+' + msg.a + '+' + msg.b
         const a = stream()
-        const b = send(prop(), [0])
+        const b = send(prop(), [value(0)])
         const c = stream()
         const d = stream()
         expect(Kefir.combine({c, d}, {a, b}, join)).to.emit(
-          ['2+3+1+0', '5+3+1+4', '6+3+1+4', '6+7+1+4', '<end>'],
+          [value('2+3+1+0'), value('5+3+1+4'), value('6+3+1+4'), value('6+7+1+4'), end()],
           () => {
-            send(a, [1])
-            send(c, [2])
-            send(d, [3])
-            send(b, [4, '<end>'])
-            send(c, [5, 6, '<end>'])
-            send(d, [7, '<end>'])
+            send(a, [value(1)])
+            send(c, [value(2)])
+            send(d, [value(3)])
+            send(b, [value(4), end()])
+            send(c, [value(5), value(6), end()])
+            send(d, [value(7), end()])
           }
         )
       })
 
       it('when activating second time and has 2+ properties in sources, should emit current value at most once', () => {
-        const a = send(prop(), [0])
-        const b = send(prop(), [1])
-        const c = send(prop(), [2])
+        const a = send(prop(), [value(0)])
+        const b = send(prop(), [value(1)])
+        const c = send(prop(), [value(2)])
         const sb = Kefir.combine({a, b}, {c})
         activate(sb)
         deactivate(sb)
-        expect(sb).to.emit([{current: {a: 0, b: 1, c: 2}}])
+        expect(sb).to.emit([value({a: 0, b: 1, c: 2}, {current: true})])
       })
 
       it('errors should flow', () => {
@@ -480,7 +498,9 @@ describe('combine', () => {
         const a = stream()
         const b = a.map(x => x + 2)
         const c = a.map(x => x * 2)
-        expect(Kefir.combine({b}, {c})).to.emit([{b: 3, c: 2}, {b: 4, c: 4}, {b: 5, c: 6}], () => send(a, [1, 2, 3]))
+        expect(Kefir.combine({b}, {c})).to.emit([value({b: 3, c: 2}), value({b: 4, c: 4}), value({b: 5, c: 6})], () =>
+          send(a, [value(1), value(2), value(3)])
+        )
       })
 
       it('should prefer active keys over passive keys', () => {
@@ -488,15 +508,18 @@ describe('combine', () => {
         const b = stream()
         const _a = stream()
 
-        expect(Kefir.combine({a, b}, {a: _a})).to.emit([{a: 1, b: 4}, {a: 2, b: 4}, {a: 3, b: 4}], () => {
-          send(_a, [-1])
-          send(a, [1])
-          send(b, [4])
-          send(_a, [-2])
-          send(a, [2])
-          send(_a, [-3])
-          send(a, [3])
-        })
+        expect(Kefir.combine({a, b}, {a: _a})).to.emit(
+          [value({a: 1, b: 4}), value({a: 2, b: 4}), value({a: 3, b: 4})],
+          () => {
+            send(_a, [value(-1)])
+            send(a, [value(1)])
+            send(b, [value(4)])
+            send(_a, [value(-2)])
+            send(a, [value(2)])
+            send(_a, [value(-3)])
+            send(a, [value(3)])
+          }
+        )
       })
     })
   })

--- a/test/specs/concat.js
+++ b/test/specs/concat.js
@@ -1,4 +1,4 @@
-const {stream, prop, send, activate, deactivate, Kefir, expect} = require('../test-helpers')
+const {stream, prop, send, value, end, activate, deactivate, Kefir, expect} = require('../test-helpers')
 
 describe('concat', () => {
   it('should stream', () => {
@@ -9,15 +9,15 @@ describe('concat', () => {
   })
 
   it('should be ended if empty array provided', () => {
-    expect(Kefir.concat([])).to.emit(['<end:current>'])
+    expect(Kefir.concat([])).to.emit([end({current: true})])
   })
 
   it('should be ended if array of ended observables provided', () => {
-    const a = send(stream(), ['<end>'])
-    const b = send(prop(), ['<end>'])
-    const c = send(stream(), ['<end>'])
-    expect(Kefir.concat([a, b, c])).to.emit(['<end:current>'])
-    expect(a.concat(b)).to.emit(['<end:current>'])
+    const a = send(stream(), [end()])
+    const b = send(prop(), [end()])
+    const c = send(stream(), [end()])
+    expect(Kefir.concat([a, b, c])).to.emit([end({current: true})])
+    expect(a.concat(b)).to.emit([end({current: true})])
   })
 
   it('should activate only current source', () => {
@@ -28,7 +28,7 @@ describe('concat', () => {
     expect(Kefir.concat([a, b, c])).not.to.activate(b, c)
     expect(a.concat(b)).to.activate(a)
     expect(a.concat(b)).not.to.activate(b)
-    send(a, ['<end>'])
+    send(a, [end()])
     expect(Kefir.concat([a, b, c])).to.activate(b)
     expect(Kefir.concat([a, b, c])).not.to.activate(a, c)
     expect(a.concat(b)).to.activate(b)
@@ -36,36 +36,39 @@ describe('concat', () => {
   })
 
   it('should deliver events from observables, then end when all of them end', () => {
-    let a = send(prop(), [0])
+    let a = send(prop(), [value(0)])
     let b = prop()
     const c = stream()
-    expect(Kefir.concat([a, b, c])).to.emit([{current: 0}, 1, 4, 2, 5, 7, 8, '<end>'], () => {
-      send(a, [1])
-      send(b, [2])
-      send(c, [3])
-      send(a, [4, '<end>'])
-      send(b, [5])
-      send(c, [6])
-      send(b, ['<end>'])
-      send(c, [7, 8, '<end>'])
-    })
-    a = send(prop(), [0])
+    expect(Kefir.concat([a, b, c])).to.emit(
+      [value(0, {current: true}), value(1), value(4), value(2), value(5), value(7), value(8), end()],
+      () => {
+        send(a, [value(1)])
+        send(b, [value(2)])
+        send(c, [value(3)])
+        send(a, [value(4), end()])
+        send(b, [value(5)])
+        send(c, [value(6)])
+        send(b, [end()])
+        send(c, [value(7), value(8), end()])
+      }
+    )
+    a = send(prop(), [value(0)])
     b = stream()
-    expect(a.concat(b)).to.emit([{current: 0}, 1, 3, 4, '<end>'], () => {
-      send(a, [1])
-      send(b, [2])
-      send(a, ['<end>'])
-      send(b, [3, 4, '<end>'])
+    expect(a.concat(b)).to.emit([value(0, {current: true}), value(1), value(3), value(4), end()], () => {
+      send(a, [value(1)])
+      send(b, [value(2)])
+      send(a, [end()])
+      send(b, [value(3), value(4), end()])
     })
   })
 
   it('should deliver current from current source, but only to first subscriber on each activation', () => {
-    const a = send(prop(), [0])
-    const b = send(prop(), [1])
+    const a = send(prop(), [value(0)])
+    const b = send(prop(), [value(1)])
     const c = stream()
 
     let concat = Kefir.concat([a, b, c])
-    expect(concat).to.emit([{current: 0}])
+    expect(concat).to.emit([value(0, {current: true})])
 
     concat = Kefir.concat([a, b, c])
     activate(concat)
@@ -74,16 +77,13 @@ describe('concat', () => {
     concat = Kefir.concat([a, b, c])
     activate(concat)
     deactivate(concat)
-    expect(concat).to.emit([{current: 0}])
+    expect(concat).to.emit([value(0, {current: true})])
   })
 
   it('if made of ended properties, should emit all currents then end', () => {
-    expect(Kefir.concat([send(prop(), [0, '<end>']), send(prop(), [1, '<end>']), send(prop(), [2, '<end>'])])).to.emit([
-      {current: 0},
-      {current: 1},
-      {current: 2},
-      '<end:current>',
-    ])
+    expect(
+      Kefir.concat([send(prop(), [value(0), end()]), send(prop(), [value(1), end()]), send(prop(), [value(2), end()])])
+    ).to.emit([value(0, {current: true}), value(1, {current: true}), value(2, {current: true}), end({current: true})])
   })
 
   it('errors should flow', () => {
@@ -91,16 +91,16 @@ describe('concat', () => {
     let b = prop()
     let c = stream()
     expect(Kefir.concat([a, b, c])).to.flowErrors(a)
-    a = send(stream(), ['<end>'])
+    a = send(stream(), [end()])
     b = prop()
     c = stream()
     expect(Kefir.concat([a, b, c])).to.flowErrors(b)
-    a = send(stream(), ['<end>'])
+    a = send(stream(), [end()])
     b = prop()
     c = stream()
     const result = Kefir.concat([a, b, c])
     activate(result)
-    send(b, ['<end>'])
+    send(b, [end()])
     deactivate(result)
     expect(result).to.flowErrors(c)
   })

--- a/test/specs/concat.js
+++ b/test/specs/concat.js
@@ -1,45 +1,45 @@
-const {stream, prop, send, activate, deactivate, Kefir} = require('../test-helpers')
+const {stream, prop, send, activate, deactivate, Kefir, expect} = require('../test-helpers')
 
 describe('concat', () => {
   it('should stream', () => {
-    expect(Kefir.concat([])).toBeStream()
-    expect(Kefir.concat([stream(), prop()])).toBeStream()
-    expect(stream().concat(stream())).toBeStream()
-    expect(prop().concat(prop())).toBeStream()
+    expect(Kefir.concat([])).to.be.observable.stream()
+    expect(Kefir.concat([stream(), prop()])).to.be.observable.stream()
+    expect(stream().concat(stream())).to.be.observable.stream()
+    expect(prop().concat(prop())).to.be.observable.stream()
   })
 
   it('should be ended if empty array provided', () => {
-    expect(Kefir.concat([])).toEmit(['<end:current>'])
+    expect(Kefir.concat([])).to.emit(['<end:current>'])
   })
 
   it('should be ended if array of ended observables provided', () => {
     const a = send(stream(), ['<end>'])
     const b = send(prop(), ['<end>'])
     const c = send(stream(), ['<end>'])
-    expect(Kefir.concat([a, b, c])).toEmit(['<end:current>'])
-    expect(a.concat(b)).toEmit(['<end:current>'])
+    expect(Kefir.concat([a, b, c])).to.emit(['<end:current>'])
+    expect(a.concat(b)).to.emit(['<end:current>'])
   })
 
   it('should activate only current source', () => {
     const a = stream()
     const b = prop()
     const c = stream()
-    expect(Kefir.concat([a, b, c])).toActivate(a)
-    expect(Kefir.concat([a, b, c])).not.toActivate(b, c)
-    expect(a.concat(b)).toActivate(a)
-    expect(a.concat(b)).not.toActivate(b)
+    expect(Kefir.concat([a, b, c])).to.activate(a)
+    expect(Kefir.concat([a, b, c])).not.to.activate(b, c)
+    expect(a.concat(b)).to.activate(a)
+    expect(a.concat(b)).not.to.activate(b)
     send(a, ['<end>'])
-    expect(Kefir.concat([a, b, c])).toActivate(b)
-    expect(Kefir.concat([a, b, c])).not.toActivate(a, c)
-    expect(a.concat(b)).toActivate(b)
-    expect(a.concat(b)).not.toActivate(a)
+    expect(Kefir.concat([a, b, c])).to.activate(b)
+    expect(Kefir.concat([a, b, c])).not.to.activate(a, c)
+    expect(a.concat(b)).to.activate(b)
+    expect(a.concat(b)).not.to.activate(a)
   })
 
   it('should deliver events from observables, then end when all of them end', () => {
     let a = send(prop(), [0])
     let b = prop()
     const c = stream()
-    expect(Kefir.concat([a, b, c])).toEmit([{current: 0}, 1, 4, 2, 5, 7, 8, '<end>'], () => {
+    expect(Kefir.concat([a, b, c])).to.emit([{current: 0}, 1, 4, 2, 5, 7, 8, '<end>'], () => {
       send(a, [1])
       send(b, [2])
       send(c, [3])
@@ -51,7 +51,7 @@ describe('concat', () => {
     })
     a = send(prop(), [0])
     b = stream()
-    expect(a.concat(b)).toEmit([{current: 0}, 1, 3, 4, '<end>'], () => {
+    expect(a.concat(b)).to.emit([{current: 0}, 1, 3, 4, '<end>'], () => {
       send(a, [1])
       send(b, [2])
       send(a, ['<end>'])
@@ -65,20 +65,20 @@ describe('concat', () => {
     const c = stream()
 
     let concat = Kefir.concat([a, b, c])
-    expect(concat).toEmit([{current: 0}])
+    expect(concat).to.emit([{current: 0}])
 
     concat = Kefir.concat([a, b, c])
     activate(concat)
-    expect(concat).toEmit([])
+    expect(concat).to.emit([])
 
     concat = Kefir.concat([a, b, c])
     activate(concat)
     deactivate(concat)
-    expect(concat).toEmit([{current: 0}])
+    expect(concat).to.emit([{current: 0}])
   })
 
   it('if made of ended properties, should emit all currents then end', () => {
-    expect(Kefir.concat([send(prop(), [0, '<end>']), send(prop(), [1, '<end>']), send(prop(), [2, '<end>'])])).toEmit([
+    expect(Kefir.concat([send(prop(), [0, '<end>']), send(prop(), [1, '<end>']), send(prop(), [2, '<end>'])])).to.emit([
       {current: 0},
       {current: 1},
       {current: 2},
@@ -90,11 +90,11 @@ describe('concat', () => {
     let a = stream()
     let b = prop()
     let c = stream()
-    expect(Kefir.concat([a, b, c])).errorsToFlow(a)
+    expect(Kefir.concat([a, b, c])).to.flowErrors(a)
     a = send(stream(), ['<end>'])
     b = prop()
     c = stream()
-    expect(Kefir.concat([a, b, c])).errorsToFlow(b)
+    expect(Kefir.concat([a, b, c])).to.flowErrors(b)
     a = send(stream(), ['<end>'])
     b = prop()
     c = stream()
@@ -102,6 +102,6 @@ describe('concat', () => {
     activate(result)
     send(b, ['<end>'])
     deactivate(result)
-    expect(result).errorsToFlow(c)
+    expect(result).to.flowErrors(c)
   })
 })

--- a/test/specs/constant-error.js
+++ b/test/specs/constant-error.js
@@ -1,11 +1,11 @@
-const {Kefir} = require('../test-helpers')
+const {Kefir, expect} = require('../test-helpers')
 
 describe('constantError', () => {
   it('should return property', () => {
-    expect(Kefir.constantError(1)).toBeProperty()
+    expect(Kefir.constantError(1)).to.be.observable.property()
   })
 
   it('should be ended and has a current error', () => {
-    expect(Kefir.constantError(1)).toEmit([{currentError: 1}, '<end:current>'])
+    expect(Kefir.constantError(1)).to.emit([{currentError: 1}, '<end:current>'])
   })
 })

--- a/test/specs/constant-error.js
+++ b/test/specs/constant-error.js
@@ -1,4 +1,4 @@
-const {Kefir, expect} = require('../test-helpers')
+const {Kefir, error, end, expect} = require('../test-helpers')
 
 describe('constantError', () => {
   it('should return property', () => {
@@ -6,6 +6,6 @@ describe('constantError', () => {
   })
 
   it('should be ended and has a current error', () => {
-    expect(Kefir.constantError(1)).to.emit([{currentError: 1}, '<end:current>'])
+    expect(Kefir.constantError(1)).to.emit([error(1, {current: true}), end({current: true})])
   })
 })

--- a/test/specs/constant.js
+++ b/test/specs/constant.js
@@ -1,11 +1,11 @@
-const {Kefir} = require('../test-helpers')
+const {Kefir, expect} = require('../test-helpers')
 
 describe('constant', () => {
   it('should return property', () => {
-    expect(Kefir.constant(1)).toBeProperty()
+    expect(Kefir.constant(1)).to.be.observable.property()
   })
 
   it('should be ended and has current', () => {
-    expect(Kefir.constant(1)).toEmit([{current: 1}, '<end:current>'])
+    expect(Kefir.constant(1)).to.emit([{current: 1}, '<end:current>'])
   })
 })

--- a/test/specs/constant.js
+++ b/test/specs/constant.js
@@ -1,4 +1,4 @@
-const {Kefir, expect} = require('../test-helpers')
+const {Kefir, expect, value, end} = require('../test-helpers')
 
 describe('constant', () => {
   it('should return property', () => {
@@ -6,6 +6,6 @@ describe('constant', () => {
   })
 
   it('should be ended and has current', () => {
-    expect(Kefir.constant(1)).to.emit([{current: 1}, '<end:current>'])
+    expect(Kefir.constant(1)).to.emit([value(1, {current: true}), end({current: true})])
   })
 })

--- a/test/specs/debounce.js
+++ b/test/specs/debounce.js
@@ -1,23 +1,23 @@
-const {stream, prop, send} = require('../test-helpers')
+const {stream, prop, send, expect} = require('../test-helpers')
 
 describe('debounce', () => {
   describe('stream', () => {
     it('should return stream', () => {
-      expect(stream().debounce(100)).toBeStream()
+      expect(stream().debounce(100)).to.be.observable.stream()
     })
 
     it('should activate/deactivate source', () => {
       const a = stream()
-      expect(a.debounce(100)).toActivate(a)
+      expect(a.debounce(100)).to.activate(a)
     })
 
     it('should be ended if source was ended', () => {
-      expect(send(stream(), ['<end>']).debounce(100)).toEmit(['<end:current>'])
+      expect(send(stream(), ['<end>']).debounce(100)).to.emit(['<end:current>'])
     })
 
     it('should handle events', () => {
       const a = stream()
-      expect(a.debounce(100)).toEmitInTime([[160, 3], [360, 4], [710, 8], [710, '<end>']], tick => {
+      expect(a.debounce(100)).to.emitInTime([[160, 3], [360, 4], [710, 8], [710, '<end>']], tick => {
         send(a, [1])
         tick(30)
         send(a, [2])
@@ -38,7 +38,7 @@ describe('debounce', () => {
 
     it('should end immediately if no value to emit later', () => {
       const a = stream()
-      expect(a.debounce(100)).toEmitInTime([[100, 1], [200, '<end>']], tick => {
+      expect(a.debounce(100)).to.emitInTime([[100, 1], [200, '<end>']], tick => {
         send(a, [1])
         tick(200)
         send(a, ['<end>'])
@@ -47,7 +47,7 @@ describe('debounce', () => {
 
     it('should handle events (immediate)', () => {
       const a = stream()
-      expect(a.debounce(100, {immediate: true})).toEmitInTime([[0, 1], [260, 4], [460, 5], [610, '<end>']], tick => {
+      expect(a.debounce(100, {immediate: true})).to.emitInTime([[0, 1], [260, 4], [460, 5], [610, '<end>']], tick => {
         send(a, [1])
         tick(30)
         send(a, [2])
@@ -68,36 +68,36 @@ describe('debounce', () => {
 
     it('should end immediately if no value to emit later (immediate)', () => {
       const a = stream()
-      expect(a.debounce(100, {immediate: true})).toEmitInTime([[0, 1], [0, '<end>']], tick => send(a, [1, '<end>']))
+      expect(a.debounce(100, {immediate: true})).to.emitInTime([[0, 1], [0, '<end>']], tick => send(a, [1, '<end>']))
     })
 
     it('errors should flow', () => {
       const a = stream()
-      expect(a.debounce(100)).errorsToFlow(a)
+      expect(a.debounce(100)).to.flowErrors(a)
     })
   })
 
   describe('property', () => {
     it('should return property', () => {
-      expect(prop().debounce(100)).toBeProperty()
+      expect(prop().debounce(100)).to.be.observable.property()
     })
 
     it('should activate/deactivate source', () => {
       const a = prop()
-      expect(a.debounce(100)).toActivate(a)
+      expect(a.debounce(100)).to.activate(a)
     })
 
     it('should be ended if source was ended', () => {
-      expect(send(prop(), ['<end>']).debounce(100)).toEmit(['<end:current>'])
+      expect(send(prop(), ['<end>']).debounce(100)).to.emit(['<end:current>'])
     })
 
     it('should be ended if source was ended (with current)', () => {
-      expect(send(prop(), [1, '<end>']).debounce(100)).toEmit([{current: 1}, '<end:current>'])
+      expect(send(prop(), [1, '<end>']).debounce(100)).to.emit([{current: 1}, '<end:current>'])
     })
 
     it('should handle events', () => {
       const a = send(prop(), [0])
-      expect(a.debounce(100)).toEmitInTime([[0, {current: 0}], [160, 3], [360, 4], [710, 8], [710, '<end>']], tick => {
+      expect(a.debounce(100)).to.emitInTime([[0, {current: 0}], [160, 3], [360, 4], [710, 8], [710, '<end>']], tick => {
         send(a, [1])
         tick(30)
         send(a, [2])
@@ -118,7 +118,7 @@ describe('debounce', () => {
 
     it('should end immediately if no value to emit later', () => {
       const a = send(prop(), [0])
-      expect(a.debounce(100)).toEmitInTime([[0, {current: 0}], [100, 1], [200, '<end>']], tick => {
+      expect(a.debounce(100)).to.emitInTime([[0, {current: 0}], [100, 1], [200, '<end>']], tick => {
         send(a, [1])
         tick(200)
         send(a, ['<end>'])
@@ -127,7 +127,7 @@ describe('debounce', () => {
 
     it('should handle events (immediate)', () => {
       const a = send(prop(), [0])
-      expect(a.debounce(100, {immediate: true})).toEmitInTime(
+      expect(a.debounce(100, {immediate: true})).to.emitInTime(
         [[0, {current: 0}], [0, 1], [260, 4], [460, 5], [610, '<end>']],
         tick => {
           send(a, [1])
@@ -151,14 +151,14 @@ describe('debounce', () => {
 
     it('should end immediately if no value to emit later (immediate)', () => {
       const a = send(prop(), [0])
-      expect(a.debounce(100, {immediate: true})).toEmitInTime([[0, {current: 0}], [0, 1], [0, '<end>']], tick =>
+      expect(a.debounce(100, {immediate: true})).to.emitInTime([[0, {current: 0}], [0, 1], [0, '<end>']], tick =>
         send(a, [1, '<end>'])
       )
     })
 
     it('errors should flow', () => {
       const a = prop()
-      expect(a.debounce(100)).errorsToFlow(a)
+      expect(a.debounce(100)).to.flowErrors(a)
     })
   })
 })

--- a/test/specs/debounce.js
+++ b/test/specs/debounce.js
@@ -1,4 +1,4 @@
-const {stream, prop, send, expect} = require('../test-helpers')
+const {stream, prop, send, value, end, expect} = require('../test-helpers')
 
 describe('debounce', () => {
   describe('stream', () => {
@@ -12,63 +12,68 @@ describe('debounce', () => {
     })
 
     it('should be ended if source was ended', () => {
-      expect(send(stream(), ['<end>']).debounce(100)).to.emit(['<end:current>'])
+      expect(send(stream(), [end()]).debounce(100)).to.emit([end({current: true})])
     })
 
     it('should handle events', () => {
       const a = stream()
-      expect(a.debounce(100)).to.emitInTime([[160, 3], [360, 4], [710, 8], [710, '<end>']], tick => {
-        send(a, [1])
+      expect(a.debounce(100)).to.emitInTime([[160, value(3)], [360, value(4)], [710, value(8)], [710, end()]], tick => {
+        send(a, [value(1)])
         tick(30)
-        send(a, [2])
+        send(a, [value(2)])
         tick(30)
-        send(a, [3])
+        send(a, [value(3)])
         tick(200)
-        send(a, [4])
+        send(a, [value(4)])
         tick(200)
-        send(a, [5])
+        send(a, [value(5)])
         tick(90)
-        send(a, [6])
+        send(a, [value(6)])
         tick(30)
-        send(a, [7])
+        send(a, [value(7)])
         tick(30)
-        send(a, [8, '<end>'])
+        send(a, [value(8), end()])
       })
     })
 
     it('should end immediately if no value to emit later', () => {
       const a = stream()
-      expect(a.debounce(100)).to.emitInTime([[100, 1], [200, '<end>']], tick => {
-        send(a, [1])
+      expect(a.debounce(100)).to.emitInTime([[100, value(1)], [200, end()]], tick => {
+        send(a, [value(1)])
         tick(200)
-        send(a, ['<end>'])
+        send(a, [end()])
       })
     })
 
     it('should handle events (immediate)', () => {
       const a = stream()
-      expect(a.debounce(100, {immediate: true})).to.emitInTime([[0, 1], [260, 4], [460, 5], [610, '<end>']], tick => {
-        send(a, [1])
-        tick(30)
-        send(a, [2])
-        tick(30)
-        send(a, [3])
-        tick(200)
-        send(a, [4])
-        tick(200)
-        send(a, [5])
-        tick(90)
-        send(a, [6])
-        tick(30)
-        send(a, [7])
-        tick(30)
-        send(a, [8, '<end>'])
-      })
+      expect(a.debounce(100, {immediate: true})).to.emitInTime(
+        [[0, value(1)], [260, value(4)], [460, value(5)], [610, end()]],
+        tick => {
+          send(a, [value(1)])
+          tick(30)
+          send(a, [value(2)])
+          tick(30)
+          send(a, [value(3)])
+          tick(200)
+          send(a, [value(4)])
+          tick(200)
+          send(a, [value(5)])
+          tick(90)
+          send(a, [value(6)])
+          tick(30)
+          send(a, [value(7)])
+          tick(30)
+          send(a, [value(8), end()])
+        }
+      )
     })
 
     it('should end immediately if no value to emit later (immediate)', () => {
       const a = stream()
-      expect(a.debounce(100, {immediate: true})).to.emitInTime([[0, 1], [0, '<end>']], tick => send(a, [1, '<end>']))
+      expect(a.debounce(100, {immediate: true})).to.emitInTime([[0, value(1)], [0, end()]], tick =>
+        send(a, [value(1), end()])
+      )
     })
 
     it('errors should flow', () => {
@@ -88,71 +93,75 @@ describe('debounce', () => {
     })
 
     it('should be ended if source was ended', () => {
-      expect(send(prop(), ['<end>']).debounce(100)).to.emit(['<end:current>'])
+      expect(send(prop(), [end()]).debounce(100)).to.emit([end({current: true})])
     })
 
     it('should be ended if source was ended (with current)', () => {
-      expect(send(prop(), [1, '<end>']).debounce(100)).to.emit([{current: 1}, '<end:current>'])
+      expect(send(prop(), [value(1), end()]).debounce(100)).to.emit([value(1, {current: true}), end({current: true})])
     })
 
     it('should handle events', () => {
-      const a = send(prop(), [0])
-      expect(a.debounce(100)).to.emitInTime([[0, {current: 0}], [160, 3], [360, 4], [710, 8], [710, '<end>']], tick => {
-        send(a, [1])
-        tick(30)
-        send(a, [2])
-        tick(30)
-        send(a, [3])
-        tick(200)
-        send(a, [4])
-        tick(200)
-        send(a, [5])
-        tick(90)
-        send(a, [6])
-        tick(30)
-        send(a, [7])
-        tick(30)
-        send(a, [8, '<end>'])
-      })
+      const a = send(prop(), [value(0)])
+      expect(a.debounce(100)).to.emitInTime(
+        [[0, value(0, {current: true})], [160, value(3)], [360, value(4)], [710, value(8)], [710, end()]],
+        tick => {
+          send(a, [value(1)])
+          tick(30)
+          send(a, [value(2)])
+          tick(30)
+          send(a, [value(3)])
+          tick(200)
+          send(a, [value(4)])
+          tick(200)
+          send(a, [value(5)])
+          tick(90)
+          send(a, [value(6)])
+          tick(30)
+          send(a, [value(7)])
+          tick(30)
+          send(a, [value(8), end()])
+        }
+      )
     })
 
     it('should end immediately if no value to emit later', () => {
-      const a = send(prop(), [0])
-      expect(a.debounce(100)).to.emitInTime([[0, {current: 0}], [100, 1], [200, '<end>']], tick => {
-        send(a, [1])
+      const a = send(prop(), [value(0)])
+      expect(a.debounce(100)).to.emitInTime([[0, value(0, {current: true})], [100, value(1)], [200, end()]], tick => {
+        send(a, [value(1)])
         tick(200)
-        send(a, ['<end>'])
+        send(a, [end()])
       })
     })
 
     it('should handle events (immediate)', () => {
-      const a = send(prop(), [0])
+      const a = send(prop(), [value(0)])
       expect(a.debounce(100, {immediate: true})).to.emitInTime(
-        [[0, {current: 0}], [0, 1], [260, 4], [460, 5], [610, '<end>']],
+        [[0, value(0, {current: true})], [0, value(1)], [260, value(4)], [460, value(5)], [610, end()]],
         tick => {
-          send(a, [1])
+          send(a, [value(1)])
           tick(30)
-          send(a, [2])
+          send(a, [value(2)])
           tick(30)
-          send(a, [3])
+          send(a, [value(3)])
           tick(200)
-          send(a, [4])
+          send(a, [value(4)])
           tick(200)
-          send(a, [5])
+          send(a, [value(5)])
           tick(90)
-          send(a, [6])
+          send(a, [value(6)])
           tick(30)
-          send(a, [7])
+          send(a, [value(7)])
           tick(30)
-          send(a, [8, '<end>'])
+          send(a, [value(8), end()])
         }
       )
     })
 
     it('should end immediately if no value to emit later (immediate)', () => {
-      const a = send(prop(), [0])
-      expect(a.debounce(100, {immediate: true})).to.emitInTime([[0, {current: 0}], [0, 1], [0, '<end>']], tick =>
-        send(a, [1, '<end>'])
+      const a = send(prop(), [value(0)])
+      expect(a.debounce(100, {immediate: true})).to.emitInTime(
+        [[0, value(0, {current: true})], [0, value(1)], [0, end()]],
+        tick => send(a, [value(1), end()])
       )
     })
 

--- a/test/specs/delay.js
+++ b/test/specs/delay.js
@@ -1,23 +1,23 @@
-const {stream, prop, send, shakyTimeTest} = require('../test-helpers')
+const {stream, prop, send, shakyTimeTest, expect} = require('../test-helpers')
 
 describe('delay', () => {
   describe('stream', () => {
     it('should return stream', () => {
-      expect(stream().delay(100)).toBeStream()
+      expect(stream().delay(100)).to.be.observable.stream()
     })
 
     it('should activate/deactivate source', () => {
       const a = stream()
-      expect(a.delay(100)).toActivate(a)
+      expect(a.delay(100)).to.activate(a)
     })
 
     it('should be ended if source was ended', () => {
-      expect(send(stream(), ['<end>']).delay(100)).toEmit(['<end:current>'])
+      expect(send(stream(), ['<end>']).delay(100)).to.emit(['<end:current>'])
     })
 
     it('should handle events', () => {
       const a = stream()
-      expect(a.delay(100)).toEmitInTime([[100, 1], [150, 2], [250, '<end>']], tick => {
+      expect(a.delay(100)).to.emitInTime([[100, 1], [150, 2], [250, '<end>']], tick => {
         send(a, [1])
         tick(50)
         send(a, [2])
@@ -28,7 +28,7 @@ describe('delay', () => {
 
     it('errors should flow', () => {
       const a = stream()
-      expect(a.delay(100)).errorsToFlow(a)
+      expect(a.delay(100)).to.flowErrors(a)
     })
 
     // see https://github.com/rpominov/kefir/issues/134
@@ -47,21 +47,21 @@ describe('delay', () => {
 
   describe('property', () => {
     it('should return property', () => {
-      expect(prop().delay(100)).toBeProperty()
+      expect(prop().delay(100)).to.be.observable.property()
     })
 
     it('should activate/deactivate source', () => {
       const a = prop()
-      expect(a.delay(100)).toActivate(a)
+      expect(a.delay(100)).to.activate(a)
     })
 
     it('should be ended if source was ended', () => {
-      expect(send(prop(), ['<end>']).delay(100)).toEmit(['<end:current>'])
+      expect(send(prop(), ['<end>']).delay(100)).to.emit(['<end:current>'])
     })
 
     it('should handle events and current', () => {
       const a = send(prop(), [1])
-      expect(a.delay(100)).toEmitInTime([[0, {current: 1}], [100, 2], [150, 3], [250, '<end>']], tick => {
+      expect(a.delay(100)).to.emitInTime([[0, {current: 1}], [100, 2], [150, 3], [250, '<end>']], tick => {
         send(a, [2])
         tick(50)
         send(a, [3])
@@ -72,7 +72,7 @@ describe('delay', () => {
 
     it('errors should flow', () => {
       const a = prop()
-      expect(a.delay(100)).errorsToFlow(a)
+      expect(a.delay(100)).to.flowErrors(a)
     })
   })
 })

--- a/test/specs/diff.js
+++ b/test/specs/diff.js
@@ -1,4 +1,4 @@
-const {stream, prop, send} = require('../test-helpers')
+const {stream, prop, send, expect} = require('../test-helpers')
 
 const noop = () => {}
 const minus = (prev, next) => prev - next
@@ -6,75 +6,75 @@ const minus = (prev, next) => prev - next
 describe('diff', () => {
   describe('stream', () => {
     it('should return stream', () => {
-      expect(stream().diff(noop, 0)).toBeStream()
+      expect(stream().diff(noop, 0)).to.be.observable.stream()
     })
 
     it('should activate/deactivate source', () => {
       const a = stream()
-      expect(a.diff(noop, 0)).toActivate(a)
+      expect(a.diff(noop, 0)).to.activate(a)
     })
 
     it('should be ended if source was ended', () => {
-      expect(send(stream(), ['<end>']).diff(noop, 0)).toEmit(['<end:current>'])
+      expect(send(stream(), ['<end>']).diff(noop, 0)).to.emit(['<end:current>'])
     })
 
     it('should handle events', () => {
       const a = stream()
-      expect(a.diff(minus, 0)).toEmit([-1, -2, '<end>'], () => send(a, [1, 3, '<end>']))
+      expect(a.diff(minus, 0)).to.emit([-1, -2, '<end>'], () => send(a, [1, 3, '<end>']))
     })
 
     it('works without fn argument', () => {
       const a = stream()
-      expect(a.diff(null, 0)).toEmit([[0, 1], [1, 3], '<end>'], () => send(a, [1, 3, '<end>']))
+      expect(a.diff(null, 0)).to.emit([[0, 1], [1, 3], '<end>'], () => send(a, [1, 3, '<end>']))
     })
 
     it('if no seed provided uses first value as seed', () => {
       let a = stream()
-      expect(a.diff(minus)).toEmit([-1, -2, '<end>'], () => send(a, [0, 1, 3, '<end>']))
+      expect(a.diff(minus)).to.emit([-1, -2, '<end>'], () => send(a, [0, 1, 3, '<end>']))
       a = stream()
-      expect(a.diff()).toEmit([[0, 1], [1, 3], '<end>'], () => send(a, [0, 1, 3, '<end>']))
+      expect(a.diff()).to.emit([[0, 1], [1, 3], '<end>'], () => send(a, [0, 1, 3, '<end>']))
     })
 
     it('errors should flow', () => {
       const a = stream()
-      expect(a.diff()).errorsToFlow(a)
+      expect(a.diff()).to.flowErrors(a)
     })
   })
 
   describe('property', () => {
     it('should return property', () => {
-      expect(prop().diff(noop, 0)).toBeProperty()
+      expect(prop().diff(noop, 0)).to.be.observable.property()
     })
 
     it('should activate/deactivate source', () => {
       const a = prop()
-      expect(a.diff(noop, 0)).toActivate(a)
+      expect(a.diff(noop, 0)).to.activate(a)
     })
 
     it('should be ended if source was ended', () => {
-      expect(send(prop(), ['<end>']).diff(noop, 0)).toEmit(['<end:current>'])
+      expect(send(prop(), ['<end>']).diff(noop, 0)).to.emit(['<end:current>'])
     })
 
     it('should handle events and current', () => {
       const a = send(prop(), [1])
-      expect(a.diff(minus, 0)).toEmit([{current: -1}, -2, -3, '<end>'], () => send(a, [3, 6, '<end>']))
+      expect(a.diff(minus, 0)).to.emit([{current: -1}, -2, -3, '<end>'], () => send(a, [3, 6, '<end>']))
     })
 
     it('works without fn argument', () => {
       const a = send(prop(), [1])
-      expect(a.diff(null, 0)).toEmit([{current: [0, 1]}, [1, 3], [3, 6], '<end>'], () => send(a, [3, 6, '<end>']))
+      expect(a.diff(null, 0)).to.emit([{current: [0, 1]}, [1, 3], [3, 6], '<end>'], () => send(a, [3, 6, '<end>']))
     })
 
     it('if no seed provided uses first value as seed', () => {
       let a = send(prop(), [0])
-      expect(a.diff(minus)).toEmit([-1, -2, '<end>'], () => send(a, [1, 3, '<end>']))
+      expect(a.diff(minus)).to.emit([-1, -2, '<end>'], () => send(a, [1, 3, '<end>']))
       a = send(prop(), [0])
-      expect(a.diff()).toEmit([[0, 1], [1, 3], '<end>'], () => send(a, [1, 3, '<end>']))
+      expect(a.diff()).to.emit([[0, 1], [1, 3], '<end>'], () => send(a, [1, 3, '<end>']))
     })
 
     it('errors should flow', () => {
       const a = prop()
-      expect(a.diff()).errorsToFlow(a)
+      expect(a.diff()).to.flowErrors(a)
     })
   })
 })

--- a/test/specs/diff.js
+++ b/test/specs/diff.js
@@ -1,4 +1,4 @@
-const {stream, prop, send, expect} = require('../test-helpers')
+const {stream, prop, send, value, end, expect} = require('../test-helpers')
 
 const noop = () => {}
 const minus = (prev, next) => prev - next
@@ -15,24 +15,26 @@ describe('diff', () => {
     })
 
     it('should be ended if source was ended', () => {
-      expect(send(stream(), ['<end>']).diff(noop, 0)).to.emit(['<end:current>'])
+      expect(send(stream(), [end()]).diff(noop, 0)).to.emit([end({current: true})])
     })
 
     it('should handle events', () => {
       const a = stream()
-      expect(a.diff(minus, 0)).to.emit([-1, -2, '<end>'], () => send(a, [1, 3, '<end>']))
+      expect(a.diff(minus, 0)).to.emit([value(-1), value(-2), end()], () => send(a, [value(1), value(3), end()]))
     })
 
     it('works without fn argument', () => {
       const a = stream()
-      expect(a.diff(null, 0)).to.emit([[0, 1], [1, 3], '<end>'], () => send(a, [1, 3, '<end>']))
+      expect(a.diff(null, 0)).to.emit([value([0, 1]), value([1, 3]), end()], () => send(a, [value(1), value(3), end()]))
     })
 
     it('if no seed provided uses first value as seed', () => {
       let a = stream()
-      expect(a.diff(minus)).to.emit([-1, -2, '<end>'], () => send(a, [0, 1, 3, '<end>']))
+      expect(a.diff(minus)).to.emit([value(-1), value(-2), end()], () => send(a, [value(0), value(1), value(3), end()]))
       a = stream()
-      expect(a.diff()).to.emit([[0, 1], [1, 3], '<end>'], () => send(a, [0, 1, 3, '<end>']))
+      expect(a.diff()).to.emit([value([0, 1]), value([1, 3]), end()], () =>
+        send(a, [value(0), value(1), value(3), end()])
+      )
     })
 
     it('errors should flow', () => {
@@ -52,24 +54,28 @@ describe('diff', () => {
     })
 
     it('should be ended if source was ended', () => {
-      expect(send(prop(), ['<end>']).diff(noop, 0)).to.emit(['<end:current>'])
+      expect(send(prop(), [end()]).diff(noop, 0)).to.emit([end({current: true})])
     })
 
     it('should handle events and current', () => {
-      const a = send(prop(), [1])
-      expect(a.diff(minus, 0)).to.emit([{current: -1}, -2, -3, '<end>'], () => send(a, [3, 6, '<end>']))
+      const a = send(prop(), [value(1)])
+      expect(a.diff(minus, 0)).to.emit([value(-1, {current: true}), value(-2), value(-3), end()], () =>
+        send(a, [value(3), value(6), end()])
+      )
     })
 
     it('works without fn argument', () => {
-      const a = send(prop(), [1])
-      expect(a.diff(null, 0)).to.emit([{current: [0, 1]}, [1, 3], [3, 6], '<end>'], () => send(a, [3, 6, '<end>']))
+      const a = send(prop(), [value(1)])
+      expect(a.diff(null, 0)).to.emit([value([0, 1], {current: true}), value([1, 3]), value([3, 6]), end()], () =>
+        send(a, [value(3), value(6), end()])
+      )
     })
 
     it('if no seed provided uses first value as seed', () => {
-      let a = send(prop(), [0])
-      expect(a.diff(minus)).to.emit([-1, -2, '<end>'], () => send(a, [1, 3, '<end>']))
-      a = send(prop(), [0])
-      expect(a.diff()).to.emit([[0, 1], [1, 3], '<end>'], () => send(a, [1, 3, '<end>']))
+      let a = send(prop(), [value(0)])
+      expect(a.diff(minus)).to.emit([value(-1), value(-2), end()], () => send(a, [value(1), value(3), end()]))
+      a = send(prop(), [value(0)])
+      expect(a.diff()).to.emit([value([0, 1]), value([1, 3]), end()], () => send(a, [value(1), value(3), end()]))
     })
 
     it('errors should flow', () => {

--- a/test/specs/end-on-error.js
+++ b/test/specs/end-on-error.js
@@ -1,4 +1,4 @@
-const {stream, prop, send, expect} = require('../test-helpers')
+const {stream, prop, send, value, error, end, expect} = require('../test-helpers')
 
 describe('endOnError', () => {
   describe('stream', () => {
@@ -12,14 +12,14 @@ describe('endOnError', () => {
     })
 
     it('should be ended if source was ended', () => {
-      expect(send(stream(), ['<end>']).endOnError()).to.emit(['<end:current>'])
+      expect(send(stream(), [end()]).endOnError()).to.emit([end({current: true})])
     })
 
     it('should handle events', () => {
       let a = stream()
-      expect(a.endOnError()).to.emit([1, {error: 5}, '<end>'], () => send(a, [1, {error: 5}, 2]))
+      expect(a.endOnError()).to.emit([value(1), error(5), end()], () => send(a, [value(1), error(5), value(2)]))
       a = stream()
-      expect(a.endOnError()).to.emit([1, 2, '<end>'], () => send(a, [1, 2, '<end>']))
+      expect(a.endOnError()).to.emit([value(1), value(2), end()], () => send(a, [value(1), value(2), end()]))
     })
   })
 
@@ -34,25 +34,25 @@ describe('endOnError', () => {
     })
 
     it('should be ended if source was ended', () => {
-      expect(send(prop(), ['<end>']).endOnError()).to.emit(['<end:current>'])
+      expect(send(prop(), [end()]).endOnError()).to.emit([end({current: true})])
     })
 
     it('should handle events and current', () => {
-      let a = send(prop(), [1])
-      expect(a.endOnError()).to.emit([{current: 1}, {error: 5}, '<end>'], () => send(a, [{error: 5}, 2]))
-      a = send(prop(), [1])
-      expect(a.endOnError()).to.emit([{current: 1}, 2, '<end>'], () => send(a, [2, '<end>']))
+      let a = send(prop(), [value(1)])
+      expect(a.endOnError()).to.emit([value(1, {current: true}), error(5), end()], () => send(a, [error(5), value(2)]))
+      a = send(prop(), [value(1)])
+      expect(a.endOnError()).to.emit([value(1, {current: true}), value(2), end()], () => send(a, [value(2), end()]))
     })
 
     it('should handle currents', () => {
-      let a = send(prop(), [{error: -1}])
-      expect(a.endOnError()).to.emit([{currentError: -1}, '<end:current>'])
-      a = send(prop(), [{error: -1}, '<end>'])
-      expect(a.endOnError()).to.emit([{currentError: -1}, '<end:current>'])
-      a = send(prop(), [1])
-      expect(a.endOnError()).to.emit([{current: 1}])
-      a = send(prop(), [1, '<end>'])
-      expect(a.endOnError()).to.emit([{current: 1}, '<end:current>'])
+      let a = send(prop(), [error(-1, {current: true})])
+      expect(a.endOnError()).to.emit([error(-1, {current: true}), end({current: true})])
+      a = send(prop(), [error(-1, {current: true}), end()])
+      expect(a.endOnError()).to.emit([error(-1, {current: true}), end({current: true})])
+      a = send(prop(), [value(1)])
+      expect(a.endOnError()).to.emit([value(1, {current: true})])
+      a = send(prop(), [value(1), end()])
+      expect(a.endOnError()).to.emit([value(1, {current: true}), end({current: true})])
     })
   })
 })

--- a/test/specs/end-on-error.js
+++ b/test/specs/end-on-error.js
@@ -1,58 +1,58 @@
-const {stream, prop, send} = require('../test-helpers')
+const {stream, prop, send, expect} = require('../test-helpers')
 
 describe('endOnError', () => {
   describe('stream', () => {
     it('should return stream', () => {
-      expect(stream().endOnError()).toBeStream()
+      expect(stream().endOnError()).to.be.observable.stream()
     })
 
     it('should activate/deactivate source', () => {
       const a = stream()
-      expect(a.endOnError()).toActivate(a)
+      expect(a.endOnError()).to.activate(a)
     })
 
     it('should be ended if source was ended', () => {
-      expect(send(stream(), ['<end>']).endOnError()).toEmit(['<end:current>'])
+      expect(send(stream(), ['<end>']).endOnError()).to.emit(['<end:current>'])
     })
 
     it('should handle events', () => {
       let a = stream()
-      expect(a.endOnError()).toEmit([1, {error: 5}, '<end>'], () => send(a, [1, {error: 5}, 2]))
+      expect(a.endOnError()).to.emit([1, {error: 5}, '<end>'], () => send(a, [1, {error: 5}, 2]))
       a = stream()
-      expect(a.endOnError()).toEmit([1, 2, '<end>'], () => send(a, [1, 2, '<end>']))
+      expect(a.endOnError()).to.emit([1, 2, '<end>'], () => send(a, [1, 2, '<end>']))
     })
   })
 
   describe('property', () => {
     it('should return property', () => {
-      expect(prop().endOnError()).toBeProperty()
+      expect(prop().endOnError()).to.be.observable.property()
     })
 
     it('should activate/deactivate source', () => {
       const a = prop()
-      expect(a.endOnError()).toActivate(a)
+      expect(a.endOnError()).to.activate(a)
     })
 
     it('should be ended if source was ended', () => {
-      expect(send(prop(), ['<end>']).endOnError()).toEmit(['<end:current>'])
+      expect(send(prop(), ['<end>']).endOnError()).to.emit(['<end:current>'])
     })
 
     it('should handle events and current', () => {
       let a = send(prop(), [1])
-      expect(a.endOnError()).toEmit([{current: 1}, {error: 5}, '<end>'], () => send(a, [{error: 5}, 2]))
+      expect(a.endOnError()).to.emit([{current: 1}, {error: 5}, '<end>'], () => send(a, [{error: 5}, 2]))
       a = send(prop(), [1])
-      expect(a.endOnError()).toEmit([{current: 1}, 2, '<end>'], () => send(a, [2, '<end>']))
+      expect(a.endOnError()).to.emit([{current: 1}, 2, '<end>'], () => send(a, [2, '<end>']))
     })
 
     it('should handle currents', () => {
       let a = send(prop(), [{error: -1}])
-      expect(a.endOnError()).toEmit([{currentError: -1}, '<end:current>'])
+      expect(a.endOnError()).to.emit([{currentError: -1}, '<end:current>'])
       a = send(prop(), [{error: -1}, '<end>'])
-      expect(a.endOnError()).toEmit([{currentError: -1}, '<end:current>'])
+      expect(a.endOnError()).to.emit([{currentError: -1}, '<end:current>'])
       a = send(prop(), [1])
-      expect(a.endOnError()).toEmit([{current: 1}])
+      expect(a.endOnError()).to.emit([{current: 1}])
       a = send(prop(), [1, '<end>'])
-      expect(a.endOnError()).toEmit([{current: 1}, '<end:current>'])
+      expect(a.endOnError()).to.emit([{current: 1}, '<end:current>'])
     })
   })
 })

--- a/test/specs/errors-to-values.js
+++ b/test/specs/errors-to-values.js
@@ -1,4 +1,4 @@
-const {stream, prop, send, expect} = require('../test-helpers')
+const {stream, prop, send, value, error, end, expect} = require('../test-helpers')
 
 const handler = x => ({
   convert: x >= 0,
@@ -17,20 +17,20 @@ describe('errorsToValues', () => {
     })
 
     it('should be ended if source was ended', () => {
-      expect(send(stream(), ['<end>']).errorsToValues(() => {})).to.emit(['<end:current>'])
+      expect(send(stream(), [end()]).errorsToValues(() => {})).to.emit([end({current: true})])
     })
 
     it('should handle events', () => {
       const a = stream()
-      expect(a.errorsToValues(handler)).to.emit([1, 6, {error: -1}, 9, 4, '<end>'], () =>
-        send(a, [1, {error: 2}, {error: -1}, {error: 3}, 4, '<end>'])
+      expect(a.errorsToValues(handler)).to.emit([value(1), value(6), error(-1), value(9), value(4), end()], () =>
+        send(a, [value(1), error(2), error(-1), error(3), value(4), end()])
       )
     })
 
     it('default handler should convert all errors', () => {
       const a = stream()
-      expect(a.errorsToValues()).to.emit([1, 2, -1, 3, 4, '<end>'], () =>
-        send(a, [1, {error: 2}, {error: -1}, {error: 3}, 4, '<end>'])
+      expect(a.errorsToValues()).to.emit([value(1), value(2), value(-1), value(3), value(4), end()], () =>
+        send(a, [value(1), error(2), error(-1), error(3), value(4), end()])
       )
     })
   })
@@ -46,23 +46,24 @@ describe('errorsToValues', () => {
     })
 
     it('should be ended if source was ended', () => {
-      expect(send(prop(), ['<end>']).errorsToValues(() => {})).to.emit(['<end:current>'])
+      expect(send(prop(), [end()]).errorsToValues(() => {})).to.emit([end({current: true})])
     })
 
     it('should handle events', () => {
-      const a = send(prop(), [1])
-      expect(a.errorsToValues(handler)).to.emit([{current: 1}, 6, {error: -1}, 9, 4, '<end>'], () =>
-        send(a, [{error: 2}, {error: -1}, {error: 3}, 4, '<end>'])
+      const a = send(prop(), [value(1)])
+      expect(a.errorsToValues(handler)).to.emit(
+        [value(1, {current: true}), value(6), error(-1), value(9), value(4), end()],
+        () => send(a, [error(2), error(-1), error(3), value(4), end()])
       )
     })
 
     it('should handle currents', () => {
-      let a = send(prop(), [{error: -2}])
-      expect(a.errorsToValues(handler)).to.emit([{currentError: -2}])
-      a = send(prop(), [{error: 2}])
-      expect(a.errorsToValues(handler)).to.emit([{current: 6}])
-      a = send(prop(), [1])
-      expect(a.errorsToValues(handler)).to.emit([{current: 1}])
+      let a = send(prop(), [error(-2)])
+      expect(a.errorsToValues(handler)).to.emit([error(-2, {current: true})])
+      a = send(prop(), [error(2)])
+      expect(a.errorsToValues(handler)).to.emit([value(6, {current: true})])
+      a = send(prop(), [value(1)])
+      expect(a.errorsToValues(handler)).to.emit([value(1, {current: true})])
     })
   })
 })

--- a/test/specs/errors-to-values.js
+++ b/test/specs/errors-to-values.js
@@ -1,4 +1,4 @@
-const {stream, prop, send} = require('../test-helpers')
+const {stream, prop, send, expect} = require('../test-helpers')
 
 const handler = x => ({
   convert: x >= 0,
@@ -8,28 +8,28 @@ const handler = x => ({
 describe('errorsToValues', () => {
   describe('stream', () => {
     it('should return stream', () => {
-      expect(stream().errorsToValues(() => {})).toBeStream()
+      expect(stream().errorsToValues(() => {})).to.be.observable.stream()
     })
 
     it('should activate/deactivate source', () => {
       const a = stream()
-      expect(a.errorsToValues(() => {})).toActivate(a)
+      expect(a.errorsToValues(() => {})).to.activate(a)
     })
 
     it('should be ended if source was ended', () => {
-      expect(send(stream(), ['<end>']).errorsToValues(() => {})).toEmit(['<end:current>'])
+      expect(send(stream(), ['<end>']).errorsToValues(() => {})).to.emit(['<end:current>'])
     })
 
     it('should handle events', () => {
       const a = stream()
-      expect(a.errorsToValues(handler)).toEmit([1, 6, {error: -1}, 9, 4, '<end>'], () =>
+      expect(a.errorsToValues(handler)).to.emit([1, 6, {error: -1}, 9, 4, '<end>'], () =>
         send(a, [1, {error: 2}, {error: -1}, {error: 3}, 4, '<end>'])
       )
     })
 
     it('default handler should convert all errors', () => {
       const a = stream()
-      expect(a.errorsToValues()).toEmit([1, 2, -1, 3, 4, '<end>'], () =>
+      expect(a.errorsToValues()).to.emit([1, 2, -1, 3, 4, '<end>'], () =>
         send(a, [1, {error: 2}, {error: -1}, {error: 3}, 4, '<end>'])
       )
     })
@@ -37,32 +37,32 @@ describe('errorsToValues', () => {
 
   describe('property', () => {
     it('should return property', () => {
-      expect(prop().errorsToValues(() => {})).toBeProperty()
+      expect(prop().errorsToValues(() => {})).to.be.observable.property()
     })
 
     it('should activate/deactivate source', () => {
       const a = prop()
-      expect(a.errorsToValues(() => {})).toActivate(a)
+      expect(a.errorsToValues(() => {})).to.activate(a)
     })
 
     it('should be ended if source was ended', () => {
-      expect(send(prop(), ['<end>']).errorsToValues(() => {})).toEmit(['<end:current>'])
+      expect(send(prop(), ['<end>']).errorsToValues(() => {})).to.emit(['<end:current>'])
     })
 
     it('should handle events', () => {
       const a = send(prop(), [1])
-      expect(a.errorsToValues(handler)).toEmit([{current: 1}, 6, {error: -1}, 9, 4, '<end>'], () =>
+      expect(a.errorsToValues(handler)).to.emit([{current: 1}, 6, {error: -1}, 9, 4, '<end>'], () =>
         send(a, [{error: 2}, {error: -1}, {error: 3}, 4, '<end>'])
       )
     })
 
     it('should handle currents', () => {
       let a = send(prop(), [{error: -2}])
-      expect(a.errorsToValues(handler)).toEmit([{currentError: -2}])
+      expect(a.errorsToValues(handler)).to.emit([{currentError: -2}])
       a = send(prop(), [{error: 2}])
-      expect(a.errorsToValues(handler)).toEmit([{current: 6}])
+      expect(a.errorsToValues(handler)).to.emit([{current: 6}])
       a = send(prop(), [1])
-      expect(a.errorsToValues(handler)).toEmit([{current: 1}])
+      expect(a.errorsToValues(handler)).to.emit([{current: 1}])
     })
   })
 })

--- a/test/specs/es-observable.js
+++ b/test/specs/es-observable.js
@@ -1,6 +1,6 @@
 const $$observable = require('symbol-observable').default
 const Observable = require('zen-observable')
-const {stream, send, expect} = require('../test-helpers')
+const {stream, send, value, error, end, expect} = require('../test-helpers')
 
 describe('[Symbol.observable]', () => {
   it('outputs a compatible Observable', done => {
@@ -11,12 +11,12 @@ describe('[Symbol.observable]', () => {
       next(x) {
         values.push(x)
       },
-      complete(x) {
+      complete() {
         expect(values).to.deep.equal([1, 2, 3])
         done()
       },
     })
-    send(a, [1, 2, 3, '<end>'])
+    send(a, [value(1), value(2), value(3), end()])
   })
 
   it('unsubscribes stream after an error', () => {
@@ -28,7 +28,7 @@ describe('[Symbol.observable]', () => {
         values.push(x)
       },
     })
-    send(a, [1, {error: 2}, 3])
+    send(a, [value(1), error(2), value(3)])
     expect(values).to.deep.equal([1])
   })
 
@@ -41,9 +41,9 @@ describe('[Symbol.observable]', () => {
         values.push(x)
       },
     })
-    send(a, [1])
+    send(a, [value(1)])
     subscribtion.unsubscribe()
-    send(a, [2])
+    send(a, [value(2)])
     expect(values).to.deep.equal([1])
   })
 
@@ -66,7 +66,7 @@ describe('[Symbol.observable]', () => {
     const onComplete = x => completes.push(x)
     const observable = a[$$observable]()
     observable.subscribe(onValue, onError, onComplete)
-    send(a, [1, {error: 2}])
+    send(a, [value(1), error(2)])
     expect(values).to.deep.equal([1])
     expect(errors).to.deep.equal([2])
     expect(completes).to.deep.equal([undefined])
@@ -77,7 +77,7 @@ describe('[Symbol.observable]', () => {
     const observable = a[$$observable]()
     const subscribtion = observable.subscribe(() => {})
     expect(subscribtion.closed).to.deep.equal(false)
-    send(a, ['<end>'])
+    send(a, [end()])
     expect(subscribtion.closed).to.deep.equal(true)
   })
 })

--- a/test/specs/es-observable.js
+++ b/test/specs/es-observable.js
@@ -1,6 +1,6 @@
 const $$observable = require('symbol-observable').default
 const Observable = require('zen-observable')
-const {stream, send} = require('../test-helpers')
+const {stream, send, expect} = require('../test-helpers')
 
 describe('[Symbol.observable]', () => {
   it('outputs a compatible Observable', done => {
@@ -12,7 +12,7 @@ describe('[Symbol.observable]', () => {
         values.push(x)
       },
       complete(x) {
-        expect(values).toEqual([1, 2, 3])
+        expect(values).to.deep.equal([1, 2, 3])
         done()
       },
     })
@@ -29,7 +29,7 @@ describe('[Symbol.observable]', () => {
       },
     })
     send(a, [1, {error: 2}, 3])
-    expect(values).toEqual([1])
+    expect(values).to.deep.equal([1])
   })
 
   it('subscribe() returns an subscribtion object with unsubscribe method', () => {
@@ -44,16 +44,16 @@ describe('[Symbol.observable]', () => {
     send(a, [1])
     subscribtion.unsubscribe()
     send(a, [2])
-    expect(values).toEqual([1])
+    expect(values).to.deep.equal([1])
   })
 
   it('subscribtion object has `closed` property', () => {
     const a = stream()
     const observable = a[$$observable]()
     const subscribtion = observable.subscribe({next() {}})
-    expect(subscribtion.closed).toEqual(false)
+    expect(subscribtion.closed).to.deep.equal(false)
     subscribtion.unsubscribe()
-    expect(subscribtion.closed).toEqual(true)
+    expect(subscribtion.closed).to.deep.equal(true)
   })
 
   it('supports subscribe(onNext, onError, onCompete) format', () => {
@@ -67,17 +67,17 @@ describe('[Symbol.observable]', () => {
     const observable = a[$$observable]()
     observable.subscribe(onValue, onError, onComplete)
     send(a, [1, {error: 2}])
-    expect(values).toEqual([1])
-    expect(errors).toEqual([2])
-    expect(completes).toEqual([undefined])
+    expect(values).to.deep.equal([1])
+    expect(errors).to.deep.equal([2])
+    expect(completes).to.deep.equal([undefined])
   })
 
   it('closed=true after end', () => {
     const a = stream()
     const observable = a[$$observable]()
     const subscribtion = observable.subscribe(() => {})
-    expect(subscribtion.closed).toEqual(false)
+    expect(subscribtion.closed).to.deep.equal(false)
     send(a, ['<end>'])
-    expect(subscribtion.closed).toEqual(true)
+    expect(subscribtion.closed).to.deep.equal(true)
   })
 })

--- a/test/specs/filter-by.js
+++ b/test/specs/filter-by.js
@@ -1,76 +1,76 @@
-const {stream, prop, send} = require('../test-helpers')
+const {stream, prop, send, expect} = require('../test-helpers')
 
 describe('filterBy', () => {
   describe('common', () => {
     it('errors should flow', () => {
       let a = stream()
       let b = stream()
-      expect(a.filterBy(b)).errorsToFlow(a)
+      expect(a.filterBy(b)).to.flowErrors(a)
       a = stream()
       b = stream()
-      expect(a.filterBy(b)).errorsToFlow(b)
+      expect(a.filterBy(b)).to.flowErrors(b)
       a = prop()
       b = stream()
-      expect(a.filterBy(b)).errorsToFlow(a)
+      expect(a.filterBy(b)).to.flowErrors(a)
       a = prop()
       b = stream()
-      expect(a.filterBy(b)).errorsToFlow(b)
+      expect(a.filterBy(b)).to.flowErrors(b)
       a = stream()
       b = prop()
-      expect(a.filterBy(b)).errorsToFlow(a)
+      expect(a.filterBy(b)).to.flowErrors(a)
       a = stream()
       b = prop()
-      expect(a.filterBy(b)).errorsToFlow(b)
+      expect(a.filterBy(b)).to.flowErrors(b)
       a = prop()
       b = prop()
-      expect(a.filterBy(b)).errorsToFlow(a)
+      expect(a.filterBy(b)).to.flowErrors(a)
       a = prop()
       b = prop()
-      expect(a.filterBy(b)).errorsToFlow(b)
+      expect(a.filterBy(b)).to.flowErrors(b)
     })
   })
 
   describe('stream, stream', () => {
     it('should return a stream', () => {
-      expect(stream().filterBy(stream())).toBeStream()
+      expect(stream().filterBy(stream())).to.be.observable.stream()
     })
 
     it('should activate/deactivate sources', () => {
       const a = stream()
       const b = stream()
-      expect(a.filterBy(b)).toActivate(a, b)
+      expect(a.filterBy(b)).to.activate(a, b)
     })
 
     it('should be ended if primary was ended', () => {
-      expect(send(stream(), ['<end>']).filterBy(stream())).toEmit(['<end:current>'])
+      expect(send(stream(), ['<end>']).filterBy(stream())).to.emit(['<end:current>'])
     })
 
     it('should be ended if secondary was ended', () => {
-      expect(stream().filterBy(send(stream(), ['<end>']))).toEmit(['<end:current>'])
+      expect(stream().filterBy(send(stream(), ['<end>']))).to.emit(['<end:current>'])
     })
 
     it('should end when secondary ends if last value from it was falsey', () => {
       const a = stream()
       const b = stream()
-      expect(a.filterBy(b)).toEmit(['<end>'], () => send(b, [false, '<end>']))
+      expect(a.filterBy(b)).to.emit(['<end>'], () => send(b, [false, '<end>']))
     })
 
     it("should not end when secondary ends if last value from it wasn't falsey", () => {
       const a = stream()
       const b = stream()
-      expect(a.filterBy(b)).toEmit([], () => send(b, [true, '<end>']))
+      expect(a.filterBy(b)).to.emit([], () => send(b, [true, '<end>']))
     })
 
     it('should ignore values from primary until first value from secondary', () => {
       const a = stream()
       const b = stream()
-      expect(a.filterBy(b)).toEmit([], () => send(a, [1, 2]))
+      expect(a.filterBy(b)).to.emit([], () => send(a, [1, 2]))
     })
 
     it('should filter values as expected', () => {
       const a = stream()
       const b = stream()
-      expect(a.filterBy(b)).toEmit([3, 4, 7, 8, '<end>'], () => {
+      expect(a.filterBy(b)).to.emit([3, 4, 7, 8, '<end>'], () => {
         send(b, [true])
         send(a, [3, 4])
         send(b, [0])
@@ -85,53 +85,53 @@ describe('filterBy', () => {
 
   describe('stream, property', () => {
     it('should return a stream', () => {
-      expect(stream().filterBy(prop())).toBeStream()
+      expect(stream().filterBy(prop())).to.be.observable.stream()
     })
 
     it('should activate/deactivate sources', () => {
       const a = stream()
       const b = prop()
-      expect(a.filterBy(b)).toActivate(a, b)
+      expect(a.filterBy(b)).to.activate(a, b)
     })
 
     it('should be ended if primary was ended', () => {
-      expect(send(stream(), ['<end>']).filterBy(prop())).toEmit(['<end:current>'])
+      expect(send(stream(), ['<end>']).filterBy(prop())).to.emit(['<end:current>'])
     })
 
     it('should be ended if secondary was ended and has no current', () => {
-      expect(stream().filterBy(send(prop(), ['<end>']))).toEmit(['<end:current>'])
+      expect(stream().filterBy(send(prop(), ['<end>']))).to.emit(['<end:current>'])
     })
 
     it('should be ended if secondary was ended and has falsey current', () => {
-      expect(stream().filterBy(send(prop(), [false, '<end>']))).toEmit(['<end:current>'])
+      expect(stream().filterBy(send(prop(), [false, '<end>']))).to.emit(['<end:current>'])
     })
 
     it('should not be ended if secondary was ended but has truthy current', () => {
-      expect(stream().filterBy(send(prop(), [true, '<end>']))).toEmit([])
+      expect(stream().filterBy(send(prop(), [true, '<end>']))).to.emit([])
     })
 
     it('should end when secondary ends if last value from it was falsey', () => {
       const a = stream()
       const b = prop()
-      expect(a.filterBy(b)).toEmit(['<end>'], () => send(b, [false, '<end>']))
+      expect(a.filterBy(b)).to.emit(['<end>'], () => send(b, [false, '<end>']))
     })
 
     it("should not end when secondary ends if last value from it wasn't falsey", () => {
       const a = stream()
       const b = prop()
-      expect(a.filterBy(b)).toEmit([], () => send(b, [true, '<end>']))
+      expect(a.filterBy(b)).to.emit([], () => send(b, [true, '<end>']))
     })
 
     it('should ignore values from primary until first value from secondary', () => {
       const a = stream()
       const b = prop()
-      expect(a.filterBy(b)).toEmit([], () => send(a, [1, 2]))
+      expect(a.filterBy(b)).to.emit([], () => send(a, [1, 2]))
     })
 
     it('should filter values as expected', () => {
       const a = stream()
       const b = prop()
-      expect(a.filterBy(b)).toEmit([3, 4, 7, 8, '<end>'], () => {
+      expect(a.filterBy(b)).to.emit([3, 4, 7, 8, '<end>'], () => {
         send(b, [true])
         send(a, [3, 4])
         send(b, [0])
@@ -146,45 +146,45 @@ describe('filterBy', () => {
 
   describe('property, stream', () => {
     it('should return a property', () => {
-      expect(prop().filterBy(stream())).toBeProperty()
+      expect(prop().filterBy(stream())).to.be.observable.property()
     })
 
     it('should activate/deactivate sources', () => {
       const a = prop()
       const b = stream()
-      expect(a.filterBy(b)).toActivate(a, b)
+      expect(a.filterBy(b)).to.activate(a, b)
     })
 
     it('should be ended if primary was ended', () => {
-      expect(send(prop(), ['<end>']).filterBy(stream())).toEmit(['<end:current>'])
+      expect(send(prop(), ['<end>']).filterBy(stream())).to.emit(['<end:current>'])
     })
 
     it('should be ended if secondary was ended', () => {
-      expect(prop().filterBy(send(stream(), ['<end>']))).toEmit(['<end:current>'])
+      expect(prop().filterBy(send(stream(), ['<end>']))).to.emit(['<end:current>'])
     })
 
     it('should end when secondary ends if last value from it was falsey', () => {
       const a = prop()
       const b = stream()
-      expect(a.filterBy(b)).toEmit(['<end>'], () => send(b, [false, '<end>']))
+      expect(a.filterBy(b)).to.emit(['<end>'], () => send(b, [false, '<end>']))
     })
 
     it("should not end when secondary ends if last value from it wasn't falsey", () => {
       const a = prop()
       const b = stream()
-      expect(a.filterBy(b)).toEmit([], () => send(b, [true, '<end>']))
+      expect(a.filterBy(b)).to.emit([], () => send(b, [true, '<end>']))
     })
 
     it('should ignore values from primary until first value from secondary', () => {
       const a = prop()
       const b = stream()
-      expect(a.filterBy(b)).toEmit([], () => send(a, [1, 2]))
+      expect(a.filterBy(b)).to.emit([], () => send(a, [1, 2]))
     })
 
     it('should filter values as expected', () => {
       const a = send(prop(), [0])
       const b = stream()
-      expect(a.filterBy(b)).toEmit([3, 4, 7, 8, '<end>'], () => {
+      expect(a.filterBy(b)).to.emit([3, 4, 7, 8, '<end>'], () => {
         send(b, [true])
         send(a, [3, 4])
         send(b, [0])
@@ -199,53 +199,53 @@ describe('filterBy', () => {
 
   describe('property, property', () => {
     it('should return a property', () => {
-      expect(prop().filterBy(prop())).toBeProperty()
+      expect(prop().filterBy(prop())).to.be.observable.property()
     })
 
     it('should activate/deactivate sources', () => {
       const a = prop()
       const b = prop()
-      expect(a.filterBy(b)).toActivate(a, b)
+      expect(a.filterBy(b)).to.activate(a, b)
     })
 
     it('should be ended if primary was ended', () => {
-      expect(send(prop(), ['<end>']).filterBy(prop())).toEmit(['<end:current>'])
+      expect(send(prop(), ['<end>']).filterBy(prop())).to.emit(['<end:current>'])
     })
 
     it('should be ended if secondary was ended and has no current', () => {
-      expect(prop().filterBy(send(prop(), ['<end>']))).toEmit(['<end:current>'])
+      expect(prop().filterBy(send(prop(), ['<end>']))).to.emit(['<end:current>'])
     })
 
     it('should be ended if secondary was ended and has falsey current', () => {
-      expect(prop().filterBy(send(prop(), [false, '<end>']))).toEmit(['<end:current>'])
+      expect(prop().filterBy(send(prop(), [false, '<end>']))).to.emit(['<end:current>'])
     })
 
     it('should not be ended if secondary was ended but has truthy current', () => {
-      expect(prop().filterBy(send(prop(), [true, '<end>']))).toEmit([])
+      expect(prop().filterBy(send(prop(), [true, '<end>']))).to.emit([])
     })
 
     it('should end when secondary ends if last value from it was falsey', () => {
       const a = prop()
       const b = prop()
-      expect(a.filterBy(b)).toEmit(['<end>'], () => send(b, [false, '<end>']))
+      expect(a.filterBy(b)).to.emit(['<end>'], () => send(b, [false, '<end>']))
     })
 
     it("should not end when secondary ends if last value from it wasn't falsey", () => {
       const a = prop()
       const b = prop()
-      expect(a.filterBy(b)).toEmit([], () => send(b, [true, '<end>']))
+      expect(a.filterBy(b)).to.emit([], () => send(b, [true, '<end>']))
     })
 
     it('should ignore values from primary until first value from secondary', () => {
       const a = prop()
       const b = prop()
-      expect(a.filterBy(b)).toEmit([], () => send(a, [1, 2]))
+      expect(a.filterBy(b)).to.emit([], () => send(a, [1, 2]))
     })
 
     it('should filter values as expected', () => {
       const a = send(prop(), [0])
       const b = send(prop(), [true])
-      expect(a.filterBy(b)).toEmit([{current: 0}, 3, 4, 7, 8, '<end>'], () => {
+      expect(a.filterBy(b)).to.emit([{current: 0}, 3, 4, 7, 8, '<end>'], () => {
         send(a, [3, 4])
         send(b, [0])
         send(a, [5, 6])

--- a/test/specs/filter-by.js
+++ b/test/specs/filter-by.js
@@ -1,4 +1,4 @@
-const {stream, prop, send, expect} = require('../test-helpers')
+const {stream, prop, send, value, error, end, expect} = require('../test-helpers')
 
 describe('filterBy', () => {
   describe('common', () => {
@@ -42,43 +42,43 @@ describe('filterBy', () => {
     })
 
     it('should be ended if primary was ended', () => {
-      expect(send(stream(), ['<end>']).filterBy(stream())).to.emit(['<end:current>'])
+      expect(send(stream(), [end()]).filterBy(stream())).to.emit([end({current: true})])
     })
 
     it('should be ended if secondary was ended', () => {
-      expect(stream().filterBy(send(stream(), ['<end>']))).to.emit(['<end:current>'])
+      expect(stream().filterBy(send(stream(), [end()]))).to.emit([end({current: true})])
     })
 
     it('should end when secondary ends if last value from it was falsey', () => {
       const a = stream()
       const b = stream()
-      expect(a.filterBy(b)).to.emit(['<end>'], () => send(b, [false, '<end>']))
+      expect(a.filterBy(b)).to.emit([end()], () => send(b, [value(false), end()]))
     })
 
     it("should not end when secondary ends if last value from it wasn't falsey", () => {
       const a = stream()
       const b = stream()
-      expect(a.filterBy(b)).to.emit([], () => send(b, [true, '<end>']))
+      expect(a.filterBy(b)).to.emit([], () => send(b, [value(true), end()]))
     })
 
     it('should ignore values from primary until first value from secondary', () => {
       const a = stream()
       const b = stream()
-      expect(a.filterBy(b)).to.emit([], () => send(a, [1, 2]))
+      expect(a.filterBy(b)).to.emit([], () => send(a, [value(1), value(2)]))
     })
 
     it('should filter values as expected', () => {
       const a = stream()
       const b = stream()
-      expect(a.filterBy(b)).to.emit([3, 4, 7, 8, '<end>'], () => {
-        send(b, [true])
-        send(a, [3, 4])
-        send(b, [0])
-        send(a, [5, 6])
-        send(b, [1])
-        send(a, [7, 8])
-        send(b, [false])
-        send(a, [9, '<end>'])
+      expect(a.filterBy(b)).to.emit([value(3), value(4), value(7), value(8), end()], () => {
+        send(b, [value(true)])
+        send(a, [value(3), value(4)])
+        send(b, [value(0)])
+        send(a, [value(5), value(6)])
+        send(b, [value(1)])
+        send(a, [value(7), value(8)])
+        send(b, [value(false)])
+        send(a, [value(9), end()])
       })
     })
   })
@@ -95,51 +95,51 @@ describe('filterBy', () => {
     })
 
     it('should be ended if primary was ended', () => {
-      expect(send(stream(), ['<end>']).filterBy(prop())).to.emit(['<end:current>'])
+      expect(send(stream(), [end()]).filterBy(prop())).to.emit([end({current: true})])
     })
 
     it('should be ended if secondary was ended and has no current', () => {
-      expect(stream().filterBy(send(prop(), ['<end>']))).to.emit(['<end:current>'])
+      expect(stream().filterBy(send(prop(), [end()]))).to.emit([end({current: true})])
     })
 
     it('should be ended if secondary was ended and has falsey current', () => {
-      expect(stream().filterBy(send(prop(), [false, '<end>']))).to.emit(['<end:current>'])
+      expect(stream().filterBy(send(prop(), [value(false), end()]))).to.emit([end({current: true})])
     })
 
     it('should not be ended if secondary was ended but has truthy current', () => {
-      expect(stream().filterBy(send(prop(), [true, '<end>']))).to.emit([])
+      expect(stream().filterBy(send(prop(), [value(true), end()]))).to.emit([])
     })
 
     it('should end when secondary ends if last value from it was falsey', () => {
       const a = stream()
       const b = prop()
-      expect(a.filterBy(b)).to.emit(['<end>'], () => send(b, [false, '<end>']))
+      expect(a.filterBy(b)).to.emit([end()], () => send(b, [value(false), end()]))
     })
 
     it("should not end when secondary ends if last value from it wasn't falsey", () => {
       const a = stream()
       const b = prop()
-      expect(a.filterBy(b)).to.emit([], () => send(b, [true, '<end>']))
+      expect(a.filterBy(b)).to.emit([], () => send(b, [value(true), end()]))
     })
 
     it('should ignore values from primary until first value from secondary', () => {
       const a = stream()
       const b = prop()
-      expect(a.filterBy(b)).to.emit([], () => send(a, [1, 2]))
+      expect(a.filterBy(b)).to.emit([], () => send(a, [value(1), value(2)]))
     })
 
     it('should filter values as expected', () => {
       const a = stream()
       const b = prop()
-      expect(a.filterBy(b)).to.emit([3, 4, 7, 8, '<end>'], () => {
-        send(b, [true])
-        send(a, [3, 4])
-        send(b, [0])
-        send(a, [5, 6])
-        send(b, [1])
-        send(a, [7, 8])
-        send(b, [false])
-        send(a, [9, '<end>'])
+      expect(a.filterBy(b)).to.emit([value(3), value(4), value(7), value(8), end()], () => {
+        send(b, [value(true)])
+        send(a, [value(3), value(4)])
+        send(b, [value(0)])
+        send(a, [value(5), value(6)])
+        send(b, [value(1)])
+        send(a, [value(7), value(8)])
+        send(b, [value(false)])
+        send(a, [value(9), end()])
       })
     })
   })
@@ -156,43 +156,43 @@ describe('filterBy', () => {
     })
 
     it('should be ended if primary was ended', () => {
-      expect(send(prop(), ['<end>']).filterBy(stream())).to.emit(['<end:current>'])
+      expect(send(prop(), [end()]).filterBy(stream())).to.emit([end({current: true})])
     })
 
     it('should be ended if secondary was ended', () => {
-      expect(prop().filterBy(send(stream(), ['<end>']))).to.emit(['<end:current>'])
+      expect(prop().filterBy(send(stream(), [end()]))).to.emit([end({current: true})])
     })
 
     it('should end when secondary ends if last value from it was falsey', () => {
       const a = prop()
       const b = stream()
-      expect(a.filterBy(b)).to.emit(['<end>'], () => send(b, [false, '<end>']))
+      expect(a.filterBy(b)).to.emit([end()], () => send(b, [value(false), end()]))
     })
 
     it("should not end when secondary ends if last value from it wasn't falsey", () => {
       const a = prop()
       const b = stream()
-      expect(a.filterBy(b)).to.emit([], () => send(b, [true, '<end>']))
+      expect(a.filterBy(b)).to.emit([], () => send(b, [value(true), end()]))
     })
 
     it('should ignore values from primary until first value from secondary', () => {
       const a = prop()
       const b = stream()
-      expect(a.filterBy(b)).to.emit([], () => send(a, [1, 2]))
+      expect(a.filterBy(b)).to.emit([], () => send(a, [value(1), value(2)]))
     })
 
     it('should filter values as expected', () => {
-      const a = send(prop(), [0])
+      const a = send(prop(), [value(0)])
       const b = stream()
-      expect(a.filterBy(b)).to.emit([3, 4, 7, 8, '<end>'], () => {
-        send(b, [true])
-        send(a, [3, 4])
-        send(b, [0])
-        send(a, [5, 6])
-        send(b, [1])
-        send(a, [7, 8])
-        send(b, [false])
-        send(a, [9, '<end>'])
+      expect(a.filterBy(b)).to.emit([value(3), value(4), value(7), value(8), end()], () => {
+        send(b, [value(true)])
+        send(a, [value(3), value(4)])
+        send(b, [value(0)])
+        send(a, [value(5), value(6)])
+        send(b, [value(1)])
+        send(a, [value(7), value(8)])
+        send(b, [value(false)])
+        send(a, [value(9), end()])
       })
     })
   })
@@ -209,50 +209,50 @@ describe('filterBy', () => {
     })
 
     it('should be ended if primary was ended', () => {
-      expect(send(prop(), ['<end>']).filterBy(prop())).to.emit(['<end:current>'])
+      expect(send(prop(), [end()]).filterBy(prop())).to.emit([end({current: true})])
     })
 
     it('should be ended if secondary was ended and has no current', () => {
-      expect(prop().filterBy(send(prop(), ['<end>']))).to.emit(['<end:current>'])
+      expect(prop().filterBy(send(prop(), [end()]))).to.emit([end({current: true})])
     })
 
     it('should be ended if secondary was ended and has falsey current', () => {
-      expect(prop().filterBy(send(prop(), [false, '<end>']))).to.emit(['<end:current>'])
+      expect(prop().filterBy(send(prop(), [value(false), end()]))).to.emit([end({current: true})])
     })
 
     it('should not be ended if secondary was ended but has truthy current', () => {
-      expect(prop().filterBy(send(prop(), [true, '<end>']))).to.emit([])
+      expect(prop().filterBy(send(prop(), [value(true), end()]))).to.emit([])
     })
 
     it('should end when secondary ends if last value from it was falsey', () => {
       const a = prop()
       const b = prop()
-      expect(a.filterBy(b)).to.emit(['<end>'], () => send(b, [false, '<end>']))
+      expect(a.filterBy(b)).to.emit([end()], () => send(b, [value(false), end()]))
     })
 
     it("should not end when secondary ends if last value from it wasn't falsey", () => {
       const a = prop()
       const b = prop()
-      expect(a.filterBy(b)).to.emit([], () => send(b, [true, '<end>']))
+      expect(a.filterBy(b)).to.emit([], () => send(b, [value(true), end()]))
     })
 
     it('should ignore values from primary until first value from secondary', () => {
       const a = prop()
       const b = prop()
-      expect(a.filterBy(b)).to.emit([], () => send(a, [1, 2]))
+      expect(a.filterBy(b)).to.emit([], () => send(a, [value(1), value(2)]))
     })
 
     it('should filter values as expected', () => {
-      const a = send(prop(), [0])
-      const b = send(prop(), [true])
-      expect(a.filterBy(b)).to.emit([{current: 0}, 3, 4, 7, 8, '<end>'], () => {
-        send(a, [3, 4])
-        send(b, [0])
-        send(a, [5, 6])
-        send(b, [1])
-        send(a, [7, 8])
-        send(b, [false])
-        send(a, [9, '<end>'])
+      const a = send(prop(), [value(0)])
+      const b = send(prop(), [value(true)])
+      expect(a.filterBy(b)).to.emit([value(0, {current: true}), value(3), value(4), value(7), value(8), end()], () => {
+        send(a, [value(3), value(4)])
+        send(b, [value(0)])
+        send(a, [value(5), value(6)])
+        send(b, [value(1)])
+        send(a, [value(7), value(8)])
+        send(b, [value(false)])
+        send(a, [value(9), end()])
       })
     })
   })

--- a/test/specs/filter-errors.js
+++ b/test/specs/filter-errors.js
@@ -1,29 +1,29 @@
-const {stream, prop, send} = require('../test-helpers')
+const {stream, prop, send, expect} = require('../test-helpers')
 
 describe('filterErrors', () => {
   describe('stream', () => {
     it('should return stream', () => {
-      expect(stream().filterErrors(() => {})).toBeStream()
+      expect(stream().filterErrors(() => {})).to.be.observable.stream()
     })
 
     it('should activate/deactivate source', () => {
       const a = stream()
-      expect(a.filterErrors(() => {})).toActivate(a)
+      expect(a.filterErrors(() => {})).to.activate(a)
     })
 
     it('should be ended if source was ended', () =>
-      expect(send(stream(), ['<end>']).filterErrors(() => {})).toEmit(['<end:current>']))
+      expect(send(stream(), ['<end>']).filterErrors(() => {})).to.emit(['<end:current>']))
 
     it('should handle events', () => {
       const a = stream()
-      expect(a.filterErrors(x => x > 3)).toEmit([-1, {error: 4}, -2, {error: 5}, {error: 6}, '<end>'], () =>
+      expect(a.filterErrors(x => x > 3)).to.emit([-1, {error: 4}, -2, {error: 5}, {error: 6}, '<end>'], () =>
         send(a, [-1, {error: 1}, {error: 2}, {error: 3}, {error: 4}, -2, {error: 5}, {error: 0}, {error: 6}, '<end>'])
       )
     })
 
     it('shoud use id as default predicate', () => {
       const a = stream()
-      expect(a.filterErrors()).toEmit([-1, {error: 4}, -2, {error: 5}, false, {error: 6}, '<end>'], () =>
+      expect(a.filterErrors()).to.emit([-1, {error: 4}, -2, {error: 5}, false, {error: 6}, '<end>'], () =>
         send(a, [
           -1,
           {error: 0},
@@ -43,36 +43,36 @@ describe('filterErrors', () => {
 
   describe('property', () => {
     it('should return property', () => {
-      expect(prop().filterErrors(() => {})).toBeProperty()
+      expect(prop().filterErrors(() => {})).to.be.observable.property()
     })
 
     it('should activate/deactivate source', () => {
       const a = prop()
-      expect(a.filterErrors(() => {})).toActivate(a)
+      expect(a.filterErrors(() => {})).to.activate(a)
     })
 
     it('should be ended if source was ended', () =>
-      expect(send(prop(), ['<end>']).filterErrors(() => {})).toEmit(['<end:current>']))
+      expect(send(prop(), ['<end>']).filterErrors(() => {})).to.emit(['<end:current>']))
 
     it('should handle events and current', () => {
       const a = send(prop(), [{error: 5}])
-      expect(a.filterErrors(x => x > 3)).toEmit([{currentError: 5}, {error: 4}, -2, {error: 6}, '<end>'], () =>
+      expect(a.filterErrors(x => x > 3)).to.emit([{currentError: 5}, {error: 4}, -2, {error: 6}, '<end>'], () =>
         send(a, [{error: 1}, {error: 2}, {error: 3}, {error: 4}, -2, {error: 0}, {error: 6}, '<end>'])
       )
     })
 
     it('should handle current (not pass)', () => {
       const a = send(prop(), [{error: 0}])
-      expect(a.filterErrors(x => x > 2)).toEmit([])
+      expect(a.filterErrors(x => x > 2)).to.emit([])
     })
 
     it('shoud use id as default predicate', () => {
       let a = send(prop(), [{error: 5}])
-      expect(a.filterErrors()).toEmit([{currentError: 5}, {error: 4}, -2, {error: 6}, '<end>'], () =>
+      expect(a.filterErrors()).to.emit([{currentError: 5}, {error: 4}, -2, {error: 6}, '<end>'], () =>
         send(a, [{error: 0}, {error: false}, {error: null}, {error: 4}, -2, {error: undefined}, {error: 6}, '<end>'])
       )
       a = send(prop(), [{error: 0}])
-      expect(a.filterErrors()).toEmit([])
+      expect(a.filterErrors()).to.emit([])
     })
   })
 })

--- a/test/specs/filter-errors.js
+++ b/test/specs/filter-errors.js
@@ -1,4 +1,4 @@
-const {stream, prop, send, expect} = require('../test-helpers')
+const {stream, prop, send, value, error, end, expect} = require('../test-helpers')
 
 describe('filterErrors', () => {
   describe('stream', () => {
@@ -12,30 +12,30 @@ describe('filterErrors', () => {
     })
 
     it('should be ended if source was ended', () =>
-      expect(send(stream(), ['<end>']).filterErrors(() => {})).to.emit(['<end:current>']))
+      expect(send(stream(), [end()]).filterErrors(() => {})).to.emit([end({current: true})]))
 
     it('should handle events', () => {
       const a = stream()
-      expect(a.filterErrors(x => x > 3)).to.emit([-1, {error: 4}, -2, {error: 5}, {error: 6}, '<end>'], () =>
-        send(a, [-1, {error: 1}, {error: 2}, {error: 3}, {error: 4}, -2, {error: 5}, {error: 0}, {error: 6}, '<end>'])
+      expect(a.filterErrors(x => x > 3)).to.emit([value(-1), error(4), value(-2), error(5), error(6), end()], () =>
+        send(a, [value(-1), error(1), error(2), error(3), error(4), value(-2), error(5), error(0), error(6), end()])
       )
     })
 
     it('shoud use id as default predicate', () => {
       const a = stream()
-      expect(a.filterErrors()).to.emit([-1, {error: 4}, -2, {error: 5}, false, {error: 6}, '<end>'], () =>
+      expect(a.filterErrors()).to.emit([value(-1), error(4), value(-2), error(5), value(false), error(6), end()], () =>
         send(a, [
-          -1,
-          {error: 0},
-          {error: false},
-          {error: null},
-          {error: 4},
-          -2,
-          {error: 5},
-          {error: ''},
-          false,
-          {error: 6},
-          '<end>',
+          value(-1),
+          error(0),
+          error(false),
+          error(null),
+          error(4),
+          value(-2),
+          error(5),
+          error(''),
+          value(false),
+          error(6),
+          end(),
         ])
       )
     })
@@ -52,26 +52,27 @@ describe('filterErrors', () => {
     })
 
     it('should be ended if source was ended', () =>
-      expect(send(prop(), ['<end>']).filterErrors(() => {})).to.emit(['<end:current>']))
+      expect(send(prop(), [end()]).filterErrors(() => {})).to.emit([end({current: true})]))
 
     it('should handle events and current', () => {
-      const a = send(prop(), [{error: 5}])
-      expect(a.filterErrors(x => x > 3)).to.emit([{currentError: 5}, {error: 4}, -2, {error: 6}, '<end>'], () =>
-        send(a, [{error: 1}, {error: 2}, {error: 3}, {error: 4}, -2, {error: 0}, {error: 6}, '<end>'])
+      const a = send(prop(), [error(5)])
+      expect(a.filterErrors(x => x > 3)).to.emit(
+        [error(5, {current: true}), error(4), value(-2), error(6), end()],
+        () => send(a, [error(1), error(2), error(3), error(4), value(-2), error(0), error(6), end()])
       )
     })
 
     it('should handle current (not pass)', () => {
-      const a = send(prop(), [{error: 0}])
+      const a = send(prop(), [error(0)])
       expect(a.filterErrors(x => x > 2)).to.emit([])
     })
 
     it('shoud use id as default predicate', () => {
-      let a = send(prop(), [{error: 5}])
-      expect(a.filterErrors()).to.emit([{currentError: 5}, {error: 4}, -2, {error: 6}, '<end>'], () =>
-        send(a, [{error: 0}, {error: false}, {error: null}, {error: 4}, -2, {error: undefined}, {error: 6}, '<end>'])
+      let a = send(prop(), [error(5)])
+      expect(a.filterErrors()).to.emit([error(5, {current: true}), error(4), value(-2), error(6), end()], () =>
+        send(a, [error(0), error(false), error(null), error(4), value(-2), error(undefined), error(6), end()])
       )
-      a = send(prop(), [{error: 0}])
+      a = send(prop(), [error(0)])
       expect(a.filterErrors()).to.emit([])
     })
   })

--- a/test/specs/filter.js
+++ b/test/specs/filter.js
@@ -1,68 +1,68 @@
-const {stream, prop, send} = require('../test-helpers')
+const {stream, prop, send, expect} = require('../test-helpers')
 
 describe('filter', () => {
   describe('stream', () => {
     it('should return stream', () => {
-      expect(stream().filter(() => {})).toBeStream()
+      expect(stream().filter(() => {})).to.be.observable.stream()
     })
 
     it('should activate/deactivate source', () => {
       const a = stream()
-      expect(a.filter(() => {})).toActivate(a)
+      expect(a.filter(() => {})).to.activate(a)
     })
 
     it('should be ended if source was ended', () => {
-      expect(send(stream(), ['<end>']).filter(() => {})).toEmit(['<end:current>'])
+      expect(send(stream(), ['<end>']).filter(() => {})).to.emit(['<end:current>'])
     })
 
     it('should handle events', () => {
       const a = stream()
-      expect(a.filter(x => x > 3)).toEmit([4, 5, {error: 7}, 6, '<end>'], () =>
+      expect(a.filter(x => x > 3)).to.emit([4, 5, {error: 7}, 6, '<end>'], () =>
         send(a, [1, 2, 4, 5, 0, {error: 7}, 6, '<end>'])
       )
     })
 
     it('shoud use id as default predicate', () => {
       const a = stream()
-      expect(a.filter()).toEmit([4, 5, {error: 7}, 6, '<end>'], () => send(a, [0, 0, 4, 5, 0, {error: 7}, 6, '<end>']))
+      expect(a.filter()).to.emit([4, 5, {error: 7}, 6, '<end>'], () => send(a, [0, 0, 4, 5, 0, {error: 7}, 6, '<end>']))
     })
   })
 
   describe('property', () => {
     it('should return property', () => {
-      expect(prop().filter(() => {})).toBeProperty()
+      expect(prop().filter(() => {})).to.be.observable.property()
     })
 
     it('should activate/deactivate source', () => {
       const a = prop()
-      expect(a.filter(() => {})).toActivate(a)
+      expect(a.filter(() => {})).to.activate(a)
     })
 
     it('should be ended if source was ended', () => {
-      expect(send(prop(), ['<end>']).filter(() => {})).toEmit(['<end:current>'])
+      expect(send(prop(), ['<end>']).filter(() => {})).to.emit(['<end:current>'])
     })
 
     it('should handle events and current', () => {
       let a = send(prop(), [5])
-      expect(a.filter(x => x > 2)).toEmit([{current: 5}, 4, {error: 7}, 3, '<end>'], () =>
+      expect(a.filter(x => x > 2)).to.emit([{current: 5}, 4, {error: 7}, 3, '<end>'], () =>
         send(a, [4, {error: 7}, 3, 2, 1, '<end>'])
       )
       a = send(prop(), [{error: 0}])
-      expect(a.filter(x => x > 2)).toEmit([{currentError: 0}, 4, {error: 7}, 3, '<end>'], () =>
+      expect(a.filter(x => x > 2)).to.emit([{currentError: 0}, 4, {error: 7}, 3, '<end>'], () =>
         send(a, [4, {error: 7}, 3, 2, 1, '<end>'])
       )
     })
 
     it('should handle current (not pass)', () => {
       const a = send(prop(), [1, {error: 0}])
-      expect(a.filter(x => x > 2)).toEmit([{currentError: 0}])
+      expect(a.filter(x => x > 2)).to.emit([{currentError: 0}])
     })
 
     it('shoud use id as default predicate', () => {
       let a = send(prop(), [0])
-      expect(a.filter()).toEmit([4, {error: -2}, 5, 6, '<end>'], () => send(a, [0, 4, {error: -2}, 5, 0, 6, '<end>']))
+      expect(a.filter()).to.emit([4, {error: -2}, 5, 6, '<end>'], () => send(a, [0, 4, {error: -2}, 5, 0, 6, '<end>']))
       a = send(prop(), [1])
-      expect(a.filter()).toEmit([{current: 1}, 4, {error: -2}, 5, 6, '<end>'], () =>
+      expect(a.filter()).to.emit([{current: 1}, 4, {error: -2}, 5, 6, '<end>'], () =>
         send(a, [0, 4, {error: -2}, 5, 0, 6, '<end>'])
       )
     })

--- a/test/specs/filter.js
+++ b/test/specs/filter.js
@@ -1,4 +1,4 @@
-const {stream, prop, send, expect} = require('../test-helpers')
+const {stream, prop, send, value, error, end, expect} = require('../test-helpers')
 
 describe('filter', () => {
   describe('stream', () => {
@@ -12,19 +12,21 @@ describe('filter', () => {
     })
 
     it('should be ended if source was ended', () => {
-      expect(send(stream(), ['<end>']).filter(() => {})).to.emit(['<end:current>'])
+      expect(send(stream(), [end()]).filter(() => {})).to.emit([end({current: true})])
     })
 
     it('should handle events', () => {
       const a = stream()
-      expect(a.filter(x => x > 3)).to.emit([4, 5, {error: 7}, 6, '<end>'], () =>
-        send(a, [1, 2, 4, 5, 0, {error: 7}, 6, '<end>'])
+      expect(a.filter(x => x > 3)).to.emit([value(4), value(5), error(7), value(6), end()], () =>
+        send(a, [value(1), value(2), value(4), value(5), value(0), error(7), value(6), end()])
       )
     })
 
     it('shoud use id as default predicate', () => {
       const a = stream()
-      expect(a.filter()).to.emit([4, 5, {error: 7}, 6, '<end>'], () => send(a, [0, 0, 4, 5, 0, {error: 7}, 6, '<end>']))
+      expect(a.filter()).to.emit([value(4), value(5), error(7), value(6), end()], () =>
+        send(a, [value(0), value(0), value(4), value(5), value(0), error(7), value(6), end()])
+      )
     })
   })
 
@@ -39,31 +41,34 @@ describe('filter', () => {
     })
 
     it('should be ended if source was ended', () => {
-      expect(send(prop(), ['<end>']).filter(() => {})).to.emit(['<end:current>'])
+      expect(send(prop(), [end()]).filter(() => {})).to.emit([end({current: true})])
     })
 
     it('should handle events and current', () => {
-      let a = send(prop(), [5])
-      expect(a.filter(x => x > 2)).to.emit([{current: 5}, 4, {error: 7}, 3, '<end>'], () =>
-        send(a, [4, {error: 7}, 3, 2, 1, '<end>'])
+      let a = send(prop(), [value(5)])
+      expect(a.filter(x => x > 2)).to.emit([value(5, {current: true}), value(4), error(7), value(3), end()], () =>
+        send(a, [value(4), error(7), value(3), value(2), value(1), end()])
       )
-      a = send(prop(), [{error: 0}])
-      expect(a.filter(x => x > 2)).to.emit([{currentError: 0}, 4, {error: 7}, 3, '<end>'], () =>
-        send(a, [4, {error: 7}, 3, 2, 1, '<end>'])
+      a = send(prop(), [error(0)])
+      expect(a.filter(x => x > 2)).to.emit([error(0, {current: true}), value(4), error(7), value(3), end()], () =>
+        send(a, [value(4), error(7), value(3), value(2), value(1), end()])
       )
     })
 
     it('should handle current (not pass)', () => {
-      const a = send(prop(), [1, {error: 0}])
-      expect(a.filter(x => x > 2)).to.emit([{currentError: 0}])
+      const a = send(prop(), [value(1), error(0)])
+      expect(a.filter(x => x > 2)).to.emit([error(0, {current: true})])
     })
 
     it('shoud use id as default predicate', () => {
-      let a = send(prop(), [0])
-      expect(a.filter()).to.emit([4, {error: -2}, 5, 6, '<end>'], () => send(a, [0, 4, {error: -2}, 5, 0, 6, '<end>']))
-      a = send(prop(), [1])
-      expect(a.filter()).to.emit([{current: 1}, 4, {error: -2}, 5, 6, '<end>'], () =>
-        send(a, [0, 4, {error: -2}, 5, 0, 6, '<end>'])
+      let a = send(prop(), [value(0)])
+      expect(a.filter()).to.emit([value(4), error(-value(2)), value(5), value(6), end()], () =>
+        send(a, [value(0), value(4), error(-value(2)), value(5), value(0), value(6), end()])
+      )
+      a = send(prop(), [value(1)])
+      expect(a.filter()).to.emit(
+        [value(1, {current: true}), value(4), error(-value(2)), value(5), value(6), end()],
+        () => send(a, [value(0), value(4), error(-value(2)), value(5), value(0), value(6), end()])
       )
     })
   })

--- a/test/specs/flat-map-concat.js
+++ b/test/specs/flat-map-concat.js
@@ -1,24 +1,24 @@
-const {stream, prop, send, activate, deactivate, Kefir} = require('../test-helpers')
+const {stream, prop, send, activate, deactivate, Kefir, expect} = require('../test-helpers')
 
 describe('flatMapConcat', () => {
   describe('stream', () => {
     it('should return stream', () => {
-      expect(stream().flatMapConcat()).toBeStream()
+      expect(stream().flatMapConcat()).to.be.observable.stream()
     })
 
     it('should activate/deactivate source', () => {
       const a = stream()
-      expect(a.flatMapConcat()).toActivate(a)
+      expect(a.flatMapConcat()).to.activate(a)
     })
 
     it('should be ended if source was ended', () =>
-      expect(send(stream(), ['<end>']).flatMapConcat()).toEmit(['<end:current>']))
+      expect(send(stream(), ['<end>']).flatMapConcat()).to.emit(['<end:current>']))
 
     it('should handle events', () => {
       const a = stream()
       const b = stream()
       const c = stream()
-      expect(a.flatMapConcat()).toEmit([1, 2, 5, 6, '<end>'], () => {
+      expect(a.flatMapConcat()).to.emit([1, 2, 5, 6, '<end>'], () => {
         send(b, [0])
         send(a, [b])
         send(b, [1, 2])
@@ -37,16 +37,16 @@ describe('flatMapConcat', () => {
       activate(map)
       send(a, [b, c])
       deactivate(map)
-      expect(map).toActivate(b)
-      expect(map).not.toActivate(c)
+      expect(map).to.activate(b)
+      expect(map).not.to.activate(c)
       send(b, ['<end>'])
-      expect(map).toActivate(c)
+      expect(map).to.activate(c)
     })
 
     it('should accept optional map fn', () => {
       const a = stream()
       const b = stream()
-      expect(a.flatMapConcat(x => x.obs)).toEmit([1, 2, '<end>'], () => {
+      expect(a.flatMapConcat(x => x.obs)).to.emit([1, 2, '<end>'], () => {
         send(b, [0])
         send(a, [{obs: b}, '<end>'])
         send(b, [1, 2, '<end>'])
@@ -60,7 +60,7 @@ describe('flatMapConcat', () => {
       activate(m)
       send(a, [b])
       deactivate(m)
-      expect(m).toEmit([{current: 1}])
+      expect(m).to.emit([{current: 1}])
     })
 
     it('should correctly handle current values of new sub sources', () => {
@@ -68,7 +68,7 @@ describe('flatMapConcat', () => {
       const b = send(prop(), [1, '<end>'])
       const c = send(prop(), [2])
       const d = send(prop(), [3])
-      expect(a.flatMapConcat()).toEmit([1, 2], () => send(a, [b, c, d]))
+      expect(a.flatMapConcat()).to.emit([1, 2], () => send(a, [b, c, d]))
     })
 
     it('should work nicely with Kefir.constant and Kefir.never', () => {
@@ -81,25 +81,25 @@ describe('flatMapConcat', () => {
             return Kefir.never()
           }
         })
-      ).toEmit([3, 4, 5], () => send(a, [1, 2, 3, 4, 5]))
+      ).to.emit([3, 4, 5], () => send(a, [1, 2, 3, 4, 5]))
     })
   })
 
   describe('property', () => {
     it('should return stream', () => {
-      expect(prop().flatMapConcat()).toBeStream()
+      expect(prop().flatMapConcat()).to.be.observable.stream()
     })
 
     it('should activate/deactivate source', () => {
       const a = prop()
-      expect(a.flatMapConcat()).toActivate(a)
+      expect(a.flatMapConcat()).to.activate(a)
     })
 
     it('should be ended if source was ended', () =>
-      expect(send(prop(), ['<end>']).flatMapConcat()).toEmit(['<end:current>']))
+      expect(send(prop(), ['<end>']).flatMapConcat()).to.emit(['<end:current>']))
 
     it('should be ended if source was ended (with value)', () =>
-      expect(send(prop(), [send(prop(), [0, '<end>']), '<end>']).flatMapConcat()).toEmit([
+      expect(send(prop(), [send(prop(), [0, '<end>']), '<end>']).flatMapConcat()).to.emit([
         {current: 0},
         '<end:current>',
       ]))
@@ -107,7 +107,7 @@ describe('flatMapConcat', () => {
     it('should correctly handle current value of source', () => {
       const a = send(prop(), [0])
       const b = send(prop(), [a])
-      expect(b.flatMapConcat()).toEmit([{current: 0}])
+      expect(b.flatMapConcat()).to.emit([{current: 0}])
     })
   })
 })

--- a/test/specs/flat-map-errors.js
+++ b/test/specs/flat-map-errors.js
@@ -1,24 +1,24 @@
-const {stream, prop, send, activate, deactivate, Kefir} = require('../test-helpers')
+const {stream, prop, send, activate, deactivate, Kefir, expect} = require('../test-helpers')
 
 describe('flatMapErrors', () => {
   describe('stream', () => {
     it('should return stream', () => {
-      expect(stream().flatMapErrors()).toBeStream()
+      expect(stream().flatMapErrors()).to.be.observable.stream()
     })
 
     it('should activate/deactivate source', () => {
       const a = stream()
-      expect(a.flatMapErrors()).toActivate(a)
+      expect(a.flatMapErrors()).to.activate(a)
     })
 
     it('should be ended if source was ended', () =>
-      expect(send(stream(), ['<end>']).flatMapErrors()).toEmit(['<end:current>']))
+      expect(send(stream(), ['<end>']).flatMapErrors()).to.emit(['<end:current>']))
 
     it('should handle events', () => {
       const a = stream()
       const b = stream()
       const c = send(prop(), [0])
-      expect(a.flatMapErrors()).toEmit([1, 2, 0, 3, 4, '<end>'], () => {
+      expect(a.flatMapErrors()).to.emit([1, 2, 0, 3, 4, '<end>'], () => {
         send(b, [0])
         send(a, [{error: b}])
         send(b, [1, 2])
@@ -36,13 +36,13 @@ describe('flatMapErrors', () => {
       activate(map)
       send(a, [{error: b}, {error: c}])
       deactivate(map)
-      expect(map).toActivate(b, c)
+      expect(map).to.activate(b, c)
     })
 
     it('should accept optional map fn', () => {
       const a = stream()
       const b = stream()
-      expect(a.flatMapErrors(x => x.obs)).toEmit([1, 2, '<end>'], () => {
+      expect(a.flatMapErrors(x => x.obs)).to.emit([1, 2, '<end>'], () => {
         send(b, [0])
         send(a, [{error: {obs: b}}, '<end>'])
         send(b, [1, 2, '<end>'])
@@ -57,14 +57,14 @@ describe('flatMapErrors', () => {
       activate(m)
       send(a, [{error: b}, {error: c}])
       deactivate(m)
-      expect(m).toEmit([{current: 1}, {current: 2}])
+      expect(m).to.emit([{current: 1}, {current: 2}])
     })
 
     it('should correctly handle current values of new sub sources', () => {
       const a = stream()
       const b = send(prop(), [1])
       const c = send(prop(), [2])
-      expect(a.flatMapErrors()).toEmit([1, 2], () => send(a, [{error: b}, {error: c}]))
+      expect(a.flatMapErrors()).to.emit([1, 2], () => send(a, [{error: b}, {error: c}]))
     })
 
     it('should work nicely with Kefir.constant and Kefir.never', () => {
@@ -79,12 +79,12 @@ describe('flatMapErrors', () => {
             return Kefir.never()
           }
         })
-      ).toEmit([3, {error: -1}, 4, {error: -2}, 5], () => send(a, [1, 2, 3, -1, 4, -2, 5]))
+      ).to.emit([3, {error: -1}, 4, {error: -2}, 5], () => send(a, [1, 2, 3, -1, 4, -2, 5]))
     })
 
     it('values should flow', () => {
       const a = stream()
-      expect(a.flatMapErrors()).toEmit([1, 2, 3], () => send(a, [1, 2, 3]))
+      expect(a.flatMapErrors()).to.emit([1, 2, 3], () => send(a, [1, 2, 3]))
     })
 
     it('should be possible to add same obs twice on activation', () => {
@@ -93,13 +93,13 @@ describe('flatMapErrors', () => {
         em.error(b)
         return em.error(b)
       })
-      expect(a.flatMapErrors()).toEmit([{current: 1}, {current: 1}])
+      expect(a.flatMapErrors()).to.emit([{current: 1}, {current: 1}])
     })
   })
 
   describe('property', () => {
     it('should be ended if source was ended (with current error)', () =>
-      expect(send(prop(), [{error: send(prop(), [0, '<end>'])}, '<end>']).flatMapErrors()).toEmit([
+      expect(send(prop(), [{error: send(prop(), [0, '<end>'])}, '<end>']).flatMapErrors()).to.emit([
         {current: 0},
         '<end:current>',
       ]))
@@ -112,14 +112,14 @@ describe('flatMapErrors', () => {
       deactivate(map)
       activate(map)
       deactivate(map)
-      expect(map).toEmit([{current: 0}])
+      expect(map).to.emit([{current: 0}])
     })
 
     it('should allow to add same obs several times', () => {
       const b = send(prop(), ['b0'])
       const c = stream()
       const a = send(prop(), [b])
-      expect(a.valuesToErrors().flatMapErrors()).toEmit(
+      expect(a.valuesToErrors().flatMapErrors()).to.emit(
         [{current: 'b0'}, 'b0', 'b0', 'b0', 'b0', 'b1', 'b1', 'b1', 'b1', 'b1', 'c1', 'c1', 'c1', '<end>'],
         () => {
           send(a, [b, c, b, c, c, b, b, '<end>'])
@@ -132,12 +132,12 @@ describe('flatMapErrors', () => {
     it('should correctly handle current error of source', () => {
       const a = send(prop(), [0])
       const b = send(prop(), [{error: a}])
-      expect(b.flatMapErrors()).toEmit([{current: 0}])
+      expect(b.flatMapErrors()).to.emit([{current: 0}])
     })
 
     it('values should flow', () => {
       const a = send(prop(), [0])
-      expect(a.flatMapErrors()).toEmit([{current: 0}, 1, 2, 3], () => send(a, [1, 2, 3]))
+      expect(a.flatMapErrors()).to.emit([{current: 0}, 1, 2, 3], () => send(a, [1, 2, 3]))
     })
   })
 })

--- a/test/specs/flat-map-first.js
+++ b/test/specs/flat-map-first.js
@@ -1,24 +1,24 @@
-const {stream, prop, send, activate, deactivate, Kefir} = require('../test-helpers')
+const {stream, prop, send, activate, deactivate, Kefir, expect} = require('../test-helpers')
 
 describe('flatMapFirst', () => {
   describe('stream', () => {
     it('should return stream', () => {
-      expect(stream().flatMapFirst()).toBeStream()
+      expect(stream().flatMapFirst()).to.be.observable.stream()
     })
 
     it('should activate/deactivate source', () => {
       const a = stream()
-      expect(a.flatMapFirst()).toActivate(a)
+      expect(a.flatMapFirst()).to.activate(a)
     })
 
     it('should be ended if source was ended', () =>
-      expect(send(stream(), ['<end>']).flatMapFirst()).toEmit(['<end:current>']))
+      expect(send(stream(), ['<end>']).flatMapFirst()).to.emit(['<end:current>']))
 
     it('should handle events', () => {
       const a = stream()
       const b = stream()
       const c = stream()
-      expect(a.flatMapFirst()).toEmit([1, 2, 4, '<end>'], () => {
+      expect(a.flatMapFirst()).to.emit([1, 2, 4, '<end>'], () => {
         send(b, [0])
         send(a, [b])
         send(b, [1])
@@ -38,14 +38,14 @@ describe('flatMapFirst', () => {
       activate(map)
       send(a, [b, c])
       deactivate(map)
-      expect(map).toActivate(b)
-      expect(map).not.toActivate(c)
+      expect(map).to.activate(b)
+      expect(map).not.to.activate(c)
     })
 
     it('should accept optional map fn', () => {
       const a = stream()
       const b = stream()
-      expect(a.flatMapFirst(x => x.obs)).toEmit([1, 2, '<end>'], () => {
+      expect(a.flatMapFirst(x => x.obs)).to.emit([1, 2, '<end>'], () => {
         send(a, [{obs: b}, '<end>'])
         send(b, [1, 2, '<end>'])
       })
@@ -59,7 +59,7 @@ describe('flatMapFirst', () => {
       activate(m)
       send(a, [b, c])
       deactivate(m)
-      expect(m).toEmit([{current: 1}])
+      expect(m).to.emit([{current: 1}])
     })
 
     it('should correctly handle current values of new sub sources', () => {
@@ -67,7 +67,7 @@ describe('flatMapFirst', () => {
       const b = send(prop(), [1, '<end>'])
       const c = send(prop(), [2])
       const d = send(prop(), [3])
-      expect(a.flatMapFirst()).toEmit([1, 2], () => send(a, [b, c, d]))
+      expect(a.flatMapFirst()).to.emit([1, 2], () => send(a, [b, c, d]))
     })
 
     it('should work nicely with Kefir.constant and Kefir.never', () => {
@@ -80,7 +80,7 @@ describe('flatMapFirst', () => {
             return Kefir.never()
           }
         })
-      ).toEmit([3, 4, 5], () => send(a, [1, 2, 3, 4, 5]))
+      ).to.emit([3, 4, 5], () => send(a, [1, 2, 3, 4, 5]))
     })
 
     it('should not call transformer function when skiping values', () => {
@@ -93,33 +93,33 @@ describe('flatMapFirst', () => {
         return x
       })
       activate(result)
-      expect(count).toBe(0)
+      expect(count).to.equal(0)
       send(a, [b])
-      expect(count).toBe(1)
+      expect(count).to.equal(1)
       send(a, [c])
-      expect(count).toBe(1)
+      expect(count).to.equal(1)
       send(b, ['<end>'])
-      expect(count).toBe(1)
+      expect(count).to.equal(1)
       send(a, [c])
-      expect(count).toBe(2)
+      expect(count).to.equal(2)
     })
   })
 
   describe('property', () => {
     it('should return stream', () => {
-      expect(prop().flatMapFirst()).toBeStream()
+      expect(prop().flatMapFirst()).to.be.observable.stream()
     })
 
     it('should activate/deactivate source', () => {
       const a = prop()
-      expect(a.flatMapFirst()).toActivate(a)
+      expect(a.flatMapFirst()).to.activate(a)
     })
 
     it('should be ended if source was ended', () =>
-      expect(send(prop(), ['<end>']).flatMapFirst()).toEmit(['<end:current>']))
+      expect(send(prop(), ['<end>']).flatMapFirst()).to.emit(['<end:current>']))
 
     it('should be ended if source was ended (with value)', () =>
-      expect(send(prop(), [send(prop(), [0, '<end>']), '<end>']).flatMapFirst()).toEmit([
+      expect(send(prop(), [send(prop(), [0, '<end>']), '<end>']).flatMapFirst()).to.emit([
         {current: 0},
         '<end:current>',
       ]))
@@ -127,7 +127,7 @@ describe('flatMapFirst', () => {
     it('should correctly handle current value of source', () => {
       const a = send(prop(), [0])
       const b = send(prop(), [a])
-      expect(b.flatMapFirst()).toEmit([{current: 0}])
+      expect(b.flatMapFirst()).to.emit([{current: 0}])
     })
   })
 })

--- a/test/specs/flat-map-first.js
+++ b/test/specs/flat-map-first.js
@@ -1,4 +1,4 @@
-const {stream, prop, send, activate, deactivate, Kefir, expect} = require('../test-helpers')
+const {stream, prop, send, value, error, end, activate, deactivate, Kefir, expect} = require('../test-helpers')
 
 describe('flatMapFirst', () => {
   describe('stream', () => {
@@ -12,31 +12,31 @@ describe('flatMapFirst', () => {
     })
 
     it('should be ended if source was ended', () =>
-      expect(send(stream(), ['<end>']).flatMapFirst()).to.emit(['<end:current>']))
+      expect(send(stream(), [end()]).flatMapFirst()).to.emit([end({current: true})]))
 
     it('should handle events', () => {
       const a = stream()
       const b = stream()
       const c = stream()
-      expect(a.flatMapFirst()).to.emit([1, 2, 4, '<end>'], () => {
-        send(b, [0])
-        send(a, [b])
-        send(b, [1])
-        send(a, [c])
-        send(b, [2, '<end>'])
-        send(c, [3])
-        send(a, [c, '<end>'])
-        send(c, [4, '<end>'])
+      expect(a.flatMapFirst()).to.emit([value(1), value(2), value(4), end()], () => {
+        send(b, [value(0)])
+        send(a, [value(b)])
+        send(b, [value(1)])
+        send(a, [value(c)])
+        send(b, [value(2), end()])
+        send(c, [value(3)])
+        send(a, [value(c), end()])
+        send(c, [value(4), end()])
       })
     })
 
     it('should activate sub-sources (only first)', () => {
       const a = stream()
       const b = stream()
-      const c = send(prop(), [0])
+      const c = send(prop(), [value(0)])
       const map = a.flatMapFirst()
       activate(map)
-      send(a, [b, c])
+      send(a, [value(b), value(c)])
       deactivate(map)
       expect(map).to.activate(b)
       expect(map).not.to.activate(c)
@@ -45,29 +45,29 @@ describe('flatMapFirst', () => {
     it('should accept optional map fn', () => {
       const a = stream()
       const b = stream()
-      expect(a.flatMapFirst(x => x.obs)).to.emit([1, 2, '<end>'], () => {
-        send(a, [{obs: b}, '<end>'])
-        send(b, [1, 2, '<end>'])
+      expect(a.flatMapFirst(x => x.obs)).to.emit([value(1), value(2), end()], () => {
+        send(a, [value({obs: b}), end()])
+        send(b, [value(1), value(2), end()])
       })
     })
 
     it('should correctly handle current values of sub sources on activation', () => {
       const a = stream()
-      const b = send(prop(), [1])
-      const c = send(prop(), [2])
+      const b = send(prop(), [value(1)])
+      const c = send(prop(), [value(2)])
       const m = a.flatMapFirst()
       activate(m)
-      send(a, [b, c])
+      send(a, [value(b), value(c)])
       deactivate(m)
-      expect(m).to.emit([{current: 1}])
+      expect(m).to.emit([value(1, {current: true})])
     })
 
     it('should correctly handle current values of new sub sources', () => {
       const a = stream()
-      const b = send(prop(), [1, '<end>'])
-      const c = send(prop(), [2])
-      const d = send(prop(), [3])
-      expect(a.flatMapFirst()).to.emit([1, 2], () => send(a, [b, c, d]))
+      const b = send(prop(), [value(1), end()])
+      const c = send(prop(), [value(2)])
+      const d = send(prop(), [value(3)])
+      expect(a.flatMapFirst()).to.emit([value(1), value(2)], () => send(a, [value(b), value(c), value(d)]))
     })
 
     it('should work nicely with Kefir.constant and Kefir.never', () => {
@@ -80,7 +80,7 @@ describe('flatMapFirst', () => {
             return Kefir.never()
           }
         })
-      ).to.emit([3, 4, 5], () => send(a, [1, 2, 3, 4, 5]))
+      ).to.emit([value(3), value(4), value(5)], () => send(a, [value(1), value(2), value(3), value(4), value(5)]))
     })
 
     it('should not call transformer function when skiping values', () => {
@@ -94,13 +94,13 @@ describe('flatMapFirst', () => {
       })
       activate(result)
       expect(count).to.equal(0)
-      send(a, [b])
+      send(a, [value(b)])
       expect(count).to.equal(1)
-      send(a, [c])
+      send(a, [value(c)])
       expect(count).to.equal(1)
-      send(b, ['<end>'])
+      send(b, [end()])
       expect(count).to.equal(1)
-      send(a, [c])
+      send(a, [value(c)])
       expect(count).to.equal(2)
     })
   })
@@ -116,18 +116,18 @@ describe('flatMapFirst', () => {
     })
 
     it('should be ended if source was ended', () =>
-      expect(send(prop(), ['<end>']).flatMapFirst()).to.emit(['<end:current>']))
+      expect(send(prop(), [end()]).flatMapFirst()).to.emit([end({current: true})]))
 
     it('should be ended if source was ended (with value)', () =>
-      expect(send(prop(), [send(prop(), [0, '<end>']), '<end>']).flatMapFirst()).to.emit([
-        {current: 0},
-        '<end:current>',
+      expect(send(prop(), [value(send(prop(), [value(0), end()])), end()]).flatMapFirst()).to.emit([
+        value(0, {current: true}),
+        end({current: true}),
       ]))
 
     it('should correctly handle current value of source', () => {
-      const a = send(prop(), [0])
-      const b = send(prop(), [a])
-      expect(b.flatMapFirst()).to.emit([{current: 0}])
+      const a = send(prop(), [value(0)])
+      const b = send(prop(), [value(a)])
+      expect(b.flatMapFirst()).to.emit([value(0, {current: true})])
     })
   })
 })

--- a/test/specs/flat-map-latest.js
+++ b/test/specs/flat-map-latest.js
@@ -1,24 +1,24 @@
-const {stream, prop, send, activate, deactivate, Kefir} = require('../test-helpers')
+const {stream, prop, send, activate, deactivate, Kefir, expect} = require('../test-helpers')
 
 describe('flatMapLatest', () => {
   describe('stream', () => {
     it('should return stream', () => {
-      expect(stream().flatMapLatest()).toBeStream()
+      expect(stream().flatMapLatest()).to.be.observable.stream()
     })
 
     it('should activate/deactivate source', () => {
       const a = stream()
-      expect(a.flatMapLatest()).toActivate(a)
+      expect(a.flatMapLatest()).to.activate(a)
     })
 
     it('should be ended if source was ended', () =>
-      expect(send(stream(), ['<end>']).flatMapLatest()).toEmit(['<end:current>']))
+      expect(send(stream(), ['<end>']).flatMapLatest()).to.emit(['<end:current>']))
 
     it('should handle events', () => {
       const a = stream()
       const b = stream()
       const c = send(prop(), [0])
-      expect(a.flatMapLatest()).toEmit([1, 0, 3, 5, '<end>'], () => {
+      expect(a.flatMapLatest()).to.emit([1, 0, 3, 5, '<end>'], () => {
         send(b, [0])
         send(a, [b])
         send(b, [1])
@@ -39,14 +39,14 @@ describe('flatMapLatest', () => {
       activate(map)
       send(a, [b, c])
       deactivate(map)
-      expect(map).toActivate(c)
-      expect(map).not.toActivate(b)
+      expect(map).to.activate(c)
+      expect(map).not.to.activate(b)
     })
 
     it('should accept optional map fn', () => {
       const a = stream()
       const b = stream()
-      expect(a.flatMapLatest(x => x.obs)).toEmit([1, 2, '<end>'], () => {
+      expect(a.flatMapLatest(x => x.obs)).to.emit([1, 2, '<end>'], () => {
         send(a, [{obs: b}, '<end>'])
         send(b, [1, 2, '<end>'])
       })
@@ -60,14 +60,14 @@ describe('flatMapLatest', () => {
       activate(m)
       send(a, [b, c])
       deactivate(m)
-      expect(m).toEmit([{current: 2}])
+      expect(m).to.emit([{current: 2}])
     })
 
     it('should correctly handle current values of new sub sources', () => {
       const a = stream()
       const b = send(prop(), [1])
       const c = send(prop(), [2])
-      expect(a.flatMapLatest()).toEmit([1, 2], () => send(a, [b, c]))
+      expect(a.flatMapLatest()).to.emit([1, 2], () => send(a, [b, c]))
     })
 
     it('should work nicely with Kefir.constant and Kefir.never', () => {
@@ -80,25 +80,25 @@ describe('flatMapLatest', () => {
             return Kefir.never()
           }
         })
-      ).toEmit([3, 4, 5], () => send(a, [1, 2, 3, 4, 5]))
+      ).to.emit([3, 4, 5], () => send(a, [1, 2, 3, 4, 5]))
     })
   })
 
   describe('property', () => {
     it('should return stream', () => {
-      expect(prop().flatMapLatest()).toBeStream()
+      expect(prop().flatMapLatest()).to.be.observable.stream()
     })
 
     it('should activate/deactivate source', () => {
       const a = prop()
-      expect(a.flatMapLatest()).toActivate(a)
+      expect(a.flatMapLatest()).to.activate(a)
     })
 
     it('should be ended if source was ended', () =>
-      expect(send(prop(), ['<end>']).flatMapLatest()).toEmit(['<end:current>']))
+      expect(send(prop(), ['<end>']).flatMapLatest()).to.emit(['<end:current>']))
 
     it('should be ended if source was ended (with value)', () =>
-      expect(send(prop(), [send(prop(), [0, '<end>']), '<end>']).flatMapLatest()).toEmit([
+      expect(send(prop(), [send(prop(), [0, '<end>']), '<end>']).flatMapLatest()).to.emit([
         {current: 0},
         '<end:current>',
       ]))
@@ -106,7 +106,7 @@ describe('flatMapLatest', () => {
     it('should correctly handle current value of source', () => {
       const a = send(prop(), [0])
       const b = send(prop(), [a])
-      expect(b.flatMapLatest()).toEmit([{current: 0}])
+      expect(b.flatMapLatest()).to.emit([{current: 0}])
     })
   })
 })

--- a/test/specs/flat-map-latest.js
+++ b/test/specs/flat-map-latest.js
@@ -1,4 +1,4 @@
-const {stream, prop, send, activate, deactivate, Kefir, expect} = require('../test-helpers')
+const {stream, prop, send, value, error, end, activate, deactivate, Kefir, expect} = require('../test-helpers')
 
 describe('flatMapLatest', () => {
   describe('stream', () => {
@@ -12,32 +12,32 @@ describe('flatMapLatest', () => {
     })
 
     it('should be ended if source was ended', () =>
-      expect(send(stream(), ['<end>']).flatMapLatest()).to.emit(['<end:current>']))
+      expect(send(stream(), [end()]).flatMapLatest()).to.emit([end({current: true})]))
 
     it('should handle events', () => {
       const a = stream()
       const b = stream()
-      const c = send(prop(), [0])
-      expect(a.flatMapLatest()).to.emit([1, 0, 3, 5, '<end>'], () => {
-        send(b, [0])
-        send(a, [b])
-        send(b, [1])
-        send(a, [c])
-        send(b, [2])
-        send(c, [3])
-        send(a, [b, '<end>'])
-        send(c, [4])
-        send(b, [5, '<end>'])
+      const c = send(prop(), [value(0)])
+      expect(a.flatMapLatest()).to.emit([value(1), value(0), value(3), value(5), end()], () => {
+        send(b, [value(0)])
+        send(a, [value(b)])
+        send(b, [value(1)])
+        send(a, [value(c)])
+        send(b, [value(2)])
+        send(c, [value(3)])
+        send(a, [value(b), end()])
+        send(c, [value(4)])
+        send(b, [value(5), end()])
       })
     })
 
     it('should activate sub-sources (only latest)', () => {
       const a = stream()
       const b = stream()
-      const c = send(prop(), [0])
+      const c = send(prop(), [value(0)])
       const map = a.flatMapLatest()
       activate(map)
-      send(a, [b, c])
+      send(a, [value(b), value(c)])
       deactivate(map)
       expect(map).to.activate(c)
       expect(map).not.to.activate(b)
@@ -46,28 +46,28 @@ describe('flatMapLatest', () => {
     it('should accept optional map fn', () => {
       const a = stream()
       const b = stream()
-      expect(a.flatMapLatest(x => x.obs)).to.emit([1, 2, '<end>'], () => {
-        send(a, [{obs: b}, '<end>'])
-        send(b, [1, 2, '<end>'])
+      expect(a.flatMapLatest(x => x.obs)).to.emit([value(1), value(2), end()], () => {
+        send(a, [value({obs: b}), end()])
+        send(b, [value(1), value(2), end()])
       })
     })
 
     it('should correctly handle current values of sub sources on activation', () => {
       const a = stream()
-      const b = send(prop(), [1])
-      const c = send(prop(), [2])
+      const b = send(prop(), [value(1)])
+      const c = send(prop(), [value(2)])
       const m = a.flatMapLatest()
       activate(m)
-      send(a, [b, c])
+      send(a, [value(b), value(c)])
       deactivate(m)
-      expect(m).to.emit([{current: 2}])
+      expect(m).to.emit([value(2, {current: true})])
     })
 
     it('should correctly handle current values of new sub sources', () => {
       const a = stream()
-      const b = send(prop(), [1])
-      const c = send(prop(), [2])
-      expect(a.flatMapLatest()).to.emit([1, 2], () => send(a, [b, c]))
+      const b = send(prop(), [value(1)])
+      const c = send(prop(), [value(2)])
+      expect(a.flatMapLatest()).to.emit([value(1), value(2)], () => send(a, [value(b), value(c)]))
     })
 
     it('should work nicely with Kefir.constant and Kefir.never', () => {
@@ -80,7 +80,7 @@ describe('flatMapLatest', () => {
             return Kefir.never()
           }
         })
-      ).to.emit([3, 4, 5], () => send(a, [1, 2, 3, 4, 5]))
+      ).to.emit([value(3), value(4), value(5)], () => send(a, [value(1), value(2), value(3), value(4), value(5)]))
     })
   })
 
@@ -95,18 +95,18 @@ describe('flatMapLatest', () => {
     })
 
     it('should be ended if source was ended', () =>
-      expect(send(prop(), ['<end>']).flatMapLatest()).to.emit(['<end:current>']))
+      expect(send(prop(), [end()]).flatMapLatest()).to.emit([end({current: true})]))
 
     it('should be ended if source was ended (with value)', () =>
-      expect(send(prop(), [send(prop(), [0, '<end>']), '<end>']).flatMapLatest()).to.emit([
-        {current: 0},
-        '<end:current>',
+      expect(send(prop(), [value(send(prop(), [value(0), end()])), end()]).flatMapLatest()).to.emit([
+        value(0, {current: true}),
+        end({current: true}),
       ]))
 
     it('should correctly handle current value of source', () => {
-      const a = send(prop(), [0])
-      const b = send(prop(), [a])
-      expect(b.flatMapLatest()).to.emit([{current: 0}])
+      const a = send(prop(), [value(0)])
+      const b = send(prop(), [value(a)])
+      expect(b.flatMapLatest()).to.emit([value(0, {current: true})])
     })
   })
 })

--- a/test/specs/flat-map-with-concurrency-limit.js
+++ b/test/specs/flat-map-with-concurrency-limit.js
@@ -1,25 +1,25 @@
-const {stream, prop, send, activate, deactivate} = require('../test-helpers')
+const {stream, prop, send, activate, deactivate, expect} = require('../test-helpers')
 
 describe('flatMapConcurLimit', () => {
   describe('stream', () => {
     it('should return stream', () => {
-      expect(stream().flatMapConcurLimit(null, 1)).toBeStream()
+      expect(stream().flatMapConcurLimit(null, 1)).to.be.observable.stream()
     })
 
     it('should activate/deactivate source', () => {
       const a = stream()
-      expect(a.flatMapConcurLimit(null, 1)).toActivate(a)
+      expect(a.flatMapConcurLimit(null, 1)).to.activate(a)
     })
 
     it('should be ended if source was ended', () =>
-      expect(send(stream(), ['<end>']).flatMapConcurLimit(null, 1)).toEmit(['<end:current>']))
+      expect(send(stream(), ['<end>']).flatMapConcurLimit(null, 1)).to.emit(['<end:current>']))
 
     it('should handle events', () => {
       const a = stream()
       const b = stream()
       const c = stream()
       const d = stream()
-      expect(a.flatMapConcurLimit(null, 2)).toEmit([1, 2, 4, 5, 6, '<end>'], () => {
+      expect(a.flatMapConcurLimit(null, 2)).to.emit([1, 2, 4, 5, 6, '<end>'], () => {
         send(b, [0])
         send(a, [b])
         send(b, [1])
@@ -41,16 +41,16 @@ describe('flatMapConcurLimit', () => {
       activate(map)
       send(a, [b, c, d])
       deactivate(map)
-      expect(map).toActivate(b, c)
-      expect(map).not.toActivate(d)
+      expect(map).to.activate(b, c)
+      expect(map).not.to.activate(d)
       send(b, ['<end>'])
-      expect(map).toActivate(d)
+      expect(map).to.activate(d)
     })
 
     it('should accept optional map fn', () => {
       const a = stream()
       const b = stream()
-      expect(a.flatMapConcurLimit(x => x.obs, 1)).toEmit([1, 2, '<end>'], () => {
+      expect(a.flatMapConcurLimit(x => x.obs, 1)).to.emit([1, 2, '<end>'], () => {
         send(b, [0])
         send(a, [{obs: b}, '<end>'])
         send(b, [1, 2, '<end>'])
@@ -66,7 +66,7 @@ describe('flatMapConcurLimit', () => {
       activate(m)
       send(a, [b, c, d])
       deactivate(m)
-      expect(m).toEmit([{current: 1}, {current: 2}])
+      expect(m).to.emit([{current: 1}, {current: 2}])
     })
 
     it('should correctly handle current values of new sub sources', () => {
@@ -75,12 +75,12 @@ describe('flatMapConcurLimit', () => {
       const c = send(prop(), [2])
       const d = send(prop(), [3])
       const e = send(prop(), [4])
-      expect(a.flatMapConcurLimit(null, 2)).toEmit([4, 1, 2], () => send(a, [e, b, c, d]))
+      expect(a.flatMapConcurLimit(null, 2)).to.emit([4, 1, 2], () => send(a, [e, b, c, d]))
     })
 
     it('limit = 0', () => {
       const a = stream()
-      expect(a.flatMapConcurLimit(null, 0)).toEmit(['<end:current>'])
+      expect(a.flatMapConcurLimit(null, 0)).to.emit(['<end:current>'])
     })
 
     it('limit = -1', () => {
@@ -88,7 +88,7 @@ describe('flatMapConcurLimit', () => {
       const b = stream()
       const c = stream()
       const d = stream()
-      expect(a.flatMapConcurLimit(null, -1)).toEmit([1, 2, 3, 4, 5, 6, '<end>'], () => {
+      expect(a.flatMapConcurLimit(null, -1)).to.emit([1, 2, 3, 4, 5, 6, '<end>'], () => {
         send(b, [0])
         send(a, [b])
         send(b, [1])
@@ -107,7 +107,7 @@ describe('flatMapConcurLimit', () => {
       const b = stream()
       const c = stream()
       const d = stream()
-      expect(a.flatMapConcurLimit(null, -2)).toEmit([1, 2, 3, 4, 5, 6, '<end>'], () => {
+      expect(a.flatMapConcurLimit(null, -2)).to.emit([1, 2, 3, 4, 5, 6, '<end>'], () => {
         send(b, [0])
         send(a, [b])
         send(b, [1])
@@ -123,19 +123,19 @@ describe('flatMapConcurLimit', () => {
 
   describe('property', () => {
     it('should return stream', () => {
-      expect(prop().flatMapConcurLimit(null, 1)).toBeStream()
+      expect(prop().flatMapConcurLimit(null, 1)).to.be.observable.stream()
     })
 
     it('should activate/deactivate source', () => {
       const a = prop()
-      expect(a.flatMapConcurLimit(null, 1)).toActivate(a)
+      expect(a.flatMapConcurLimit(null, 1)).to.activate(a)
     })
 
     it('should be ended if source was ended', () =>
-      expect(send(prop(), ['<end>']).flatMapConcurLimit(null, 1)).toEmit(['<end:current>']))
+      expect(send(prop(), ['<end>']).flatMapConcurLimit(null, 1)).to.emit(['<end:current>']))
 
     it('should be ended if source was ended (with value)', () =>
-      expect(send(prop(), [send(prop(), [0, '<end>']), '<end>']).flatMapConcurLimit(null, 1)).toEmit([
+      expect(send(prop(), [send(prop(), [0, '<end>']), '<end>']).flatMapConcurLimit(null, 1)).to.emit([
         {current: 0},
         '<end:current>',
       ]))
@@ -143,7 +143,7 @@ describe('flatMapConcurLimit', () => {
     it('should correctly handle current value of source', () => {
       const a = send(prop(), [0])
       const b = send(prop(), [a])
-      expect(b.flatMapConcurLimit(null, 1)).toEmit([{current: 0}])
+      expect(b.flatMapConcurLimit(null, 1)).to.emit([{current: 0}])
     })
   })
 })

--- a/test/specs/flat-map-with-concurrency-limit.js
+++ b/test/specs/flat-map-with-concurrency-limit.js
@@ -1,4 +1,4 @@
-const {stream, prop, send, activate, deactivate, expect} = require('../test-helpers')
+const {stream, prop, send, value, error, end, activate, deactivate, expect} = require('../test-helpers')
 
 describe('flatMapConcurLimit', () => {
   describe('stream', () => {
@@ -12,23 +12,23 @@ describe('flatMapConcurLimit', () => {
     })
 
     it('should be ended if source was ended', () =>
-      expect(send(stream(), ['<end>']).flatMapConcurLimit(null, 1)).to.emit(['<end:current>']))
+      expect(send(stream(), [end()]).flatMapConcurLimit(null, 1)).to.emit([end({current: true})]))
 
     it('should handle events', () => {
       const a = stream()
       const b = stream()
       const c = stream()
       const d = stream()
-      expect(a.flatMapConcurLimit(null, 2)).to.emit([1, 2, 4, 5, 6, '<end>'], () => {
-        send(b, [0])
-        send(a, [b])
-        send(b, [1])
-        send(a, [c, d, '<end>'])
-        send(c, [2])
-        send(d, [3])
-        send(b, [4, '<end>'])
-        send(d, [5, '<end>'])
-        send(c, [6, '<end>'])
+      expect(a.flatMapConcurLimit(null, 2)).to.emit([value(1), value(2), value(4), value(5), value(6), end()], () => {
+        send(b, [value(0)])
+        send(a, [value(b)])
+        send(b, [value(1)])
+        send(a, [value(c), value(d), end()])
+        send(c, [value(2)])
+        send(d, [value(3)])
+        send(b, [value(4), end()])
+        send(d, [value(5), end()])
+        send(c, [value(6), end()])
       })
     })
 
@@ -39,48 +39,50 @@ describe('flatMapConcurLimit', () => {
       const d = stream()
       const map = a.flatMapConcurLimit(null, 2)
       activate(map)
-      send(a, [b, c, d])
+      send(a, [value(b), value(c), value(d)])
       deactivate(map)
       expect(map).to.activate(b, c)
       expect(map).not.to.activate(d)
-      send(b, ['<end>'])
+      send(b, [end()])
       expect(map).to.activate(d)
     })
 
     it('should accept optional map fn', () => {
       const a = stream()
       const b = stream()
-      expect(a.flatMapConcurLimit(x => x.obs, 1)).to.emit([1, 2, '<end>'], () => {
-        send(b, [0])
-        send(a, [{obs: b}, '<end>'])
-        send(b, [1, 2, '<end>'])
+      expect(a.flatMapConcurLimit(x => x.obs, 1)).to.emit([value(1), value(2), end()], () => {
+        send(b, [value(0)])
+        send(a, [value({obs: b}), end()])
+        send(b, [value(1), value(2), end()])
       })
     })
 
     it('should correctly handle current values of sub sources on activation', () => {
       const a = stream()
-      const b = send(prop(), [1])
-      const c = send(prop(), [2])
-      const d = send(prop(), [3])
+      const b = send(prop(), [value(1)])
+      const c = send(prop(), [value(2)])
+      const d = send(prop(), [value(3)])
       const m = a.flatMapConcurLimit(null, 2)
       activate(m)
-      send(a, [b, c, d])
+      send(a, [value(b), value(c), value(d)])
       deactivate(m)
-      expect(m).to.emit([{current: 1}, {current: 2}])
+      expect(m).to.emit([value(1, {current: true}), value(2, {current: true})])
     })
 
     it('should correctly handle current values of new sub sources', () => {
       const a = stream()
-      const b = send(prop(), [1, '<end>'])
-      const c = send(prop(), [2])
-      const d = send(prop(), [3])
-      const e = send(prop(), [4])
-      expect(a.flatMapConcurLimit(null, 2)).to.emit([4, 1, 2], () => send(a, [e, b, c, d]))
+      const b = send(prop(), [value(1), end()])
+      const c = send(prop(), [value(2)])
+      const d = send(prop(), [value(3)])
+      const e = send(prop(), [value(4)])
+      expect(a.flatMapConcurLimit(null, 2)).to.emit([value(4), value(1), value(2)], () =>
+        send(a, [value(e), value(b), value(c), value(d)])
+      )
     })
 
     it('limit = 0', () => {
       const a = stream()
-      expect(a.flatMapConcurLimit(null, 0)).to.emit(['<end:current>'])
+      expect(a.flatMapConcurLimit(null, 0)).to.emit([end({current: true})])
     })
 
     it('limit = -1', () => {
@@ -88,17 +90,20 @@ describe('flatMapConcurLimit', () => {
       const b = stream()
       const c = stream()
       const d = stream()
-      expect(a.flatMapConcurLimit(null, -1)).to.emit([1, 2, 3, 4, 5, 6, '<end>'], () => {
-        send(b, [0])
-        send(a, [b])
-        send(b, [1])
-        send(a, [c, d, '<end>'])
-        send(c, [2])
-        send(d, [3])
-        send(b, [4, '<end>'])
-        send(d, [5, '<end>'])
-        send(c, [6, '<end>'])
-      })
+      expect(a.flatMapConcurLimit(null, -1)).to.emit(
+        [value(1), value(2), value(3), value(4), value(5), value(6), end()],
+        () => {
+          send(b, [value(0)])
+          send(a, [value(b)])
+          send(b, [value(1)])
+          send(a, [value(c), value(d), end()])
+          send(c, [value(2)])
+          send(d, [value(3)])
+          send(b, [value(4), end()])
+          send(d, [value(5), end()])
+          send(c, [value(6), end()])
+        }
+      )
     })
 
     it('limit = -2', () => {
@@ -107,17 +112,20 @@ describe('flatMapConcurLimit', () => {
       const b = stream()
       const c = stream()
       const d = stream()
-      expect(a.flatMapConcurLimit(null, -2)).to.emit([1, 2, 3, 4, 5, 6, '<end>'], () => {
-        send(b, [0])
-        send(a, [b])
-        send(b, [1])
-        send(a, [c, d, '<end>'])
-        send(c, [2])
-        send(d, [3])
-        send(b, [4, '<end>'])
-        send(d, [5, '<end>'])
-        send(c, [6, '<end>'])
-      })
+      expect(a.flatMapConcurLimit(null, -2)).to.emit(
+        [value(1), value(2), value(3), value(4), value(5), value(6), end()],
+        () => {
+          send(b, [value(0)])
+          send(a, [value(b)])
+          send(b, [value(1)])
+          send(a, [value(c), value(d), end()])
+          send(c, [value(2)])
+          send(d, [value(3)])
+          send(b, [value(4), end()])
+          send(d, [value(5), end()])
+          send(c, [value(6), end()])
+        }
+      )
     })
   })
 
@@ -132,18 +140,18 @@ describe('flatMapConcurLimit', () => {
     })
 
     it('should be ended if source was ended', () =>
-      expect(send(prop(), ['<end>']).flatMapConcurLimit(null, 1)).to.emit(['<end:current>']))
+      expect(send(prop(), [end()]).flatMapConcurLimit(null, 1)).to.emit([end({current: true})]))
 
     it('should be ended if source was ended (with value)', () =>
-      expect(send(prop(), [send(prop(), [0, '<end>']), '<end>']).flatMapConcurLimit(null, 1)).to.emit([
-        {current: 0},
-        '<end:current>',
+      expect(send(prop(), [value(send(prop(), [value(0), end()])), end()]).flatMapConcurLimit(null, 1)).to.emit([
+        value(0, {current: true}),
+        end({current: true}),
       ]))
 
     it('should correctly handle current value of source', () => {
-      const a = send(prop(), [0])
-      const b = send(prop(), [a])
-      expect(b.flatMapConcurLimit(null, 1)).to.emit([{current: 0}])
+      const a = send(prop(), [value(0)])
+      const b = send(prop(), [value(a)])
+      expect(b.flatMapConcurLimit(null, 1)).to.emit([value(0, {current: true})])
     })
   })
 })

--- a/test/specs/flat-map.js
+++ b/test/specs/flat-map.js
@@ -1,24 +1,24 @@
-const {stream, prop, send, activate, deactivate, Kefir} = require('../test-helpers')
+const {stream, prop, send, activate, deactivate, Kefir, expect} = require('../test-helpers')
 
 describe('flatMap', () => {
   describe('stream', () => {
     it('should return stream', () => {
-      expect(stream().flatMap()).toBeStream()
+      expect(stream().flatMap()).to.be.observable.stream()
     })
 
     it('should activate/deactivate source', () => {
       const a = stream()
-      expect(a.flatMap()).toActivate(a)
+      expect(a.flatMap()).to.activate(a)
     })
 
     it('should be ended if source was ended', () =>
-      expect(send(stream(), ['<end>']).flatMap()).toEmit(['<end:current>']))
+      expect(send(stream(), ['<end>']).flatMap()).to.emit(['<end:current>']))
 
     it('should handle events', () => {
       const a = stream()
       const b = stream()
       const c = send(prop(), [0])
-      expect(a.flatMap()).toEmit([1, 2, 0, 3, 4, '<end>'], () => {
+      expect(a.flatMap()).to.emit([1, 2, 0, 3, 4, '<end>'], () => {
         send(b, [0])
         send(a, [b])
         send(b, [1, 2])
@@ -36,13 +36,13 @@ describe('flatMap', () => {
       activate(map)
       send(a, [b, c])
       deactivate(map)
-      expect(map).toActivate(b, c)
+      expect(map).to.activate(b, c)
     })
 
     it('should accept optional map fn', () => {
       const a = stream()
       const b = stream()
-      expect(a.flatMap(x => x.obs)).toEmit([1, 2, '<end>'], () => {
+      expect(a.flatMap(x => x.obs)).to.emit([1, 2, '<end>'], () => {
         send(b, [0])
         send(a, [{obs: b}, '<end>'])
         send(b, [1, 2, '<end>'])
@@ -57,14 +57,14 @@ describe('flatMap', () => {
       activate(m)
       send(a, [b, c])
       deactivate(m)
-      expect(m).toEmit([{current: 1}, {current: 2}])
+      expect(m).to.emit([{current: 1}, {current: 2}])
     })
 
     it('should correctly handle current values of new sub sources', () => {
       const a = stream()
       const b = send(prop(), [1])
       const c = send(prop(), [2])
-      expect(a.flatMap()).toEmit([1, 2], () => send(a, [b, c]))
+      expect(a.flatMap()).to.emit([1, 2], () => send(a, [b, c]))
     })
 
     it('should work nicely with Kefir.constant and Kefir.never', () => {
@@ -79,7 +79,7 @@ describe('flatMap', () => {
             return Kefir.never()
           }
         })
-      ).toEmit([3, {error: -1}, 4, {error: -2}, 5], () => send(a, [1, 2, 3, -1, 4, -2, 5]))
+      ).to.emit([3, {error: -1}, 4, {error: -2}, 5], () => send(a, [1, 2, 3, -1, 4, -2, 5]))
     })
 
     // https://github.com/rpominov/kefir/issues/29
@@ -104,9 +104,9 @@ describe('flatMap', () => {
       activate(result)
       send(a, [b, c])
       deactivate(result)
-      expect(result).errorsToFlow(a)
-      expect(result).errorsToFlow(b)
-      expect(result).errorsToFlow(c)
+      expect(result).to.flowErrors(a)
+      expect(result).to.flowErrors(b)
+      expect(result).to.flowErrors(c)
     })
 
     // https://github.com/rpominov/kefir/issues/92
@@ -123,8 +123,8 @@ describe('flatMap', () => {
 
       b.onValue(() => {})
 
-      expect(subs).toBe(1)
-      expect(unsubs).toBe(1)
+      expect(subs).to.equal(1)
+      expect(unsubs).to.equal(1)
     })
 
     it('should be possible to add same obs twice on activation', () => {
@@ -133,26 +133,26 @@ describe('flatMap', () => {
         em.emit(b)
         return em.emit(b)
       })
-      expect(a.flatMap()).toEmit([{current: 1}, {current: 1}])
+      expect(a.flatMap()).to.emit([{current: 1}, {current: 1}])
     })
   })
 
   describe('property', () => {
     it('should return stream', () => {
-      expect(prop().flatMap()).toBeStream()
+      expect(prop().flatMap()).to.be.observable.stream()
     })
 
     it('should activate/deactivate source', () => {
       const a = prop()
-      expect(a.flatMap()).toActivate(a)
+      expect(a.flatMap()).to.activate(a)
     })
 
     it('should be ended if source was ended', () => {
-      expect(send(prop(), ['<end>']).flatMap()).toEmit(['<end:current>'])
+      expect(send(prop(), ['<end>']).flatMap()).to.emit(['<end:current>'])
     })
 
     it('should be ended if source was ended (with value)', () =>
-      expect(send(prop(), [send(prop(), [0, '<end>']), '<end>']).flatMap()).toEmit([{current: 0}, '<end:current>']))
+      expect(send(prop(), [send(prop(), [0, '<end>']), '<end>']).flatMap()).to.emit([{current: 0}, '<end:current>']))
 
     it('should not costantly adding current value on each activation', () => {
       const a = send(prop(), [0])
@@ -162,14 +162,14 @@ describe('flatMap', () => {
       deactivate(map)
       activate(map)
       deactivate(map)
-      expect(map).toEmit([{current: 0}])
+      expect(map).to.emit([{current: 0}])
     })
 
     it('should allow to add same obs several times', () => {
       const b = send(prop(), ['b0'])
       const c = stream()
       const a = send(prop(), [b])
-      expect(a.flatMap()).toEmit(
+      expect(a.flatMap()).to.emit(
         [{current: 'b0'}, 'b0', 'b0', 'b0', 'b0', 'b1', 'b1', 'b1', 'b1', 'b1', 'c1', 'c1', 'c1', '<end>'],
         () => {
           send(a, [b, c, b, c, c, b, b, '<end>'])
@@ -182,13 +182,13 @@ describe('flatMap', () => {
     it('should correctly handle current value of source', () => {
       const a = send(prop(), [0])
       const b = send(prop(), [a])
-      expect(b.flatMap()).toEmit([{current: 0}])
+      expect(b.flatMap()).to.emit([{current: 0}])
     })
 
     it('errors should flow 1', () => {
       const a = prop()
       const result = a.flatMap()
-      expect(result).errorsToFlow(a)
+      expect(result).to.flowErrors(a)
     })
 
     it('errors should flow 2', () => {
@@ -199,8 +199,8 @@ describe('flatMap', () => {
       activate(result)
       send(a, [b, c])
       deactivate(result)
-      expect(result).errorsToFlow(b)
-      expect(result).errorsToFlow(c)
+      expect(result).to.flowErrors(b)
+      expect(result).to.flowErrors(c)
     })
   })
 })

--- a/test/specs/flatten.js
+++ b/test/specs/flatten.js
@@ -1,18 +1,18 @@
-const {stream, prop, send, Kefir} = require('../test-helpers')
+const {stream, prop, send, Kefir, expect} = require('../test-helpers')
 
 describe('flatten', () => {
   describe('stream', () => {
     it('should return stream', () => {
-      expect(stream().flatten(() => {})).toBeStream()
+      expect(stream().flatten(() => {})).to.be.observable.stream()
     })
 
     it('should activate/deactivate source', () => {
       const a = stream()
-      expect(a.flatten(() => {})).toActivate(a)
+      expect(a.flatten(() => {})).to.activate(a)
     })
 
     it('should be ended if source was ended', () =>
-      expect(send(stream(), ['<end>']).flatten(() => {})).toEmit(['<end:current>']))
+      expect(send(stream(), ['<end>']).flatten(() => {})).to.emit(['<end:current>']))
 
     it('should handle events', () => {
       const a = stream()
@@ -24,27 +24,27 @@ describe('flatten', () => {
             return []
           }
         })
-      ).toEmit([1, 2, {error: 4}, 1, 2, 3, '<end>'], () => send(a, [1, 2, {error: 4}, 3, '<end>']))
+      ).to.emit([1, 2, {error: 4}, 1, 2, 3, '<end>'], () => send(a, [1, 2, {error: 4}, 3, '<end>']))
     })
 
     it('if no `fn` provided should use the `id` function by default', () => {
       const a = stream()
-      expect(a.flatten()).toEmit([1, 2, 3, '<end>'], () => send(a, [[1], [], [2, 3], '<end>']))
+      expect(a.flatten()).to.emit([1, 2, 3, '<end>'], () => send(a, [[1], [], [2, 3], '<end>']))
     })
   })
 
   describe('property', () => {
     it('should return stream', () => {
-      expect(prop().flatten(() => {})).toBeStream()
+      expect(prop().flatten(() => {})).to.be.observable.stream()
     })
 
     it('should activate/deactivate source', () => {
       const a = prop()
-      expect(a.flatten(() => {})).toActivate(a)
+      expect(a.flatten(() => {})).to.activate(a)
     })
 
     it('should be ended if source was ended', () =>
-      expect(send(prop(), ['<end>']).flatten(() => {})).toEmit(['<end:current>']))
+      expect(send(prop(), ['<end>']).flatten(() => {})).to.emit(['<end:current>']))
 
     it('should handle events (handler skips current)', () => {
       const a = send(prop(), [1])
@@ -56,16 +56,16 @@ describe('flatten', () => {
             return []
           }
         })
-      ).toEmit([1, 2, {error: 4}, 1, 2, 3, '<end>'], () => send(a, [2, {error: 4}, 3, '<end>']))
+      ).to.emit([1, 2, {error: 4}, 1, 2, 3, '<end>'], () => send(a, [2, {error: 4}, 3, '<end>']))
     })
 
     it('should handle current correctly', () => {
-      expect(send(prop(), [1]).flatten(x => [x])).toEmit([{current: 1}])
-      expect(send(prop(), [{error: 0}]).flatten(() => {})).toEmit([{currentError: 0}])
+      expect(send(prop(), [1]).flatten(x => [x])).to.emit([{current: 1}])
+      expect(send(prop(), [{error: 0}]).flatten(() => {})).to.emit([{currentError: 0}])
     })
 
     it('should handle multiple currents correctly', () =>
-      expect(send(prop(), [2]).flatten(x => __range__(1, x, true))).toEmit([{current: 1}, {current: 2}]))
+      expect(send(prop(), [2]).flatten(x => __range__(1, x, true))).to.emit([{current: 1}, {current: 2}]))
   })
 })
 

--- a/test/specs/from-callback.js
+++ b/test/specs/from-callback.js
@@ -1,30 +1,30 @@
-const {activate, deactivate, Kefir} = require('../test-helpers')
+const {activate, deactivate, Kefir, expect} = require('../test-helpers')
 
 describe('fromCallback', () => {
   it('should return stream', () => {
-    expect(Kefir.fromCallback(() => {})).toBeStream()
+    expect(Kefir.fromCallback(() => {})).to.be.observable.stream()
   })
 
   it('should not be ended', () => {
-    expect(Kefir.fromCallback(() => {})).toEmit([])
+    expect(Kefir.fromCallback(() => {})).to.emit([])
   })
 
   it('should call `callbackConsumer` on first activation, and only on first', () => {
     let count = 0
     const s = Kefir.fromCallback(() => count++)
-    expect(count).toBe(0)
+    expect(count).to.equal(0)
     activate(s)
-    expect(count).toBe(1)
+    expect(count).to.equal(1)
     deactivate(s)
     activate(s)
     deactivate(s)
     activate(s)
-    expect(count).toBe(1)
+    expect(count).to.equal(1)
   })
 
   it('should emit first result and end after that', () => {
     let cb = null
-    expect(Kefir.fromCallback(_cb => cb = _cb)).toEmit([1, '<end>'], () => cb(1))
+    expect(Kefir.fromCallback(_cb => cb = _cb)).to.emit([1, '<end>'], () => cb(1))
   })
 
   it('should work after deactivation/activate cicle', () => {
@@ -34,10 +34,10 @@ describe('fromCallback', () => {
     deactivate(s)
     activate(s)
     deactivate(s)
-    expect(s).toEmit([1, '<end>'], () => cb(1))
+    expect(s).to.emit([1, '<end>'], () => cb(1))
   })
 
   it('should emit a current, if `callback` is called immediately in `callbackConsumer`', () => {
-    expect(Kefir.fromCallback(cb => cb(1))).toEmit([{current: 1}, '<end:current>'])
+    expect(Kefir.fromCallback(cb => cb(1))).to.emit([{current: 1}, '<end:current>'])
   })
 })

--- a/test/specs/from-callback.js
+++ b/test/specs/from-callback.js
@@ -1,4 +1,4 @@
-const {activate, deactivate, Kefir, expect} = require('../test-helpers')
+const {activate, deactivate, Kefir, value, end, expect} = require('../test-helpers')
 
 describe('fromCallback', () => {
   it('should return stream', () => {
@@ -24,7 +24,7 @@ describe('fromCallback', () => {
 
   it('should emit first result and end after that', () => {
     let cb = null
-    expect(Kefir.fromCallback(_cb => cb = _cb)).to.emit([1, '<end>'], () => cb(1))
+    expect(Kefir.fromCallback(_cb => cb = _cb)).to.emit([value(1), end()], () => cb(1))
   })
 
   it('should work after deactivation/activate cicle', () => {
@@ -34,10 +34,10 @@ describe('fromCallback', () => {
     deactivate(s)
     activate(s)
     deactivate(s)
-    expect(s).to.emit([1, '<end>'], () => cb(1))
+    expect(s).to.emit([value(1), end()], () => cb(1))
   })
 
   it('should emit a current, if `callback` is called immediately in `callbackConsumer`', () => {
-    expect(Kefir.fromCallback(cb => cb(1))).to.emit([{current: 1}, '<end:current>'])
+    expect(Kefir.fromCallback(cb => cb(1))).to.emit([value(1, {current: true}), end({current: true})])
   })
 })

--- a/test/specs/from-es-observable.js
+++ b/test/specs/from-es-observable.js
@@ -1,10 +1,10 @@
 const Observable = require('zen-observable')
 const Rx = require('@reactivex/rxjs')
-const {activate, deactivate, Kefir} = require('../test-helpers')
+const {activate, deactivate, Kefir, expect} = require('../test-helpers')
 
 describe('fromESObservable', () => {
   it('turns an ES7 observable into a stream', () => {
-    expect(Kefir.fromESObservable(Observable.of(1, 2))).toBeStream()
+    expect(Kefir.fromESObservable(Observable.of(1, 2))).to.be.observable.stream()
   })
 
   it('emits events from observable to stream', done => {
@@ -12,7 +12,7 @@ describe('fromESObservable', () => {
     const values = []
     stream.onValue(value => values.push(value))
     return stream.onEnd(() => {
-      expect(values).toEqual([1, 2])
+      expect(values).to.deep.equal([1, 2])
       return done()
     })
   })
@@ -30,7 +30,7 @@ describe('fromESObservable', () => {
     const values = []
     stream.onValue(value => values.push(value))
     return stream.onEnd(() => {
-      expect(values).toEqual(['hello world'])
+      expect(values).to.deep.equal(['hello world'])
       return done()
     })
   })

--- a/test/specs/from-event.js
+++ b/test/specs/from-event.js
@@ -1,4 +1,4 @@
-const {activate, deactivate, Kefir, expect} = require('../test-helpers')
+const {activate, deactivate, Kefir, value, end, expect} = require('../test-helpers')
 
 describe('fromEvents', () => {
   const domTarget = () => ({
@@ -74,26 +74,26 @@ describe('fromEvents', () => {
   it('should emit values', () => {
     let target = domTarget()
     let a = Kefir.fromEvents(target, 'foo')
-    expect(a).to.emit([1, 2, 3], () => {
+    expect(a).to.emit([value(1), value(2), value(3)], () => {
       target.fooListener(1)
       target.fooListener(2)
-      return target.fooListener(3)
+      target.fooListener(3)
     })
 
     target = nodeTarget()
     a = Kefir.fromEvents(target, 'foo')
-    expect(a).to.emit([1, 2, 3], () => {
+    expect(a).to.emit([value(1), value(2), value(3)], () => {
       target.fooListener(1)
       target.fooListener(2)
-      return target.fooListener(3)
+      target.fooListener(3)
     })
 
     target = onOffTarget()
     a = Kefir.fromEvents(target, 'foo')
-    expect(a).to.emit([1, 2, 3], () => {
+    expect(a).to.emit([value(1), value(2), value(3)], () => {
       target.fooListener(1)
       target.fooListener(2)
-      return target.fooListener(3)
+      target.fooListener(3)
     })
   })
 
@@ -102,11 +102,14 @@ describe('fromEvents', () => {
     const a = Kefir.fromEvents(target, 'foo', function(a, b) {
       return [this, a, b]
     })
-    expect(a).to.emit([[{a: 1}, undefined, undefined], [{b: 1}, 1, undefined], [{c: 1}, 1, 2]], () => {
-      target.fooListener.call({a: 1})
-      target.fooListener.call({b: 1}, 1)
-      return target.fooListener.call({c: 1}, 1, 2)
-    })
+    expect(a).to.emit(
+      [value([{a: 1}, undefined, undefined]), value([{b: 1}, 1, undefined]), value([{c: 1}, 1, 2])],
+      () => {
+        target.fooListener.call({a: 1})
+        target.fooListener.call({b: 1}, 1)
+        target.fooListener.call({c: 1}, 1, 2)
+      }
+    )
   })
 
   it('the callback passed to the target should always retrun undefined (no transformer)', () => {

--- a/test/specs/from-event.js
+++ b/test/specs/from-event.js
@@ -1,4 +1,4 @@
-const {activate, deactivate, Kefir} = require('../test-helpers')
+const {activate, deactivate, Kefir, expect} = require('../test-helpers')
 
 describe('fromEvents', () => {
   const domTarget = () => ({
@@ -38,43 +38,43 @@ describe('fromEvents', () => {
   })
 
   it('should return stream', () => {
-    expect(Kefir.fromEvents(domTarget(), 'foo')).toBeStream()
+    expect(Kefir.fromEvents(domTarget(), 'foo')).to.be.observable.stream()
   })
 
   it('should not be ended', () => {
-    expect(Kefir.fromEvents(domTarget(), 'foo')).toEmit([])
+    expect(Kefir.fromEvents(domTarget(), 'foo')).to.emit([])
   })
 
   it('should subscribe/unsubscribe from target', () => {
     let target = domTarget()
     let a = Kefir.fromEvents(target, 'foo')
-    expect(target.fooListener).toBeUndefined()
+    expect(target.fooListener).to.equal(undefined)
     activate(a)
-    expect(target.fooListener).toEqual(jasmine.any(Function))
+    expect(target.fooListener).to.be.a('function')
     deactivate(a)
-    expect(target.fooListener).toBeUndefined()
+    expect(target.fooListener).to.equal(undefined)
 
     target = onOffTarget()
     a = Kefir.fromEvents(target, 'foo')
-    expect(target.fooListener).toBeUndefined()
+    expect(target.fooListener).to.equal(undefined)
     activate(a)
-    expect(target.fooListener).toEqual(jasmine.any(Function))
+    expect(target.fooListener).to.be.a('function')
     deactivate(a)
-    expect(target.fooListener).toBeUndefined()
+    expect(target.fooListener).to.equal(undefined)
 
     target = nodeTarget()
     a = Kefir.fromEvents(target, 'foo')
-    expect(target.fooListener).toBeUndefined()
+    expect(target.fooListener).to.equal(undefined)
     activate(a)
-    expect(target.fooListener).toEqual(jasmine.any(Function))
+    expect(target.fooListener).to.be.a('function')
     deactivate(a)
-    expect(target.fooListener).toBeUndefined()
+    expect(target.fooListener).to.equal(undefined)
   })
 
   it('should emit values', () => {
     let target = domTarget()
     let a = Kefir.fromEvents(target, 'foo')
-    expect(a).toEmit([1, 2, 3], () => {
+    expect(a).to.emit([1, 2, 3], () => {
       target.fooListener(1)
       target.fooListener(2)
       return target.fooListener(3)
@@ -82,7 +82,7 @@ describe('fromEvents', () => {
 
     target = nodeTarget()
     a = Kefir.fromEvents(target, 'foo')
-    expect(a).toEmit([1, 2, 3], () => {
+    expect(a).to.emit([1, 2, 3], () => {
       target.fooListener(1)
       target.fooListener(2)
       return target.fooListener(3)
@@ -90,7 +90,7 @@ describe('fromEvents', () => {
 
     target = onOffTarget()
     a = Kefir.fromEvents(target, 'foo')
-    expect(a).toEmit([1, 2, 3], () => {
+    expect(a).to.emit([1, 2, 3], () => {
       target.fooListener(1)
       target.fooListener(2)
       return target.fooListener(3)
@@ -102,7 +102,7 @@ describe('fromEvents', () => {
     const a = Kefir.fromEvents(target, 'foo', function(a, b) {
       return [this, a, b]
     })
-    expect(a).toEmit([[{a: 1}, undefined, undefined], [{b: 1}, 1, undefined], [{c: 1}, 1, 2]], () => {
+    expect(a).to.emit([[{a: 1}, undefined, undefined], [{b: 1}, 1, undefined], [{c: 1}, 1, 2]], () => {
       target.fooListener.call({a: 1})
       target.fooListener.call({b: 1}, 1)
       return target.fooListener.call({c: 1}, 1, 2)
@@ -121,9 +121,9 @@ describe('fromEvents', () => {
     }
     const a = Kefir.fromEvents(target, 'foo')
     a.take(2).onValue(() => {})
-    expect(cb(1)).toEqual(undefined)
-    expect(cb(2)).toEqual(undefined)
-    expect(cb).toEqual(null)
+    expect(cb(1)).to.deep.equal(undefined)
+    expect(cb(2)).to.deep.equal(undefined)
+    expect(cb).to.deep.equal(null)
   })
 
   it('the callback passed to the target should always retrun undefined (with transformer)', () => {
@@ -138,8 +138,8 @@ describe('fromEvents', () => {
     }
     const a = Kefir.fromEvents(target, 'foo', x => x)
     a.take(2).onValue(() => {})
-    expect(cb(1)).toEqual(undefined)
-    expect(cb(2)).toEqual(undefined)
-    expect(cb).toEqual(null)
+    expect(cb(1)).to.deep.equal(undefined)
+    expect(cb(2)).to.deep.equal(undefined)
+    expect(cb).to.deep.equal(null)
   })
 })

--- a/test/specs/from-node-callback.js
+++ b/test/specs/from-node-callback.js
@@ -1,4 +1,4 @@
-const {activate, deactivate, Kefir, expect} = require('../test-helpers')
+const {activate, deactivate, Kefir, value, error, end, expect} = require('../test-helpers')
 
 describe('fromNodeCallback', () => {
   it('should return stream', () => {
@@ -24,12 +24,12 @@ describe('fromNodeCallback', () => {
 
   it('should emit first result and end after that', () => {
     let cb = null
-    expect(Kefir.fromNodeCallback(_cb => cb = _cb)).to.emit([1, '<end>'], () => cb(null, 1))
+    expect(Kefir.fromNodeCallback(_cb => cb = _cb)).to.emit([value(1), end()], () => cb(null, 1))
   })
 
   it('should emit first error and end after that', () => {
     let cb = null
-    expect(Kefir.fromNodeCallback(_cb => cb = _cb)).to.emit([{error: -1}, '<end>'], () => cb(-1))
+    expect(Kefir.fromNodeCallback(_cb => cb = _cb)).to.emit([error(-1), end()], () => cb(-1))
   })
 
   it('should work after deactivation/activate cicle', () => {
@@ -39,12 +39,12 @@ describe('fromNodeCallback', () => {
     deactivate(s)
     activate(s)
     deactivate(s)
-    expect(s).to.emit([1, '<end>'], () => cb(null, 1))
+    expect(s).to.emit([value(1), end()], () => cb(null, 1))
   })
 
   it('should emit a current, if `callback` is called immediately in `callbackConsumer`', () => {
-    expect(Kefir.fromNodeCallback(cb => cb(null, 1))).to.emit([{current: 1}, '<end:current>'])
+    expect(Kefir.fromNodeCallback(cb => cb(null, 1))).to.emit([value(1, {current: true}), end({current: true})])
 
-    expect(Kefir.fromNodeCallback(cb => cb(-1))).to.emit([{currentError: -1}, '<end:current>'])
+    expect(Kefir.fromNodeCallback(cb => cb(-1))).to.emit([error(-1, {current: true}), end({current: true})])
   })
 })

--- a/test/specs/from-node-callback.js
+++ b/test/specs/from-node-callback.js
@@ -1,35 +1,35 @@
-const {activate, deactivate, Kefir} = require('../test-helpers')
+const {activate, deactivate, Kefir, expect} = require('../test-helpers')
 
 describe('fromNodeCallback', () => {
   it('should return stream', () => {
-    expect(Kefir.fromNodeCallback(() => {})).toBeStream()
+    expect(Kefir.fromNodeCallback(() => {})).to.be.observable.stream()
   })
 
   it('should not be ended', () => {
-    expect(Kefir.fromNodeCallback(() => {})).toEmit([])
+    expect(Kefir.fromNodeCallback(() => {})).to.emit([])
   })
 
   it('should call `callbackConsumer` on first activation, and only on first', () => {
     let count = 0
     const s = Kefir.fromNodeCallback(() => count++)
-    expect(count).toBe(0)
+    expect(count).to.equal(0)
     activate(s)
-    expect(count).toBe(1)
+    expect(count).to.equal(1)
     deactivate(s)
     activate(s)
     deactivate(s)
     activate(s)
-    expect(count).toBe(1)
+    expect(count).to.equal(1)
   })
 
   it('should emit first result and end after that', () => {
     let cb = null
-    expect(Kefir.fromNodeCallback(_cb => cb = _cb)).toEmit([1, '<end>'], () => cb(null, 1))
+    expect(Kefir.fromNodeCallback(_cb => cb = _cb)).to.emit([1, '<end>'], () => cb(null, 1))
   })
 
   it('should emit first error and end after that', () => {
     let cb = null
-    expect(Kefir.fromNodeCallback(_cb => cb = _cb)).toEmit([{error: -1}, '<end>'], () => cb(-1))
+    expect(Kefir.fromNodeCallback(_cb => cb = _cb)).to.emit([{error: -1}, '<end>'], () => cb(-1))
   })
 
   it('should work after deactivation/activate cicle', () => {
@@ -39,12 +39,12 @@ describe('fromNodeCallback', () => {
     deactivate(s)
     activate(s)
     deactivate(s)
-    expect(s).toEmit([1, '<end>'], () => cb(null, 1))
+    expect(s).to.emit([1, '<end>'], () => cb(null, 1))
   })
 
   it('should emit a current, if `callback` is called immediately in `callbackConsumer`', () => {
-    expect(Kefir.fromNodeCallback(cb => cb(null, 1))).toEmit([{current: 1}, '<end:current>'])
+    expect(Kefir.fromNodeCallback(cb => cb(null, 1))).to.emit([{current: 1}, '<end:current>'])
 
-    expect(Kefir.fromNodeCallback(cb => cb(-1))).toEmit([{currentError: -1}, '<end:current>'])
+    expect(Kefir.fromNodeCallback(cb => cb(-1))).to.emit([{currentError: -1}, '<end:current>'])
   })
 })

--- a/test/specs/from-poll.js
+++ b/test/specs/from-poll.js
@@ -1,4 +1,4 @@
-const {Kefir, expect} = require('../test-helpers')
+const {value, Kefir, expect} = require('../test-helpers')
 
 describe('fromPoll', () => {
   it('should return stream', () => {
@@ -7,6 +7,10 @@ describe('fromPoll', () => {
 
   it('should emit whatever fn returns at certain time', () => {
     let i = 0
-    expect(Kefir.fromPoll(100, () => ++i)).to.emitInTime([[100, 1], [200, 2], [300, 3]], undefined, {timeLimit: 350})
+    expect(Kefir.fromPoll(100, () => ++i)).to.emitInTime(
+      [[100, value(1)], [200, value(2)], [300, value(3)]],
+      undefined,
+      {timeLimit: 350}
+    )
   })
 })

--- a/test/specs/from-poll.js
+++ b/test/specs/from-poll.js
@@ -1,12 +1,12 @@
-const Kefir = require('../../dist/kefir')
+const {Kefir, expect} = require('../test-helpers')
 
 describe('fromPoll', () => {
   it('should return stream', () => {
-    expect(Kefir.fromPoll(100, () => {})).toBeStream()
+    expect(Kefir.fromPoll(100, () => {})).to.be.observable.stream()
   })
 
   it('should emit whatever fn returns at certain time', () => {
     let i = 0
-    expect(Kefir.fromPoll(100, () => ++i)).toEmitInTime([[100, 1], [200, 2], [300, 3]], null, 350)
+    expect(Kefir.fromPoll(100, () => ++i)).to.emitInTime([[100, 1], [200, 2], [300, 3]], undefined, {timeLimit: 350})
   })
 })

--- a/test/specs/from-promise.js
+++ b/test/specs/from-promise.js
@@ -1,4 +1,4 @@
-const {activate, deactivate, Kefir, expect} = require('../test-helpers')
+const {activate, deactivate, value, error, end, Kefir, expect} = require('../test-helpers')
 
 describe('fromPromise', () => {
   const inProgress = {
@@ -77,21 +77,21 @@ describe('fromPromise', () => {
   })
 
   it('... with fulfilledSync property', () => {
-    expect(Kefir.fromPromise(fulfilledSync)).to.emit([{current: 1}, '<end:current>'])
+    expect(Kefir.fromPromise(fulfilledSync)).to.emit([value(1, {current: true}), end({current: true})])
   })
 
   it('... with failedSync property', () =>
-    expect(Kefir.fromPromise(failedSync)).to.emit([{currentError: 1}, '<end:current>']))
+    expect(Kefir.fromPromise(failedSync)).to.emit([error(1, {current: true}), end({current: true})]))
 
   it('... with fulfilledAsync property', () => {
     const a = Kefir.fromPromise(fulfilledAsync)
-    expect(a).to.emitInTime([[1000, 1], [1000, '<end>']])
-    expect(a).to.emit([{current: 1}, '<end:current>'])
+    expect(a).to.emitInTime([[1000, value(1)], [1000, end()]])
+    expect(a).to.emit([value(1, {current: true}), end({current: true})])
   })
 
   it('... with failedAsync property', () => {
     const a = Kefir.fromPromise(failedAsync)
-    expect(a).to.emitInTime([[1000, {error: 1}], [1000, '<end>']])
-    expect(a).to.emit([{currentError: 1}, '<end:current>'])
+    expect(a).to.emitInTime([[1000, error(1)], [1000, end()]])
+    expect(a).to.emit([error(1, {current: true}), end({current: true})])
   })
 })

--- a/test/specs/from-promise.js
+++ b/test/specs/from-promise.js
@@ -1,4 +1,4 @@
-const {activate, deactivate, Kefir} = require('../test-helpers')
+const {activate, deactivate, Kefir, expect} = require('../test-helpers')
 
 describe('fromPromise', () => {
   const inProgress = {
@@ -32,7 +32,7 @@ describe('fromPromise', () => {
   }
 
   it('should return property', () => {
-    expect(Kefir.fromPromise(inProgress)).toBeProperty()
+    expect(Kefir.fromPromise(inProgress)).to.be.observable.property()
   })
 
   it('should call `property.then` on first activation, and only on first', () => {
@@ -42,14 +42,14 @@ describe('fromPromise', () => {
         return count++
       },
     })
-    expect(count).toBe(0)
+    expect(count).to.equal(0)
     activate(s)
-    expect(count).toBe(1)
+    expect(count).to.equal(1)
     deactivate(s)
     activate(s)
     deactivate(s)
     activate(s)
-    expect(count).toBe(1)
+    expect(count).to.equal(1)
   })
 
   it('should call `property.done`', () => {
@@ -62,36 +62,36 @@ describe('fromPromise', () => {
         return count++
       },
     })
-    expect(count).toBe(0)
+    expect(count).to.equal(0)
     activate(s)
-    expect(count).toBe(1)
+    expect(count).to.equal(1)
     deactivate(s)
     activate(s)
     deactivate(s)
     activate(s)
-    expect(count).toBe(1)
+    expect(count).to.equal(1)
   })
 
   it('should work correctly with inProgress property', () => {
-    expect(Kefir.fromPromise(inProgress)).toEmitInTime([])
+    expect(Kefir.fromPromise(inProgress)).to.emitInTime([])
   })
 
   it('... with fulfilledSync property', () => {
-    expect(Kefir.fromPromise(fulfilledSync)).toEmit([{current: 1}, '<end:current>'])
+    expect(Kefir.fromPromise(fulfilledSync)).to.emit([{current: 1}, '<end:current>'])
   })
 
   it('... with failedSync property', () =>
-    expect(Kefir.fromPromise(failedSync)).toEmit([{currentError: 1}, '<end:current>']))
+    expect(Kefir.fromPromise(failedSync)).to.emit([{currentError: 1}, '<end:current>']))
 
   it('... with fulfilledAsync property', () => {
     const a = Kefir.fromPromise(fulfilledAsync)
-    expect(a).toEmitInTime([[1000, 1], [1000, '<end>']])
-    expect(a).toEmit([{current: 1}, '<end:current>'])
+    expect(a).to.emitInTime([[1000, 1], [1000, '<end>']])
+    expect(a).to.emit([{current: 1}, '<end:current>'])
   })
 
   it('... with failedAsync property', () => {
     const a = Kefir.fromPromise(failedAsync)
-    expect(a).toEmitInTime([[1000, {error: 1}], [1000, '<end>']])
-    expect(a).toEmit([{currentError: 1}, '<end:current>'])
+    expect(a).to.emitInTime([[1000, {error: 1}], [1000, '<end>']])
+    expect(a).to.emit([{currentError: 1}, '<end:current>'])
   })
 })

--- a/test/specs/ignore-end.js
+++ b/test/specs/ignore-end.js
@@ -1,54 +1,54 @@
-const {stream, prop, send} = require('../test-helpers')
+const {stream, prop, send, expect} = require('../test-helpers')
 
 describe('ignoreEnd', () => {
   describe('stream', () => {
     it('should return stream', () => {
-      expect(stream().ignoreEnd()).toBeStream()
+      expect(stream().ignoreEnd()).to.be.observable.stream()
     })
 
     it('should activate/deactivate source', () => {
       const a = stream()
-      expect(a.ignoreEnd()).toActivate(a)
+      expect(a.ignoreEnd()).to.activate(a)
     })
 
     it('should not be ended if source was ended', () => {
-      expect(send(stream(), ['<end>']).ignoreEnd()).toEmit([])
+      expect(send(stream(), ['<end>']).ignoreEnd()).to.emit([])
     })
 
     it('should handle events', () => {
       const a = stream()
-      expect(a.ignoreEnd()).toEmit([1, 2], () => send(a, [1, 2, '<end>']))
+      expect(a.ignoreEnd()).to.emit([1, 2], () => send(a, [1, 2, '<end>']))
     })
 
     it('errors should flow', () => {
       const a = stream()
-      expect(a.ignoreEnd()).errorsToFlow(a)
+      expect(a.ignoreEnd()).to.flowErrors(a)
     })
   })
 
   describe('property', () => {
     it('should return property', () => {
-      expect(prop().ignoreEnd()).toBeProperty()
+      expect(prop().ignoreEnd()).to.be.observable.property()
     })
 
     it('should activate/deactivate source', () => {
       const a = prop()
-      expect(a.ignoreEnd()).toActivate(a)
+      expect(a.ignoreEnd()).to.activate(a)
     })
 
     it('should not be ended if source was ended', () => {
-      expect(send(prop(), ['<end>']).ignoreEnd()).toEmit([])
-      expect(send(prop(), [1, '<end>']).ignoreEnd()).toEmit([{current: 1}])
+      expect(send(prop(), ['<end>']).ignoreEnd()).to.emit([])
+      expect(send(prop(), [1, '<end>']).ignoreEnd()).to.emit([{current: 1}])
     })
 
     it('should handle events and current', () => {
       const a = send(prop(), [1])
-      expect(a.ignoreEnd()).toEmit([{current: 1}, 2, 3], () => send(a, [2, 3, '<end>']))
+      expect(a.ignoreEnd()).to.emit([{current: 1}, 2, 3], () => send(a, [2, 3, '<end>']))
     })
 
     it('errors should flow', () => {
       const a = prop()
-      expect(a.ignoreEnd()).errorsToFlow(a)
+      expect(a.ignoreEnd()).to.flowErrors(a)
     })
   })
 })

--- a/test/specs/ignore-end.js
+++ b/test/specs/ignore-end.js
@@ -1,4 +1,4 @@
-const {stream, prop, send, expect} = require('../test-helpers')
+const {stream, prop, send, value, end, expect} = require('../test-helpers')
 
 describe('ignoreEnd', () => {
   describe('stream', () => {
@@ -12,12 +12,12 @@ describe('ignoreEnd', () => {
     })
 
     it('should not be ended if source was ended', () => {
-      expect(send(stream(), ['<end>']).ignoreEnd()).to.emit([])
+      expect(send(stream(), [end()]).ignoreEnd()).to.emit([])
     })
 
     it('should handle events', () => {
       const a = stream()
-      expect(a.ignoreEnd()).to.emit([1, 2], () => send(a, [1, 2, '<end>']))
+      expect(a.ignoreEnd()).to.emit([value(1), value(2)], () => send(a, [value(1), value(2), end()]))
     })
 
     it('errors should flow', () => {
@@ -37,13 +37,15 @@ describe('ignoreEnd', () => {
     })
 
     it('should not be ended if source was ended', () => {
-      expect(send(prop(), ['<end>']).ignoreEnd()).to.emit([])
-      expect(send(prop(), [1, '<end>']).ignoreEnd()).to.emit([{current: 1}])
+      expect(send(prop(), [end()]).ignoreEnd()).to.emit([])
+      expect(send(prop(), [value(1), end()]).ignoreEnd()).to.emit([value(1, {current: true})])
     })
 
     it('should handle events and current', () => {
-      const a = send(prop(), [1])
-      expect(a.ignoreEnd()).to.emit([{current: 1}, 2, 3], () => send(a, [2, 3, '<end>']))
+      const a = send(prop(), [value(1)])
+      expect(a.ignoreEnd()).to.emit([value(1, {current: true}), value(2), value(3)], () =>
+        send(a, [value(2), value(3), end()])
+      )
     })
 
     it('errors should flow', () => {

--- a/test/specs/ignore-errors.js
+++ b/test/specs/ignore-errors.js
@@ -1,43 +1,43 @@
-const {stream, prop, send, Kefir} = require('../test-helpers')
+const {stream, prop, send, Kefir, expect} = require('../test-helpers')
 
 describe('ignoreErrors', () => {
   describe('stream', () => {
     it('should return stream', () => {
-      expect(stream().ignoreErrors()).toBeStream()
+      expect(stream().ignoreErrors()).to.be.observable.stream()
     })
 
     it('should activate/deactivate source', () => {
       const a = stream()
-      expect(a.ignoreErrors()).toActivate(a)
+      expect(a.ignoreErrors()).to.activate(a)
     })
 
     it('should be ended if source was ended', () =>
-      expect(send(stream(), ['<end>']).ignoreErrors()).toEmit(['<end:current>']))
+      expect(send(stream(), ['<end>']).ignoreErrors()).to.emit(['<end:current>']))
 
     it('should handle events', () => {
       const a = stream()
-      expect(a.ignoreErrors()).toEmit([1, 2, '<end>'], () => send(a, [1, {error: -1}, 2, {error: -2}, '<end>']))
+      expect(a.ignoreErrors()).to.emit([1, 2, '<end>'], () => send(a, [1, {error: -1}, 2, {error: -2}, '<end>']))
     })
   })
 
   describe('property', () => {
     it('should return property', () => {
-      expect(prop().ignoreErrors()).toBeProperty()
+      expect(prop().ignoreErrors()).to.be.observable.property()
     })
 
     it('should activate/deactivate source', () => {
       const a = prop()
-      expect(a.ignoreErrors()).toActivate(a)
+      expect(a.ignoreErrors()).to.activate(a)
     })
 
     it('should be ended if source was ended', () =>
-      expect(send(prop(), ['<end>']).ignoreErrors()).toEmit(['<end:current>']))
+      expect(send(prop(), ['<end>']).ignoreErrors()).to.emit(['<end:current>']))
 
     it('should handle events and current', () => {
       let a = send(prop(), [{error: -1}])
-      expect(a.ignoreErrors()).toEmit([2, 3, '<end>'], () => send(a, [2, {error: -2}, 3, {error: -3}, '<end>']))
+      expect(a.ignoreErrors()).to.emit([2, 3, '<end>'], () => send(a, [2, {error: -2}, 3, {error: -3}, '<end>']))
       a = send(prop(), [1])
-      expect(a.ignoreErrors()).toEmit([{current: 1}, 2, 3, '<end>'], () =>
+      expect(a.ignoreErrors()).to.emit([{current: 1}, 2, 3, '<end>'], () =>
         send(a, [2, {error: -2}, 3, {error: -3}, '<end>'])
       )
     })

--- a/test/specs/ignore-errors.js
+++ b/test/specs/ignore-errors.js
@@ -1,4 +1,4 @@
-const {stream, prop, send, Kefir, expect} = require('../test-helpers')
+const {stream, prop, send, value, error, end, expect} = require('../test-helpers')
 
 describe('ignoreErrors', () => {
   describe('stream', () => {
@@ -12,11 +12,13 @@ describe('ignoreErrors', () => {
     })
 
     it('should be ended if source was ended', () =>
-      expect(send(stream(), ['<end>']).ignoreErrors()).to.emit(['<end:current>']))
+      expect(send(stream(), [end()]).ignoreErrors()).to.emit([end({current: true})]))
 
     it('should handle events', () => {
       const a = stream()
-      expect(a.ignoreErrors()).to.emit([1, 2, '<end>'], () => send(a, [1, {error: -1}, 2, {error: -2}, '<end>']))
+      expect(a.ignoreErrors()).to.emit([value(1), value(2), end()], () =>
+        send(a, [value(1), error(-1), value(2), error(-2), end()])
+      )
     })
   })
 
@@ -31,14 +33,16 @@ describe('ignoreErrors', () => {
     })
 
     it('should be ended if source was ended', () =>
-      expect(send(prop(), ['<end>']).ignoreErrors()).to.emit(['<end:current>']))
+      expect(send(prop(), [end()]).ignoreErrors()).to.emit([end({current: true})]))
 
     it('should handle events and current', () => {
-      let a = send(prop(), [{error: -1}])
-      expect(a.ignoreErrors()).to.emit([2, 3, '<end>'], () => send(a, [2, {error: -2}, 3, {error: -3}, '<end>']))
-      a = send(prop(), [1])
-      expect(a.ignoreErrors()).to.emit([{current: 1}, 2, 3, '<end>'], () =>
-        send(a, [2, {error: -2}, 3, {error: -3}, '<end>'])
+      let a = send(prop(), [error(-1)])
+      expect(a.ignoreErrors()).to.emit([value(2), value(3), end()], () =>
+        send(a, [value(2), error(-2), value(3), error(-3), end()])
+      )
+      a = send(prop(), [value(1)])
+      expect(a.ignoreErrors()).to.emit([value(1, {current: true}), value(2), value(3), end()], () =>
+        send(a, [value(2), error(-2), value(3), error(-3), end()])
       )
     })
   })

--- a/test/specs/ignore-values.js
+++ b/test/specs/ignore-values.js
@@ -1,22 +1,22 @@
-const {stream, prop, send, Kefir} = require('../test-helpers')
+const {stream, prop, send, Kefir, expect} = require('../test-helpers')
 
 describe('ignoreValues', () => {
   describe('stream', () => {
     it('should return stream', () => {
-      expect(stream().ignoreValues()).toBeStream()
+      expect(stream().ignoreValues()).to.be.observable.stream()
     })
 
     it('should activate/deactivate source', () => {
       const a = stream()
-      expect(a.ignoreValues()).toActivate(a)
+      expect(a.ignoreValues()).to.activate(a)
     })
 
     it('should be ended if source was ended', () =>
-      expect(send(stream(), ['<end>']).ignoreValues()).toEmit(['<end:current>']))
+      expect(send(stream(), ['<end>']).ignoreValues()).to.emit(['<end:current>']))
 
     it('should handle events', () => {
       const a = stream()
-      expect(a.ignoreValues()).toEmit([{error: -1}, {error: -2}, '<end>'], () =>
+      expect(a.ignoreValues()).to.emit([{error: -1}, {error: -2}, '<end>'], () =>
         send(a, [1, {error: -1}, 2, {error: -2}, '<end>'])
       )
     })
@@ -24,20 +24,20 @@ describe('ignoreValues', () => {
 
   describe('property', () => {
     it('should return property', () => {
-      expect(prop().ignoreValues()).toBeProperty()
+      expect(prop().ignoreValues()).to.be.observable.property()
     })
 
     it('should activate/deactivate source', () => {
       const a = prop()
-      expect(a.ignoreValues()).toActivate(a)
+      expect(a.ignoreValues()).to.activate(a)
     })
 
     it('should be ended if source was ended', () =>
-      expect(send(prop(), ['<end>']).ignoreValues()).toEmit(['<end:current>']))
+      expect(send(prop(), ['<end>']).ignoreValues()).to.emit(['<end:current>']))
 
     it('should handle events and current', () => {
       const a = send(prop(), [1, {error: -1}])
-      expect(a.ignoreValues()).toEmit([{currentError: -1}, {error: -2}, {error: -3}, '<end>'], () =>
+      expect(a.ignoreValues()).to.emit([{currentError: -1}, {error: -2}, {error: -3}, '<end>'], () =>
         send(a, [2, {error: -2}, 3, {error: -3}, '<end>'])
       )
     })

--- a/test/specs/ignore-values.js
+++ b/test/specs/ignore-values.js
@@ -1,4 +1,4 @@
-const {stream, prop, send, Kefir, expect} = require('../test-helpers')
+const {stream, prop, send, value, error, end, Kefir, expect} = require('../test-helpers')
 
 describe('ignoreValues', () => {
   describe('stream', () => {
@@ -12,12 +12,12 @@ describe('ignoreValues', () => {
     })
 
     it('should be ended if source was ended', () =>
-      expect(send(stream(), ['<end>']).ignoreValues()).to.emit(['<end:current>']))
+      expect(send(stream(), [end()]).ignoreValues()).to.emit([end({current: true})]))
 
     it('should handle events', () => {
       const a = stream()
-      expect(a.ignoreValues()).to.emit([{error: -1}, {error: -2}, '<end>'], () =>
-        send(a, [1, {error: -1}, 2, {error: -2}, '<end>'])
+      expect(a.ignoreValues()).to.emit([error(-1), error(-2), end()], () =>
+        send(a, [value(1), error(-1), value(2), error(-2), end()])
       )
     })
   })
@@ -33,12 +33,12 @@ describe('ignoreValues', () => {
     })
 
     it('should be ended if source was ended', () =>
-      expect(send(prop(), ['<end>']).ignoreValues()).to.emit(['<end:current>']))
+      expect(send(prop(), [end()]).ignoreValues()).to.emit([end({current: true})]))
 
     it('should handle events and current', () => {
-      const a = send(prop(), [1, {error: -1}])
-      expect(a.ignoreValues()).to.emit([{currentError: -1}, {error: -2}, {error: -3}, '<end>'], () =>
-        send(a, [2, {error: -2}, 3, {error: -3}, '<end>'])
+      const a = send(prop(), [value(1), error(-1)])
+      expect(a.ignoreValues()).to.emit([error(-1, {current: true}), error(-2), error(-3), end()], () =>
+        send(a, [value(2), error(-2), value(3), error(-3), end()])
       )
     })
   })

--- a/test/specs/interval.js
+++ b/test/specs/interval.js
@@ -1,4 +1,4 @@
-const {Kefir, expect} = require('../test-helpers')
+const {value, Kefir, expect} = require('../test-helpers')
 
 describe('interval', () => {
   it('should return stream', () => {
@@ -6,6 +6,8 @@ describe('interval', () => {
   })
 
   it('should repeat same value at certain time', () => {
-    expect(Kefir.interval(100, 1)).to.emitInTime([[100, 1], [200, 1], [300, 1]], undefined, {timeLimit: 350})
+    expect(Kefir.interval(100, 1)).to.emitInTime([[100, value(1)], [200, value(1)], [300, value(1)]], undefined, {
+      timeLimit: 350,
+    })
   })
 })

--- a/test/specs/interval.js
+++ b/test/specs/interval.js
@@ -1,11 +1,11 @@
-const Kefir = require('../../dist/kefir')
+const {Kefir, expect} = require('../test-helpers')
 
 describe('interval', () => {
   it('should return stream', () => {
-    expect(Kefir.interval(100, 1)).toBeStream()
+    expect(Kefir.interval(100, 1)).to.be.observable.stream()
   })
 
   it('should repeat same value at certain time', () => {
-    expect(Kefir.interval(100, 1)).toEmitInTime([[100, 1], [200, 1], [300, 1]], null, 350)
+    expect(Kefir.interval(100, 1)).to.emitInTime([[100, 1], [200, 1], [300, 1]], undefined, {timeLimit: 350})
   })
 })

--- a/test/specs/kefir-observable.js
+++ b/test/specs/kefir-observable.js
@@ -1,4 +1,4 @@
-let {Kefir} = require('../test-helpers')
+let {Kefir, expect} = require('../test-helpers')
 
 describe('Kefir.Observable', () => {
   describe('observe', () => {
@@ -14,38 +14,38 @@ describe('Kefir.Observable', () => {
     })
 
     it('should return a Subscription', () => {
-      expect(sub.closed).toBe(false)
-      expect(typeof sub.unsubscribe).toBe('function')
+      expect(sub.closed).to.equal(false)
+      expect(typeof sub.unsubscribe).to.equal('function')
     })
 
     it('should call Observer methods', () => {
-      expect(count).toBe(0)
+      expect(count).to.equal(0)
 
       em.emit(1)
-      expect(count).toBe(1)
+      expect(count).to.equal(1)
 
       em.emit(1)
-      expect(count).toBe(2)
+      expect(count).to.equal(2)
 
       em.error(1)
-      expect(count).toBe(1)
+      expect(count).to.equal(1)
 
       em.end()
-      expect(count).toBe(0)
-      expect(sub.closed).toBe(true)
+      expect(count).to.equal(0)
+      expect(sub.closed).to.equal(true)
     })
 
     it('should unsubcribe early', () => {
-      expect(count).toBe(0)
+      expect(count).to.equal(0)
 
       em.emit(1)
-      expect(count).toBe(1)
+      expect(count).to.equal(1)
 
       sub.unsubscribe()
 
       em.emit(1)
-      expect(count).toBe(1)
-      expect(sub.closed).toBe(true)
+      expect(count).to.equal(1)
+      expect(sub.closed).to.equal(true)
     })
 
     it('closed=true after end (w/o end handler)', () => {
@@ -54,7 +54,7 @@ describe('Kefir.Observable', () => {
       })
       sub = obs.observe(() => {})
       em.end()
-      expect(sub.closed).toBe(true)
+      expect(sub.closed).to.equal(true)
     })
   })
 })

--- a/test/specs/kefir-stream.js
+++ b/test/specs/kefir-stream.js
@@ -1,12 +1,12 @@
-const {activate, deactivate, Kefir} = require('../test-helpers')
+const {activate, deactivate, Kefir, expect} = require('../test-helpers')
 
 describe('Kefir.stream', () => {
   it('should return stream', () => {
-    expect(Kefir.stream(() => {})).toBeStream()
+    expect(Kefir.stream(() => {})).to.be.observable.stream()
   })
 
   it('should not be ended', () => {
-    expect(Kefir.stream(() => {})).toEmit([])
+    expect(Kefir.stream(() => {})).to.emit([])
   })
 
   it('should emit values, errors, and end', () => {
@@ -15,7 +15,7 @@ describe('Kefir.stream', () => {
       emitter = em
       return null
     })
-    expect(a).toEmit([1, 2, {error: -1}, 3, '<end>'], () => {
+    expect(a).to.emit([1, 2, {error: -1}, 3, '<end>'], () => {
       emitter.value(1)
       emitter.value(2)
       emitter.error(-1)
@@ -31,22 +31,22 @@ describe('Kefir.stream', () => {
       subCount++
       return () => unsubCount++
     })
-    expect(subCount).toBe(0)
-    expect(unsubCount).toBe(0)
+    expect(subCount).to.equal(0)
+    expect(unsubCount).to.equal(0)
     activate(a)
-    expect(subCount).toBe(1)
+    expect(subCount).to.equal(1)
     activate(a)
-    expect(subCount).toBe(1)
+    expect(subCount).to.equal(1)
     deactivate(a)
-    expect(unsubCount).toBe(0)
+    expect(unsubCount).to.equal(0)
     deactivate(a)
-    expect(unsubCount).toBe(1)
-    expect(subCount).toBe(1)
+    expect(unsubCount).to.equal(1)
+    expect(subCount).to.equal(1)
     activate(a)
-    expect(subCount).toBe(2)
-    expect(unsubCount).toBe(1)
+    expect(subCount).to.equal(2)
+    expect(unsubCount).to.equal(1)
     deactivate(a)
-    expect(unsubCount).toBe(2)
+    expect(unsubCount).to.equal(2)
   })
 
   it('should automatically controll isCurent argument in `send`', () => {
@@ -55,7 +55,7 @@ describe('Kefir.stream', () => {
         emitter.end()
         return null
       })
-    ).toEmit(['<end:current>'])
+    ).to.emit(['<end:current>'])
 
     expect(
       Kefir.stream(emitter => {
@@ -68,7 +68,7 @@ describe('Kefir.stream', () => {
         }, 1000)
         return null
       })
-    ).toEmitInTime([[0, {current: 1}], [0, {currentError: -1}], [0, {current: 2}], [1000, 2], [1000, '<end>']])
+    ).to.emitInTime([[0, {current: 1}], [0, {currentError: -1}], [0, {current: 2}], [1000, 2], [1000, '<end>']])
   })
 
   it('should support emitter.event', () => {
@@ -84,7 +84,7 @@ describe('Kefir.stream', () => {
         }, 1000)
         return null
       })
-    ).toEmitInTime([
+    ).to.emitInTime([
       [0, {current: 1}],
       [0, {currentError: -1}],
       [0, {current: 2}],
@@ -108,25 +108,25 @@ describe('Kefir.stream', () => {
     a.take(1).onValue(() => {})
     a.take(1).onValue(() => {})
 
-    expect(log).toEqual([{sub: 1, unsub: 1}, {sub: 1, unsub: 1}])
+    expect(log).to.deep.equal([{sub: 1, unsub: 1}, {sub: 1, unsub: 1}])
   })
 
   it('should not throw if not falsey but not a function returned', () => {
-    expect(Kefir.stream(() => true)).toEmit([])
+    expect(Kefir.stream(() => true)).to.emit([])
   })
 
   it('emitter should return a boolean representing if anyone intrested in future events', () => {
     let emitter = null
     let a = Kefir.stream(em => emitter = em)
     activate(a)
-    expect(emitter.value(1)).toBe(true)
+    expect(emitter.value(1)).to.equal(true)
     deactivate(a)
-    expect(emitter.value(1)).toBe(false)
+    expect(emitter.value(1)).to.equal(false)
 
     a = Kefir.stream(em => {
-      expect(em.value(1)).toBe(true)
-      expect(em.value(2)).toBe(false)
-      expect(em.value(3)).toBe(false)
+      expect(em.value(1)).to.equal(true)
+      expect(em.value(2)).to.equal(false)
+      expect(em.value(3)).to.equal(false)
     })
     let lastX = null
     var f = x => {
@@ -136,7 +136,7 @@ describe('Kefir.stream', () => {
       }
     }
     a.onValue(f)
-    expect(lastX).toBe(2)
+    expect(lastX).to.equal(2)
   })
 
   it('calling emitter.end() in undubscribe() should work fine', () => {

--- a/test/specs/kefir-stream.js
+++ b/test/specs/kefir-stream.js
@@ -1,4 +1,4 @@
-const {activate, deactivate, Kefir, expect} = require('../test-helpers')
+const {activate, deactivate, value, error, end, Kefir, expect} = require('../test-helpers')
 
 describe('Kefir.stream', () => {
   it('should return stream', () => {
@@ -15,7 +15,7 @@ describe('Kefir.stream', () => {
       emitter = em
       return null
     })
-    expect(a).to.emit([1, 2, {error: -1}, 3, '<end>'], () => {
+    expect(a).to.emit([value(1), value(2), error(-1), value(3), end()], () => {
       emitter.value(1)
       emitter.value(2)
       emitter.error(-1)
@@ -55,7 +55,7 @@ describe('Kefir.stream', () => {
         emitter.end()
         return null
       })
-    ).to.emit(['<end:current>'])
+    ).to.emit([end({current: true})])
 
     expect(
       Kefir.stream(emitter => {
@@ -68,7 +68,13 @@ describe('Kefir.stream', () => {
         }, 1000)
         return null
       })
-    ).to.emitInTime([[0, {current: 1}], [0, {currentError: -1}], [0, {current: 2}], [1000, 2], [1000, '<end>']])
+    ).to.emitInTime([
+      [0, value(1, {current: true})],
+      [0, error(-1, {current: true})],
+      [0, value(2, {current: true})],
+      [1000, value(2)],
+      [1000, end()],
+    ])
   })
 
   it('should support emitter.event', () => {
@@ -85,12 +91,12 @@ describe('Kefir.stream', () => {
         return null
       })
     ).to.emitInTime([
-      [0, {current: 1}],
-      [0, {currentError: -1}],
-      [0, {current: 2}],
-      [1000, 3],
-      [1000, 4],
-      [1000, '<end>'],
+      [0, value(1, {current: true})],
+      [0, error(-1, {current: true})],
+      [0, value(2, {current: true})],
+      [1000, value(3)],
+      [1000, value(4)],
+      [1000, end()],
     ])
   })
 

--- a/test/specs/last.js
+++ b/test/specs/last.js
@@ -1,4 +1,4 @@
-const {stream, prop, send, Kefir, expect} = require('../test-helpers')
+const {stream, prop, send, value, error, end, Kefir, expect} = require('../test-helpers')
 
 describe('last', () => {
   describe('stream', () => {
@@ -12,13 +12,13 @@ describe('last', () => {
     })
 
     it('should be ended if source was ended', () => {
-      expect(send(stream(), ['<end>']).last()).to.emit(['<end:current>'])
+      expect(send(stream(), [end()]).last()).to.emit([end({current: true})])
     })
 
     it('should handle events', () => {
       const a = stream()
-      expect(a.last()).to.emit([{error: 5}, {error: 6}, 3, '<end>'], () =>
-        send(a, [1, {error: 5}, {error: 6}, 2, 3, '<end>'])
+      expect(a.last()).to.emit([error(5), error(6), value(3), end()], () =>
+        send(a, [value(1), error(5), error(6), value(2), value(3), end()])
       )
     })
   })
@@ -34,16 +34,18 @@ describe('last', () => {
     })
 
     it('should be ended if source was ended', () => {
-      expect(send(prop(), ['<end>']).last()).to.emit(['<end:current>'])
-      expect(send(prop(), [1, '<end>']).last()).to.emit([{current: 1}, '<end:current>'])
+      expect(send(prop(), [end()]).last()).to.emit([end({current: true})])
+      expect(send(prop(), [value(1), end()]).last()).to.emit([value(1, {current: true}), end({current: true})])
     })
 
     it('should handle events and current', () => {
-      let a = send(prop(), [1])
-      expect(a.last()).to.emit([{error: 5}, 1, '<end>'], () => send(a, [{error: 5}, '<end>']))
+      let a = send(prop(), [value(1)])
+      expect(a.last()).to.emit([error(5), value(1), end()], () => send(a, [error(5), end()]))
 
-      a = send(prop(), [{error: 0}])
-      expect(a.last()).to.emit([{currentError: 0}, {error: 5}, 3, '<end>'], () => send(a, [2, {error: 5}, 3, '<end>']))
+      a = send(prop(), [error(0)])
+      expect(a.last()).to.emit([error(0, {current: true}), error(5), value(3), end()], () =>
+        send(a, [value(2), error(5), value(3), end()])
+      )
     })
   })
 })

--- a/test/specs/last.js
+++ b/test/specs/last.js
@@ -1,23 +1,23 @@
-const {stream, prop, send, Kefir} = require('../test-helpers')
+const {stream, prop, send, Kefir, expect} = require('../test-helpers')
 
 describe('last', () => {
   describe('stream', () => {
     it('should return stream', () => {
-      expect(stream().last()).toBeStream()
+      expect(stream().last()).to.be.observable.stream()
     })
 
     it('should activate/deactivate source', () => {
       const a = stream()
-      expect(a.last()).toActivate(a)
+      expect(a.last()).to.activate(a)
     })
 
     it('should be ended if source was ended', () => {
-      expect(send(stream(), ['<end>']).last()).toEmit(['<end:current>'])
+      expect(send(stream(), ['<end>']).last()).to.emit(['<end:current>'])
     })
 
     it('should handle events', () => {
       const a = stream()
-      expect(a.last()).toEmit([{error: 5}, {error: 6}, 3, '<end>'], () =>
+      expect(a.last()).to.emit([{error: 5}, {error: 6}, 3, '<end>'], () =>
         send(a, [1, {error: 5}, {error: 6}, 2, 3, '<end>'])
       )
     })
@@ -25,25 +25,25 @@ describe('last', () => {
 
   describe('property', () => {
     it('should return property', () => {
-      expect(prop().last()).toBeProperty()
+      expect(prop().last()).to.be.observable.property()
     })
 
     it('should activate/deactivate source', () => {
       const a = prop()
-      expect(a.last()).toActivate(a)
+      expect(a.last()).to.activate(a)
     })
 
     it('should be ended if source was ended', () => {
-      expect(send(prop(), ['<end>']).last()).toEmit(['<end:current>'])
-      expect(send(prop(), [1, '<end>']).last()).toEmit([{current: 1}, '<end:current>'])
+      expect(send(prop(), ['<end>']).last()).to.emit(['<end:current>'])
+      expect(send(prop(), [1, '<end>']).last()).to.emit([{current: 1}, '<end:current>'])
     })
 
     it('should handle events and current', () => {
       let a = send(prop(), [1])
-      expect(a.last()).toEmit([{error: 5}, 1, '<end>'], () => send(a, [{error: 5}, '<end>']))
+      expect(a.last()).to.emit([{error: 5}, 1, '<end>'], () => send(a, [{error: 5}, '<end>']))
 
       a = send(prop(), [{error: 0}])
-      expect(a.last()).toEmit([{currentError: 0}, {error: 5}, 3, '<end>'], () => send(a, [2, {error: 5}, 3, '<end>']))
+      expect(a.last()).to.emit([{currentError: 0}, {error: 5}, 3, '<end>'], () => send(a, [2, {error: 5}, 3, '<end>']))
     })
   })
 })

--- a/test/specs/later.js
+++ b/test/specs/later.js
@@ -1,5 +1,4 @@
-const {Kefir} = require('../test-helpers')
-const {expect} = require('../test-helpers')
+const {value, end, Kefir, expect} = require('../test-helpers')
 
 describe('later', () => {
   it('should return stream', () => {
@@ -7,6 +6,6 @@ describe('later', () => {
   })
 
   it('should emmit value after interval then end', () => {
-    expect(Kefir.later(100, 1)).to.emitInTime([[100, 1], [100, '<end>']])
+    expect(Kefir.later(100, 1)).to.emitInTime([[100, value(1)], [100, end()]])
   })
 })

--- a/test/specs/later.js
+++ b/test/specs/later.js
@@ -1,11 +1,12 @@
-const Kefir = require('../../dist/kefir')
+const {Kefir} = require('../test-helpers')
+const {expect} = require('../test-helpers')
 
 describe('later', () => {
   it('should return stream', () => {
-    expect(Kefir.later(100, 1)).toBeStream()
+    expect(Kefir.later(100, 1)).to.be.observable.stream()
   })
 
   it('should emmit value after interval then end', () => {
-    expect(Kefir.later(100, 1)).toEmitInTime([[100, 1], [100, '<end>']])
+    expect(Kefir.later(100, 1)).to.emitInTime([[100, 1], [100, '<end>']])
   })
 })

--- a/test/specs/log.js
+++ b/test/specs/log.js
@@ -1,50 +1,54 @@
-const {stream, send} = require('../test-helpers')
+const {stream, send, expect} = require('../test-helpers')
+const sinon = require('sinon')
 
 describe('log', () => {
   describe('adding', () => {
     it('should return the stream', () => {
-      expect(stream().log()).toBeStream()
+      expect(stream().log()).to.be.observable.stream()
     })
 
     it('should activate the stream', () => {
       const a = stream().log()
-      expect(a).toBeActive()
+      expect(a).to.be.active()
     })
   })
 
   describe('removing', () => {
     it('should return the stream', () => {
-      expect(stream().log().offLog()).toBeStream()
+      expect(stream().log().offLog()).to.be.observable.stream()
     })
 
     it('should deactivate the stream', () => {
       const a = stream().log().offLog()
-      expect(a).not.toBeActive()
+      expect(a).not.to.be.active()
     })
   })
 
   describe('console', () => {
-    beforeEach(() => spyOn(console, 'log'))
+    let stub
+    beforeEach(() => stub = sinon.stub(console, 'log'))
+
+    afterEach(() => stub.restore())
 
     it('should have a default name', () => {
       const a = stream()
       a.log()
-      expect(a).toEmit([1, 2, 3], () => {
+      expect(a).to.emit([1, 2, 3], () => {
         send(a, [1, 2, 3])
-        expect(console.log).toHaveBeenCalledWith('[stream]', '<value>', 1)
-        expect(console.log).toHaveBeenCalledWith('[stream]', '<value>', 2)
-        expect(console.log).toHaveBeenCalledWith('[stream]', '<value>', 3)
+        expect(console.log).to.have.been.calledWith('[stream]', '<value>', 1)
+        expect(console.log).to.have.been.calledWith('[stream]', '<value>', 2)
+        expect(console.log).to.have.been.calledWith('[stream]', '<value>', 3)
       })
     })
 
     it('should use the name', () => {
       const a = stream()
       a.log('logged')
-      expect(a).toEmit([1, 2, 3], () => {
+      expect(a).to.emit([1, 2, 3], () => {
         send(a, [1, 2, 3])
-        expect(console.log).toHaveBeenCalledWith('logged', '<value>', 1)
-        expect(console.log).toHaveBeenCalledWith('logged', '<value>', 2)
-        expect(console.log).toHaveBeenCalledWith('logged', '<value>', 3)
+        expect(console.log).to.have.been.calledWith('logged', '<value>', 1)
+        expect(console.log).to.have.been.calledWith('logged', '<value>', 2)
+        expect(console.log).to.have.been.calledWith('logged', '<value>', 3)
       })
     })
 
@@ -52,9 +56,9 @@ describe('log', () => {
       const a = stream()
       a.log()
       a.offLog()
-      expect(a).toEmit([1, 2, 3], () => {
+      expect(a).to.emit([1, 2, 3], () => {
         send(a, [1, 2, 3])
-        expect(console.log).not.toHaveBeenCalled()
+        expect(console.log).not.to.have.been.called
       })
     })
   })

--- a/test/specs/log.js
+++ b/test/specs/log.js
@@ -1,4 +1,4 @@
-const {stream, send, expect} = require('../test-helpers')
+const {stream, send, value, error, end, expect} = require('../test-helpers')
 const sinon = require('sinon')
 
 describe('log', () => {
@@ -33,8 +33,8 @@ describe('log', () => {
     it('should have a default name', () => {
       const a = stream()
       a.log()
-      expect(a).to.emit([1, 2, 3], () => {
-        send(a, [1, 2, 3])
+      expect(a).to.emit([value(1), value(2), value(3)], () => {
+        send(a, [value(1), value(2), value(3)])
         expect(console.log).to.have.been.calledWith('[stream]', '<value>', 1)
         expect(console.log).to.have.been.calledWith('[stream]', '<value>', 2)
         expect(console.log).to.have.been.calledWith('[stream]', '<value>', 3)
@@ -44,8 +44,8 @@ describe('log', () => {
     it('should use the name', () => {
       const a = stream()
       a.log('logged')
-      expect(a).to.emit([1, 2, 3], () => {
-        send(a, [1, 2, 3])
+      expect(a).to.emit([value(1), value(2), value(3)], () => {
+        send(a, [value(1), value(2), value(3)])
         expect(console.log).to.have.been.calledWith('logged', '<value>', 1)
         expect(console.log).to.have.been.calledWith('logged', '<value>', 2)
         expect(console.log).to.have.been.calledWith('logged', '<value>', 3)
@@ -56,8 +56,8 @@ describe('log', () => {
       const a = stream()
       a.log()
       a.offLog()
-      expect(a).to.emit([1, 2, 3], () => {
-        send(a, [1, 2, 3])
+      expect(a).to.emit([value(1), value(2), value(3)], () => {
+        send(a, [value(1), value(2), value(3)])
         expect(console.log).not.to.have.been.called
       })
     })

--- a/test/specs/map-errors.js
+++ b/test/specs/map-errors.js
@@ -1,22 +1,22 @@
-const {stream, prop, send, Kefir} = require('../test-helpers')
+const {stream, prop, send, Kefir, expect} = require('../test-helpers')
 
 describe('mapErrors', () => {
   describe('stream', () => {
     it('should return stream', () => {
-      expect(stream().mapErrors(() => {})).toBeStream()
+      expect(stream().mapErrors(() => {})).to.be.observable.stream()
     })
 
     it('should activate/deactivate source', () => {
       const a = stream()
-      expect(a.mapErrors(() => {})).toActivate(a)
+      expect(a.mapErrors(() => {})).to.activate(a)
     })
 
     it('should be ended if source was ended', () =>
-      expect(send(stream(), ['<end>']).mapErrors(() => {})).toEmit(['<end:current>']))
+      expect(send(stream(), ['<end>']).mapErrors(() => {})).to.emit(['<end:current>']))
 
     it('should handle events', () => {
       const a = stream()
-      expect(a.mapErrors(x => x * 2)).toEmit([1, {error: -2}, 2, {error: -4}, '<end>'], () =>
+      expect(a.mapErrors(x => x * 2)).to.emit([1, {error: -2}, 2, {error: -4}, '<end>'], () =>
         send(a, [1, {error: -1}, 2, {error: -2}, '<end>'])
       )
     })
@@ -24,24 +24,24 @@ describe('mapErrors', () => {
 
   describe('property', () => {
     it('should return property', () => {
-      expect(prop().mapErrors(() => {})).toBeProperty()
+      expect(prop().mapErrors(() => {})).to.be.observable.property()
     })
 
     it('should activate/deactivate source', () => {
       const a = prop()
-      expect(a.mapErrors(() => {})).toActivate(a)
+      expect(a.mapErrors(() => {})).to.activate(a)
     })
 
     it('should be ended if source was ended', () =>
-      expect(send(prop(), ['<end>']).mapErrors(() => {})).toEmit(['<end:current>']))
+      expect(send(prop(), ['<end>']).mapErrors(() => {})).to.emit(['<end:current>']))
 
     it('should handle events and current', () => {
       let a = send(prop(), [1])
-      expect(a.mapErrors(x => x * 2)).toEmit([{current: 1}, 2, {error: -4}, 3, {error: -6}, '<end>'], () =>
+      expect(a.mapErrors(x => x * 2)).to.emit([{current: 1}, 2, {error: -4}, 3, {error: -6}, '<end>'], () =>
         send(a, [2, {error: -2}, 3, {error: -3}, '<end>'])
       )
       a = send(prop(), [{error: -1}])
-      expect(a.mapErrors(x => x * 2)).toEmit([{currentError: -2}, 2, {error: -4}, 3, {error: -6}, '<end>'], () =>
+      expect(a.mapErrors(x => x * 2)).to.emit([{currentError: -2}, 2, {error: -4}, 3, {error: -6}, '<end>'], () =>
         send(a, [2, {error: -2}, 3, {error: -3}, '<end>'])
       )
     })

--- a/test/specs/map.js
+++ b/test/specs/map.js
@@ -1,50 +1,50 @@
-const {stream, prop, send, Kefir} = require('../test-helpers')
+const {stream, prop, send, Kefir, expect} = require('../test-helpers')
 
 describe('map', () => {
   describe('stream', () => {
     it('should return stream', () => {
-      expect(stream().map(() => {})).toBeStream()
+      expect(stream().map(() => {})).to.be.observable.stream()
     })
 
     it('should activate/deactivate source', () => {
       const a = stream()
-      expect(a.map(() => {})).toActivate(a)
+      expect(a.map(() => {})).to.activate(a)
     })
 
     it('should be ended if source was ended', () =>
-      expect(send(stream(), ['<end>']).map(() => {})).toEmit(['<end:current>']))
+      expect(send(stream(), ['<end>']).map(() => {})).to.emit(['<end:current>']))
 
     it('should handle events', () => {
       const a = stream()
-      expect(a.map(x => x * 2)).toEmit([2, {error: 5}, 4, '<end>'], () => send(a, [1, {error: 5}, 2, '<end>']))
+      expect(a.map(x => x * 2)).to.emit([2, {error: 5}, 4, '<end>'], () => send(a, [1, {error: 5}, 2, '<end>']))
     })
 
     it('should work with default `fn`', () => {
       const a = stream()
-      expect(a.map()).toEmit([1, {error: 5}, 2, '<end>'], () => send(a, [1, {error: 5}, 2, '<end>']))
+      expect(a.map()).to.emit([1, {error: 5}, 2, '<end>'], () => send(a, [1, {error: 5}, 2, '<end>']))
     })
   })
 
   describe('property', () => {
     it('should return property', () => {
-      expect(prop().map(() => {})).toBeProperty()
+      expect(prop().map(() => {})).to.be.observable.property()
     })
 
     it('should activate/deactivate source', () => {
       const a = prop()
-      expect(a.map(() => {})).toActivate(a)
+      expect(a.map(() => {})).to.activate(a)
     })
 
     it('should be ended if source was ended', () =>
-      expect(send(prop(), ['<end>']).map(() => {})).toEmit(['<end:current>']))
+      expect(send(prop(), ['<end>']).map(() => {})).to.emit(['<end:current>']))
 
     it('should handle events and current', () => {
       let a = send(prop(), [1])
-      expect(a.map(x => x * 2)).toEmit([{current: 2}, 4, {error: 5}, 6, '<end>'], () =>
+      expect(a.map(x => x * 2)).to.emit([{current: 2}, 4, {error: 5}, 6, '<end>'], () =>
         send(a, [2, {error: 5}, 3, '<end>'])
       )
       a = send(prop(), [{error: 0}])
-      expect(a.map(x => x * 2)).toEmit([{currentError: 0}, 4, {error: 5}, 6, '<end>'], () =>
+      expect(a.map(x => x * 2)).to.emit([{currentError: 0}, 4, {error: 5}, 6, '<end>'], () =>
         send(a, [2, {error: 5}, 3, '<end>'])
       )
     })

--- a/test/specs/map.js
+++ b/test/specs/map.js
@@ -1,4 +1,4 @@
-const {stream, prop, send, Kefir, expect} = require('../test-helpers')
+const {stream, prop, send, value, error, end, expect} = require('../test-helpers')
 
 describe('map', () => {
   describe('stream', () => {
@@ -12,16 +12,20 @@ describe('map', () => {
     })
 
     it('should be ended if source was ended', () =>
-      expect(send(stream(), ['<end>']).map(() => {})).to.emit(['<end:current>']))
+      expect(send(stream(), [end()]).map(() => {})).to.emit([end({current: true})]))
 
     it('should handle events', () => {
       const a = stream()
-      expect(a.map(x => x * 2)).to.emit([2, {error: 5}, 4, '<end>'], () => send(a, [1, {error: 5}, 2, '<end>']))
+      expect(a.map(x => x * 2)).to.emit([value(2), error(5), value(4), end()], () =>
+        send(a, [value(1), error(5), value(2), end()])
+      )
     })
 
     it('should work with default `fn`', () => {
       const a = stream()
-      expect(a.map()).to.emit([1, {error: 5}, 2, '<end>'], () => send(a, [1, {error: 5}, 2, '<end>']))
+      expect(a.map()).to.emit([value(1), error(5), value(2), end()], () =>
+        send(a, [value(1), error(5), value(2), end()])
+      )
     })
   })
 
@@ -36,16 +40,16 @@ describe('map', () => {
     })
 
     it('should be ended if source was ended', () =>
-      expect(send(prop(), ['<end>']).map(() => {})).to.emit(['<end:current>']))
+      expect(send(prop(), [end()]).map(() => {})).to.emit([end({current: true})]))
 
     it('should handle events and current', () => {
-      let a = send(prop(), [1])
-      expect(a.map(x => x * 2)).to.emit([{current: 2}, 4, {error: 5}, 6, '<end>'], () =>
-        send(a, [2, {error: 5}, 3, '<end>'])
+      let a = send(prop(), [value(1)])
+      expect(a.map(x => x * 2)).to.emit([value(2, {current: true}), value(4), error(5), value(6), end()], () =>
+        send(a, [value(2), error(5), value(3), end()])
       )
-      a = send(prop(), [{error: 0}])
-      expect(a.map(x => x * 2)).to.emit([{currentError: 0}, 4, {error: 5}, 6, '<end>'], () =>
-        send(a, [2, {error: 5}, 3, '<end>'])
+      a = send(prop(), [error(0)])
+      expect(a.map(x => x * 2)).to.emit([error(0, {current: true}), value(4), error(5), value(6), end()], () =>
+        send(a, [value(2), error(5), value(3), end()])
       )
     })
   })

--- a/test/specs/merge.js
+++ b/test/specs/merge.js
@@ -1,38 +1,38 @@
-const {stream, prop, send, activate, deactivate, Kefir} = require('../test-helpers')
+const {stream, prop, send, activate, deactivate, Kefir, expect} = require('../test-helpers')
 
 describe('merge', () => {
   it('should return stream', () => {
-    expect(Kefir.merge([])).toBeStream()
-    expect(Kefir.merge([stream(), prop()])).toBeStream()
-    expect(stream().merge(stream())).toBeStream()
-    expect(prop().merge(prop())).toBeStream()
+    expect(Kefir.merge([])).to.be.observable.stream()
+    expect(Kefir.merge([stream(), prop()])).to.be.observable.stream()
+    expect(stream().merge(stream())).to.be.observable.stream()
+    expect(prop().merge(prop())).to.be.observable.stream()
   })
 
   it('should be ended if empty array provided', () => {
-    expect(Kefir.merge([])).toEmit(['<end:current>'])
+    expect(Kefir.merge([])).to.emit(['<end:current>'])
   })
 
   it('should be ended if array of ended observables provided', () => {
     const a = send(stream(), ['<end>'])
     const b = send(prop(), ['<end>'])
     const c = send(stream(), ['<end>'])
-    expect(Kefir.merge([a, b, c])).toEmit(['<end:current>'])
-    expect(a.merge(b)).toEmit(['<end:current>'])
+    expect(Kefir.merge([a, b, c])).to.emit(['<end:current>'])
+    expect(a.merge(b)).to.emit(['<end:current>'])
   })
 
   it('should activate sources', () => {
     const a = stream()
     const b = prop()
     const c = stream()
-    expect(Kefir.merge([a, b, c])).toActivate(a, b, c)
-    expect(a.merge(b)).toActivate(a, b)
+    expect(Kefir.merge([a, b, c])).to.activate(a, b, c)
+    expect(a.merge(b)).to.activate(a, b)
   })
 
   it('should deliver events from observables, then end when all of them end', () => {
     let a = stream()
     let b = send(prop(), [0])
     const c = stream()
-    expect(Kefir.merge([a, b, c])).toEmit([{current: 0}, 1, 2, 3, 4, 5, 6, '<end>'], () => {
+    expect(Kefir.merge([a, b, c])).to.emit([{current: 0}, 1, 2, 3, 4, 5, 6, '<end>'], () => {
       send(a, [1])
       send(b, [2])
       send(c, [3])
@@ -42,7 +42,7 @@ describe('merge', () => {
     })
     a = stream()
     b = send(prop(), [0])
-    expect(a.merge(b)).toEmit([{current: 0}, 1, 2, 3, '<end>'], () => {
+    expect(a.merge(b)).to.emit([{current: 0}, 1, 2, 3, '<end>'], () => {
       send(a, [1])
       send(b, [2])
       send(a, ['<end>'])
@@ -56,31 +56,31 @@ describe('merge', () => {
     const c = send(prop(), [2])
 
     let merge = Kefir.merge([a, b, c])
-    expect(merge).toEmit([{current: 0}, {current: 1}, {current: 2}])
+    expect(merge).to.emit([{current: 0}, {current: 1}, {current: 2}])
 
     merge = Kefir.merge([a, b, c])
     activate(merge)
-    expect(merge).toEmit([])
+    expect(merge).to.emit([])
 
     merge = Kefir.merge([a, b, c])
     activate(merge)
     deactivate(merge)
-    expect(merge).toEmit([{current: 0}, {current: 1}, {current: 2}])
+    expect(merge).to.emit([{current: 0}, {current: 1}, {current: 2}])
   })
 
   it('errors should flow', () => {
     let a = stream()
     let b = prop()
     let c = stream()
-    expect(Kefir.merge([a, b, c])).errorsToFlow(a)
+    expect(Kefir.merge([a, b, c])).to.flowErrors(a)
     a = stream()
     b = prop()
     c = stream()
-    expect(Kefir.merge([a, b, c])).errorsToFlow(b)
+    expect(Kefir.merge([a, b, c])).to.flowErrors(b)
     a = stream()
     b = prop()
     c = stream()
-    expect(Kefir.merge([a, b, c])).errorsToFlow(c)
+    expect(Kefir.merge([a, b, c])).to.flowErrors(c)
   })
 
   it('should work correctly when unsuscribing after one sync event', () => {
@@ -88,6 +88,6 @@ describe('merge', () => {
     const b = Kefir.interval(1000, 1)
     const c = a.merge(b)
     activate(c.take(1))
-    expect(b).not.toBeActive()
+    expect(b).not.to.be.active()
   })
 })

--- a/test/specs/never.js
+++ b/test/specs/never.js
@@ -1,11 +1,11 @@
-const Kefir = require('../../dist/kefir')
+const {Kefir, expect} = require('../test-helpers')
 
 describe('never', () => {
   it('should return stream', () => {
-    expect(Kefir.never()).toBeStream()
+    expect(Kefir.never()).to.be.observable.stream()
   })
 
   it('should be ended', () => {
-    expect(Kefir.never()).toEmit(['<end:current>'])
+    expect(Kefir.never()).to.emit(['<end:current>'])
   })
 })

--- a/test/specs/never.js
+++ b/test/specs/never.js
@@ -1,4 +1,4 @@
-const {Kefir, expect} = require('../test-helpers')
+const {end, Kefir, expect} = require('../test-helpers')
 
 describe('never', () => {
   it('should return stream', () => {
@@ -6,6 +6,6 @@ describe('never', () => {
   })
 
   it('should be ended', () => {
-    expect(Kefir.never()).to.emit(['<end:current>'])
+    expect(Kefir.never()).to.emit([end({current: true})])
   })
 })

--- a/test/specs/pool.js
+++ b/test/specs/pool.js
@@ -1,14 +1,14 @@
-const {stream, prop, send, activate, deactivate, Kefir} = require('../test-helpers')
+const {stream, prop, send, activate, deactivate, Kefir, expect} = require('../test-helpers')
 
 describe('pool', () => {
   it('should return stream', () => {
-    expect(Kefir.pool()).toBeStream()
-    expect(new Kefir.Pool()).toBeStream()
+    expect(Kefir.pool()).to.be.observable.stream()
+    expect(new Kefir.Pool()).to.be.observable.stream()
   })
 
   it('should return pool', () => {
-    expect(Kefir.pool()).toBePool()
-    expect(new Kefir.Pool()).toBePool()
+    expect(Kefir.pool()).to.be.pool()
+    expect(new Kefir.Pool()).to.be.pool()
   })
 
   it('should activate sources', () => {
@@ -16,10 +16,10 @@ describe('pool', () => {
     const b = prop()
     const c = stream()
     const pool = Kefir.pool().plug(a).plug(b).plug(c)
-    expect(pool).toActivate(a, b, c)
+    expect(pool).to.activate(a, b, c)
     pool.unplug(b)
-    expect(pool).toActivate(a, c)
-    expect(pool).not.toActivate(b)
+    expect(pool).to.activate(a, c)
+    expect(pool).not.to.activate(b)
   })
 
   it('should deliver events from observables', () => {
@@ -27,7 +27,7 @@ describe('pool', () => {
     const b = send(prop(), [0])
     const c = stream()
     const pool = Kefir.pool().plug(a).plug(b).plug(c)
-    expect(pool).toEmit([{current: 0}, 1, 2, 3, 4, 5, 6], () => {
+    expect(pool).to.emit([{current: 0}, 1, 2, 3, 4, 5, 6], () => {
       send(a, [1])
       send(b, [2])
       send(c, [3])
@@ -43,16 +43,16 @@ describe('pool', () => {
     const c = send(prop(), [2])
 
     let pool = Kefir.pool().plug(a).plug(b).plug(c)
-    expect(pool).toEmit([{current: 0}, {current: 1}, {current: 2}])
+    expect(pool).to.emit([{current: 0}, {current: 1}, {current: 2}])
 
     pool = Kefir.pool().plug(a).plug(b).plug(c)
     activate(pool)
-    expect(pool).toEmit([])
+    expect(pool).to.emit([])
 
     pool = Kefir.pool().plug(a).plug(b).plug(c)
     activate(pool)
     deactivate(pool)
-    expect(pool).toEmit([{current: 0}, {current: 1}, {current: 2}])
+    expect(pool).to.emit([{current: 0}, {current: 1}, {current: 2}])
   })
 
   it('should not deliver events from removed sources', () => {
@@ -60,7 +60,7 @@ describe('pool', () => {
     const b = send(prop(), [0])
     const c = stream()
     const pool = Kefir.pool().plug(a).plug(b).plug(c).unplug(b)
-    expect(pool).toEmit([1, 3, 5, 6], () => {
+    expect(pool).to.emit([1, 3, 5, 6], () => {
       send(a, [1])
       send(b, [2])
       send(c, [3])
@@ -74,7 +74,7 @@ describe('pool', () => {
     const pool = Kefir.pool()
     const b = send(prop(), [1])
     const c = send(prop(), [2])
-    expect(pool).toEmit([1, 2], () => {
+    expect(pool).to.emit([1, 2], () => {
       pool.plug(b)
       return pool.plug(c)
     })
@@ -86,16 +86,16 @@ describe('pool', () => {
     const c = stream()
     const pool = Kefir.pool()
     pool.plug(a)
-    expect(pool).errorsToFlow(a)
+    expect(pool).to.flowErrors(a)
     pool.unplug(a)
-    expect(pool).not.errorsToFlow(a)
+    expect(pool).not.to.flowErrors(a)
     pool.plug(a)
     pool.plug(b)
-    expect(pool).errorsToFlow(a)
-    expect(pool).errorsToFlow(b)
+    expect(pool).to.flowErrors(a)
+    expect(pool).to.flowErrors(b)
     pool.unplug(b)
-    expect(pool).not.errorsToFlow(b)
+    expect(pool).not.to.flowErrors(b)
     pool.plug(c)
-    expect(pool).errorsToFlow(c)
+    expect(pool).to.flowErrors(c)
   })
 })

--- a/test/specs/property.js
+++ b/test/specs/property.js
@@ -1,26 +1,26 @@
-const {prop, send, activate, Kefir} = require('../test-helpers')
+const {prop, send, activate, Kefir, expect} = require('../test-helpers')
 const sinon = require('sinon')
 
 describe('Property', () => {
   describe('new', () => {
     it('should create a Property', () => {
-      expect(prop()).toBeProperty()
-      expect(new Kefir.Property()).toBeProperty()
+      expect(prop()).to.be.observable.property()
+      expect(new Kefir.Property()).to.be.observable.property()
     })
 
     it('should not be ended', () => {
-      expect(prop()).toEmit([])
+      expect(prop()).to.emit([])
     })
 
     it('should not be active', () => {
-      expect(prop()).not.toBeActive()
+      expect(prop()).not.to.be.active()
     })
   })
 
   describe('end', () => {
     it('should end when `end` sent', () => {
       const s = prop()
-      expect(s).toEmit(['<end>'], () => send(s, ['<end>']))
+      expect(s).to.emit(['<end>'], () => send(s, ['<end>']))
     })
 
     it('should call `end` subscribers', () => {
@@ -28,9 +28,9 @@ describe('Property', () => {
       const log = []
       s.onEnd(() => log.push(1))
       s.onEnd(() => log.push(2))
-      expect(log).toEqual([])
+      expect(log).to.deep.equal([])
       send(s, ['<end>'])
-      expect(log).toEqual([1, 2])
+      expect(log).to.deep.equal([1, 2])
     })
 
     it('should call `end` subscribers on already ended property', () => {
@@ -39,20 +39,20 @@ describe('Property', () => {
       const log = []
       s.onEnd(() => log.push(1))
       s.onEnd(() => log.push(2))
-      expect(log).toEqual([1, 2])
+      expect(log).to.deep.equal([1, 2])
     })
 
     it('should deactivate on end', () => {
       const s = prop()
       activate(s)
-      expect(s).toBeActive()
+      expect(s).to.be.active()
       send(s, ['<end>'])
-      expect(s).not.toBeActive()
+      expect(s).not.to.be.active()
     })
 
     it('should stop deliver new values after end', () => {
       const s = prop()
-      expect(s).toEmit([1, 2, '<end>'], () => send(s, [1, 2, '<end>', 3]))
+      expect(s).to.emit([1, 2, '<end>'], () => send(s, [1, 2, '<end>', 3]))
     })
 
     it('calling ._emitEnd twice should work fine', () => {
@@ -64,7 +64,7 @@ describe('Property', () => {
       } catch (e) {
         err = e
       }
-      expect(err && err.message).toBe(undefined)
+      expect(err && err.message).to.equal(undefined)
     })
 
     it('calling ._emitEnd in an end handler should work fine', () => {
@@ -76,7 +76,7 @@ describe('Property', () => {
       } catch (e) {
         err = e
       }
-      expect(err && err.message).toBe(undefined)
+      expect(err && err.message).to.equal(undefined)
     })
   })
 
@@ -84,25 +84,25 @@ describe('Property', () => {
     it('should activate when first subscriber added (value)', () => {
       const s = prop()
       s.onValue(() => {})
-      expect(s).toBeActive()
+      expect(s).to.be.active()
     })
 
     it('should activate when first subscriber added (error)', () => {
       const s = prop()
       s.onError(() => {})
-      expect(s).toBeActive()
+      expect(s).to.be.active()
     })
 
     it('should activate when first subscriber added (end)', () => {
       const s = prop()
       s.onEnd(() => {})
-      expect(s).toBeActive()
+      expect(s).to.be.active()
     })
 
     it('should activate when first subscriber added (any)', () => {
       const s = prop()
       s.onAny(() => {})
-      expect(s).toBeActive()
+      expect(s).to.be.active()
     })
 
     it('should deactivate when all subscribers removed', () => {
@@ -119,21 +119,21 @@ describe('Property', () => {
       s.offAny(any1)
       s.offAny(any2)
       s.offEnd(end1)
-      expect(s).toBeActive()
+      expect(s).to.be.active()
       s.offEnd(end2)
-      expect(s).not.toBeActive()
+      expect(s).not.to.be.active()
     })
   })
 
   describe('subscribers', () => {
     it('should deliver values and current', () => {
       const s = send(prop(), [0])
-      expect(s).toEmit([{current: 0}, 1, 2], () => send(s, [1, 2]))
+      expect(s).to.emit([{current: 0}, 1, 2], () => send(s, [1, 2]))
     })
 
     it('should deliver errors and current error', () => {
       const s = send(prop(), [{error: 0}])
-      expect(s).toEmit([{currentError: 0}, {error: 1}, {error: 2}], () => send(s, [{error: 1}, {error: 2}]))
+      expect(s).to.emit([{currentError: 0}, {error: 1}, {error: 2}], () => send(s, [{error: 1}, {error: 2}]))
     })
 
     it('onValue subscribers should be called with 1 argument', () => {
@@ -142,9 +142,9 @@ describe('Property', () => {
       s.onValue(function() {
         return (count = arguments.length)
       })
-      expect(count).toBe(1)
+      expect(count).to.equal(1)
       send(s, [1])
-      expect(count).toBe(1)
+      expect(count).to.equal(1)
     })
 
     it('onError subscribers should be called with 1 argument', () => {
@@ -153,9 +153,9 @@ describe('Property', () => {
       s.onError(function() {
         return (count = arguments.length)
       })
-      expect(count).toBe(1)
+      expect(count).to.equal(1)
       send(s, [{error: 1}])
-      expect(count).toBe(1)
+      expect(count).to.equal(1)
     })
 
     it('onAny subscribers should be called with 1 arguments', () => {
@@ -164,9 +164,9 @@ describe('Property', () => {
       s.onAny(function() {
         return (count = arguments.length)
       })
-      expect(count).toBe(1)
+      expect(count).to.equal(1)
       send(s, [1])
-      expect(count).toBe(1)
+      expect(count).to.equal(1)
     })
 
     it('onEnd subscribers should be called with 0 arguments', () => {
@@ -176,20 +176,20 @@ describe('Property', () => {
         return (count = arguments.length)
       })
       send(s, ['<end>'])
-      expect(count).toBe(0)
+      expect(count).to.equal(0)
       s.onEnd(function() {
         return (count = arguments.length)
       })
-      expect(count).toBe(0)
+      expect(count).to.equal(0)
     })
 
     it("can't have current value and error at same time", () => {
       const p = send(prop(), [0])
-      expect(p).toEmit([{current: 0}])
+      expect(p).to.emit([{current: 0}])
       send(p, [{error: 1}])
-      expect(p).toEmit([{currentError: 1}])
+      expect(p).to.emit([{currentError: 1}])
       send(p, [2])
-      expect(p).toEmit([{current: 2}])
+      expect(p).to.emit([{current: 2}])
     })
 
     it('should update catched current value before dispatching it', () => {
@@ -201,7 +201,7 @@ describe('Property', () => {
         }
       })
       send(p, [1])
-      expect(spy.args).toEqual([[1]])
+      expect(spy.args).to.deep.equal([[1]])
     })
 
     it('should update catched current error before dispatching it', () => {
@@ -213,7 +213,7 @@ describe('Property', () => {
         }
       })
       send(p, [{error: 1}])
-      expect(spy.args).toEqual([[1]])
+      expect(spy.args).to.deep.equal([[1]])
     })
   })
 })

--- a/test/specs/repeat.js
+++ b/test/specs/repeat.js
@@ -1,23 +1,23 @@
-const {stream, prop, send, activate, deactivate, Kefir} = require('../test-helpers')
+const {stream, prop, send, activate, deactivate, Kefir, expect} = require('../test-helpers')
 
 describe('repeat', () => {
   it('should return stream', () => {
-    expect(Kefir.repeat()).toBeStream()
+    expect(Kefir.repeat()).to.be.observable.stream()
   })
 
   it('should work correctly (with .constant)', () => {
     const a = Kefir.repeat(i => Kefir[i === 2 ? 'constantError' : 'constant'](i))
-    expect(a.take(3)).toEmit([{current: 0}, {current: 1}, {currentError: 2}, {current: 3}, '<end:current>'])
+    expect(a.take(3)).to.emit([{current: 0}, {current: 1}, {currentError: 2}, {current: 3}, '<end:current>'])
   })
 
   it('should work correctly (with .later)', () => {
     const a = Kefir.repeat(i => Kefir.later(100, i))
-    expect(a.take(3)).toEmitInTime([[100, 0], [200, 1], [300, 2], [300, '<end>']])
+    expect(a.take(3)).to.emitInTime([[100, 0], [200, 1], [300, 2], [300, '<end>']])
   })
 
   it('should work correctly (with .sequentially)', () => {
     const a = Kefir.repeat(i => Kefir.sequentially(100, [1, 2, 3]))
-    expect(a.take(5)).toEmitInTime([[100, 1], [200, 2], [300, 3], [400, 1], [500, 2], [500, '<end>']])
+    expect(a.take(5)).to.emitInTime([[100, 1], [200, 2], [300, 3], [400, 1], [500, 2], [500, '<end>']])
   })
 
   it('should not cause stack overflow', () => {
@@ -25,7 +25,7 @@ describe('repeat', () => {
     const genConstant = () => Kefir.constant(1)
 
     const a = Kefir.repeat(genConstant).take(3000).scan(sum, 0).last()
-    expect(a).toEmit([{current: 3000}, '<end:current>'])
+    expect(a).to.emit([{current: 3000}, '<end:current>'])
   })
 
   it('should get new source only if previous one ended', () => {
@@ -40,20 +40,20 @@ describe('repeat', () => {
       return a
     })
 
-    expect(callsCount).toBe(0)
+    expect(callsCount).to.equal(0)
     activate(b)
-    expect(callsCount).toBe(1)
+    expect(callsCount).to.equal(1)
     deactivate(b)
     activate(b)
-    expect(callsCount).toBe(1)
+    expect(callsCount).to.equal(1)
     send(a, ['<end>'])
-    expect(callsCount).toBe(2)
+    expect(callsCount).to.equal(2)
   })
 
   it('should unsubscribe from source', () => {
     const a = stream()
     const b = Kefir.repeat(() => a)
-    expect(b).toActivate(a)
+    expect(b).to.activate(a)
   })
 
   it('should end when falsy value returned from generator', () => {
@@ -64,6 +64,6 @@ describe('repeat', () => {
         return false
       }
     })
-    expect(a).toEmit([{current: 0}, {current: 1}, {current: 2}, '<end:current>'])
+    expect(a).to.emit([{current: 0}, {current: 1}, {current: 2}, '<end:current>'])
   })
 })

--- a/test/specs/repeat.js
+++ b/test/specs/repeat.js
@@ -1,4 +1,4 @@
-const {stream, prop, send, activate, deactivate, Kefir, expect} = require('../test-helpers')
+const {stream, prop, send, value, error, end, activate, deactivate, Kefir, expect} = require('../test-helpers')
 
 describe('repeat', () => {
   it('should return stream', () => {
@@ -7,17 +7,30 @@ describe('repeat', () => {
 
   it('should work correctly (with .constant)', () => {
     const a = Kefir.repeat(i => Kefir[i === 2 ? 'constantError' : 'constant'](i))
-    expect(a.take(3)).to.emit([{current: 0}, {current: 1}, {currentError: 2}, {current: 3}, '<end:current>'])
+    expect(a.take(3)).to.emit([
+      value(0, {current: true}),
+      value(1, {current: true}),
+      error(2, {current: true}),
+      value(3, {current: true}),
+      end({current: true}),
+    ])
   })
 
   it('should work correctly (with .later)', () => {
     const a = Kefir.repeat(i => Kefir.later(100, i))
-    expect(a.take(3)).to.emitInTime([[100, 0], [200, 1], [300, 2], [300, '<end>']])
+    expect(a.take(3)).to.emitInTime([[100, value(0)], [200, value(1)], [300, value(2)], [300, end()]])
   })
 
   it('should work correctly (with .sequentially)', () => {
     const a = Kefir.repeat(i => Kefir.sequentially(100, [1, 2, 3]))
-    expect(a.take(5)).to.emitInTime([[100, 1], [200, 2], [300, 3], [400, 1], [500, 2], [500, '<end>']])
+    expect(a.take(5)).to.emitInTime([
+      [100, value(1)],
+      [200, value(2)],
+      [300, value(3)],
+      [400, value(1)],
+      [500, value(2)],
+      [500, end()],
+    ])
   })
 
   it('should not cause stack overflow', () => {
@@ -25,7 +38,7 @@ describe('repeat', () => {
     const genConstant = () => Kefir.constant(1)
 
     const a = Kefir.repeat(genConstant).take(3000).scan(sum, 0).last()
-    expect(a).to.emit([{current: 3000}, '<end:current>'])
+    expect(a).to.emit([value(3000, {current: true}), end({current: true})])
   })
 
   it('should get new source only if previous one ended', () => {
@@ -46,7 +59,7 @@ describe('repeat', () => {
     deactivate(b)
     activate(b)
     expect(callsCount).to.equal(1)
-    send(a, ['<end>'])
+    send(a, [end()])
     expect(callsCount).to.equal(2)
   })
 
@@ -64,6 +77,11 @@ describe('repeat', () => {
         return false
       }
     })
-    expect(a).to.emit([{current: 0}, {current: 1}, {current: 2}, '<end:current>'])
+    expect(a).to.emit([
+      value(0, {current: true}),
+      value(1, {current: true}),
+      value(2, {current: true}),
+      end({current: true}),
+    ])
   })
 })

--- a/test/specs/sampled-by.js
+++ b/test/specs/sampled-by.js
@@ -1,34 +1,34 @@
-const {stream, prop, send, activate, deactivate, Kefir} = require('../test-helpers')
+const {stream, prop, send, activate, deactivate, Kefir, expect} = require('../test-helpers')
 
 describe('sampledBy', () => {
   it('should return stream', () => {
-    expect(prop().sampledBy(stream())).toBeStream()
-    expect(stream().sampledBy(prop())).toBeStream()
+    expect(prop().sampledBy(stream())).to.be.observable.stream()
+    expect(stream().sampledBy(prop())).to.be.observable.stream()
   })
 
   it('should be ended if array of ended observables provided', () => {
     const a = send(stream(), ['<end>'])
-    expect(prop().sampledBy(a)).toEmit(['<end:current>'])
+    expect(prop().sampledBy(a)).to.emit(['<end:current>'])
   })
 
   it('should be ended and emmit current (once) if array of ended properties provided and each of them has current', () => {
     const a = send(prop(), [1, '<end>'])
     const b = send(prop(), [2, '<end>'])
     const s2 = a.sampledBy(b)
-    expect(s2).toEmit([{current: 1}, '<end:current>'])
-    expect(s2).toEmit(['<end:current>'])
+    expect(s2).to.emit([{current: 1}, '<end:current>'])
+    expect(s2).to.emit(['<end:current>'])
   })
 
   it('should activate sources', () => {
     const a = stream()
     const b = prop()
-    expect(a.sampledBy(b)).toActivate(a, b)
+    expect(a.sampledBy(b)).to.activate(a, b)
   })
 
   it('should handle events and current from observables', () => {
     const a = stream()
     const b = send(prop(), [0])
-    expect(a.sampledBy(b)).toEmit([2, 4, 4, '<end>'], () => {
+    expect(a.sampledBy(b)).to.emit([2, 4, 4, '<end>'], () => {
       send(b, [1])
       send(a, [2])
       send(b, [3])
@@ -41,7 +41,7 @@ describe('sampledBy', () => {
     const join = (...args) => args.join('+')
     const a = stream()
     const b = send(prop(), [0])
-    expect(a.sampledBy(b, join)).toEmit(['2+3', '4+5', '4+6', '<end>'], () => {
+    expect(a.sampledBy(b, join)).to.emit(['2+3', '4+5', '4+6', '<end>'], () => {
       send(b, [1])
       send(a, [2])
       send(b, [3])
@@ -58,7 +58,7 @@ describe('sampledBy', () => {
     activate(s1)
     activate(s2)
     deactivate(s2)
-    expect(s1).toEmit([0], () => send(b, [1]))
+    expect(s1).to.emit([0], () => send(b, [1]))
   })
 
   // https://github.com/rpominov/kefir/issues/98
@@ -66,6 +66,6 @@ describe('sampledBy', () => {
     const a = stream()
     const b = a.map(x => x + 2)
     const c = a.map(x => x * 2)
-    expect(b.sampledBy(c, (x, y) => [x, y])).toEmit([[3, 2], [4, 4], [5, 6]], () => send(a, [1, 2, 3]))
+    expect(b.sampledBy(c, (x, y) => [x, y])).to.emit([[3, 2], [4, 4], [5, 6]], () => send(a, [1, 2, 3]))
   })
 })

--- a/test/specs/sampled-by.js
+++ b/test/specs/sampled-by.js
@@ -1,4 +1,4 @@
-const {stream, prop, send, activate, deactivate, Kefir, expect} = require('../test-helpers')
+const {stream, prop, send, value, error, end, activate, deactivate, Kefir, expect} = require('../test-helpers')
 
 describe('sampledBy', () => {
   it('should return stream', () => {
@@ -7,16 +7,16 @@ describe('sampledBy', () => {
   })
 
   it('should be ended if array of ended observables provided', () => {
-    const a = send(stream(), ['<end>'])
-    expect(prop().sampledBy(a)).to.emit(['<end:current>'])
+    const a = send(stream(), [end()])
+    expect(prop().sampledBy(a)).to.emit([end({current: true})])
   })
 
   it('should be ended and emmit current (once) if array of ended properties provided and each of them has current', () => {
-    const a = send(prop(), [1, '<end>'])
-    const b = send(prop(), [2, '<end>'])
+    const a = send(prop(), [value(1), end()])
+    const b = send(prop(), [value(2), end()])
     const s2 = a.sampledBy(b)
-    expect(s2).to.emit([{current: 1}, '<end:current>'])
-    expect(s2).to.emit(['<end:current>'])
+    expect(s2).to.emit([value(1, {current: true}), end({current: true})])
+    expect(s2).to.emit([end({current: true})])
   })
 
   it('should activate sources', () => {
@@ -27,38 +27,38 @@ describe('sampledBy', () => {
 
   it('should handle events and current from observables', () => {
     const a = stream()
-    const b = send(prop(), [0])
-    expect(a.sampledBy(b)).to.emit([2, 4, 4, '<end>'], () => {
-      send(b, [1])
-      send(a, [2])
-      send(b, [3])
-      send(a, [4])
-      send(b, [5, 6, '<end>'])
+    const b = send(prop(), [value(0)])
+    expect(a.sampledBy(b)).to.emit([value(2), value(4), value(4), end()], () => {
+      send(b, [value(1)])
+      send(a, [value(2)])
+      send(b, [value(3)])
+      send(a, [value(4)])
+      send(b, [value(5), value(6), end()])
     })
   })
 
   it('should accept optional combinator function', () => {
     const join = (...args) => args.join('+')
     const a = stream()
-    const b = send(prop(), [0])
-    expect(a.sampledBy(b, join)).to.emit(['2+3', '4+5', '4+6', '<end>'], () => {
-      send(b, [1])
-      send(a, [2])
-      send(b, [3])
-      send(a, [4])
-      send(b, [5, 6, '<end>'])
+    const b = send(prop(), [value(0)])
+    expect(a.sampledBy(b, join)).to.emit([value('2+3'), value('4+5'), value('4+6'), end()], () => {
+      send(b, [value(1)])
+      send(a, [value(2)])
+      send(b, [value(3)])
+      send(a, [value(4)])
+      send(b, [value(5), value(6), end()])
     })
   })
 
   it('one sampledBy should remove listeners of another', () => {
-    const a = send(prop(), [0])
+    const a = send(prop(), [value(0)])
     const b = stream()
     const s1 = a.sampledBy(b)
     const s2 = a.sampledBy(b)
     activate(s1)
     activate(s2)
     deactivate(s2)
-    expect(s1).to.emit([0], () => send(b, [1]))
+    expect(s1).to.emit([value(0)], () => send(b, [value(1)]))
   })
 
   // https://github.com/rpominov/kefir/issues/98
@@ -66,6 +66,8 @@ describe('sampledBy', () => {
     const a = stream()
     const b = a.map(x => x + 2)
     const c = a.map(x => x * 2)
-    expect(b.sampledBy(c, (x, y) => [x, y])).to.emit([[3, 2], [4, 4], [5, 6]], () => send(a, [1, 2, 3]))
+    expect(b.sampledBy(c, (x, y) => [x, y])).to.emit([value([3, 2]), value([4, 4]), value([5, 6])], () =>
+      send(a, [value(1), value(2), value(3)])
+    )
   })
 })

--- a/test/specs/scan.js
+++ b/test/specs/scan.js
@@ -1,4 +1,4 @@
-const {stream, prop, send, Kefir, activate, deactivate} = require('../test-helpers')
+const {stream, prop, send, Kefir, activate, deactivate, expect} = require('../test-helpers')
 const sinon = require('sinon')
 
 const noop = () => {}
@@ -7,30 +7,30 @@ const minus = (prev, next) => prev - next
 describe('scan', () => {
   describe('stream', () => {
     it('should return stream', () => {
-      expect(stream().scan(noop, 0)).toBeProperty()
+      expect(stream().scan(noop, 0)).to.be.observable.property()
     })
 
     it('should activate/deactivate source', () => {
       const a = stream()
-      expect(a.scan(noop, 0)).toActivate(a)
+      expect(a.scan(noop, 0)).to.activate(a)
     })
 
     it('should be ended if source was ended', () =>
-      expect(send(stream(), ['<end>']).scan(noop, 0)).toEmit([{current: 0}, '<end:current>']))
+      expect(send(stream(), ['<end>']).scan(noop, 0)).to.emit([{current: 0}, '<end:current>']))
 
     it('should handle events', () => {
       const a = stream()
-      expect(a.scan(minus, 0)).toEmit([{current: 0}, -1, -4, '<end>'], () => send(a, [1, 3, '<end>']))
+      expect(a.scan(minus, 0)).to.emit([{current: 0}, -1, -4, '<end>'], () => send(a, [1, 3, '<end>']))
     })
 
     it('if no seed provided uses first value as seed', () => {
       const a = stream()
-      expect(a.scan(minus)).toEmit([0, -1, -4, '<end>'], () => send(a, [0, 1, 3, '<end>']))
+      expect(a.scan(minus)).to.emit([0, -1, -4, '<end>'], () => send(a, [0, 1, 3, '<end>']))
     })
 
     it('errors should flow', () => {
       const a = stream()
-      expect(a.scan(minus)).errorsToFlow(a)
+      expect(a.scan(minus)).to.flowErrors(a)
     })
 
     it('should never pass a value as current result if seed specified (test with error)', () => {
@@ -40,12 +40,12 @@ describe('scan', () => {
       activate(b)
       send(a, [1, {error: 'err'}, 2, 3, '<end>'])
       deactivate(b)
-      expect(handler.args.filter(xs => typeof xs[0] === 'number')).toEqual([])
+      expect(handler.args.filter(xs => typeof xs[0] === 'number')).to.deep.equal([])
     })
 
     it('should fall back to the seed after error, if seed specified', () => {
       const a = stream()
-      expect(a.scan((res, x) => res + x, 'seed')).toEmit(
+      expect(a.scan((res, x) => res + x, 'seed')).to.emit(
         [{current: 'seed'}, 'seed1', {error: 'err'}, 'seed2', 'seed23', '<end>'],
         () => send(a, [1, {error: 'err'}, 2, 3, '<end>'])
       )
@@ -53,7 +53,7 @@ describe('scan', () => {
 
     it('should use next value after error as seed, if seed not specified', () => {
       const a = stream()
-      expect(a.scan(() => 'abc')).toEmit([1, 'abc', {error: 'err'}, 3, 'abc', '<end>'], () =>
+      expect(a.scan(() => 'abc')).to.emit([1, 'abc', {error: 'err'}, 3, 'abc', '<end>'], () =>
         send(a, [1, 2, {error: 'err'}, 3, 4, '<end>'])
       )
     })
@@ -61,30 +61,30 @@ describe('scan', () => {
 
   describe('property', () => {
     it('should return property', () => {
-      expect(prop().scan(noop, 0)).toBeProperty()
+      expect(prop().scan(noop, 0)).to.be.observable.property()
     })
 
     it('should activate/deactivate source', () => {
       const a = prop()
-      expect(a.scan(noop, 0)).toActivate(a)
+      expect(a.scan(noop, 0)).to.activate(a)
     })
 
     it('should be ended if source was ended', () =>
-      expect(send(prop(), ['<end>']).scan(noop, 0)).toEmit([{current: 0}, '<end:current>']))
+      expect(send(prop(), ['<end>']).scan(noop, 0)).to.emit([{current: 0}, '<end:current>']))
 
     it('should handle events and current', () => {
       const a = send(prop(), [1])
-      expect(a.scan(minus, 0)).toEmit([{current: -1}, -4, -10, '<end>'], () => send(a, [3, 6, '<end>']))
+      expect(a.scan(minus, 0)).to.emit([{current: -1}, -4, -10, '<end>'], () => send(a, [3, 6, '<end>']))
     })
 
     it('if no seed provided uses first value as seed', () => {
       const a = send(prop(), [0])
-      expect(a.scan(minus)).toEmit([{current: 0}, -1, -4, '<end>'], () => send(a, [1, 3, '<end>']))
+      expect(a.scan(minus)).to.emit([{current: 0}, -1, -4, '<end>'], () => send(a, [1, 3, '<end>']))
     })
 
     it('errors should flow', () => {
       const a = prop()
-      expect(a.scan(minus)).errorsToFlow(a)
+      expect(a.scan(minus)).to.flowErrors(a)
     })
   })
 })

--- a/test/specs/scan.js
+++ b/test/specs/scan.js
@@ -1,4 +1,4 @@
-const {stream, prop, send, Kefir, activate, deactivate, expect} = require('../test-helpers')
+const {stream, prop, send, value, error, end, Kefir, activate, deactivate, expect} = require('../test-helpers')
 const sinon = require('sinon')
 
 const noop = () => {}
@@ -16,16 +16,20 @@ describe('scan', () => {
     })
 
     it('should be ended if source was ended', () =>
-      expect(send(stream(), ['<end>']).scan(noop, 0)).to.emit([{current: 0}, '<end:current>']))
+      expect(send(stream(), [end()]).scan(noop, 0)).to.emit([value(0, {current: true}), end({current: true})]))
 
     it('should handle events', () => {
       const a = stream()
-      expect(a.scan(minus, 0)).to.emit([{current: 0}, -1, -4, '<end>'], () => send(a, [1, 3, '<end>']))
+      expect(a.scan(minus, 0)).to.emit([value(0, {current: true}), value(-1), value(-4), end()], () =>
+        send(a, [value(1), value(3), end()])
+      )
     })
 
     it('if no seed provided uses first value as seed', () => {
       const a = stream()
-      expect(a.scan(minus)).to.emit([0, -1, -4, '<end>'], () => send(a, [0, 1, 3, '<end>']))
+      expect(a.scan(minus)).to.emit([value(0), value(-1), value(-4), end()], () =>
+        send(a, [value(0), value(1), value(3), end()])
+      )
     })
 
     it('errors should flow', () => {
@@ -38,23 +42,23 @@ describe('scan', () => {
       const handler = sinon.stub().returns('abc')
       const b = a.scan(handler, 'seed')
       activate(b)
-      send(a, [1, {error: 'err'}, 2, 3, '<end>'])
+      send(a, [value(1), error('err'), value(2), value(3), end()])
       deactivate(b)
-      expect(handler.args.filter(xs => typeof xs[0] === 'number')).to.deep.equal([])
+      expect(handler.args.filter(xs => typeof xs[value(0)] === 'number')).to.deep.equal([])
     })
 
     it('should fall back to the seed after error, if seed specified', () => {
       const a = stream()
       expect(a.scan((res, x) => res + x, 'seed')).to.emit(
-        [{current: 'seed'}, 'seed1', {error: 'err'}, 'seed2', 'seed23', '<end>'],
-        () => send(a, [1, {error: 'err'}, 2, 3, '<end>'])
+        [value('seed', {current: true}), value('seed1'), error('err'), value('seed2'), value('seed23'), end()],
+        () => send(a, [value(1), error('err'), value(2), value(3), end()])
       )
     })
 
     it('should use next value after error as seed, if seed not specified', () => {
       const a = stream()
-      expect(a.scan(() => 'abc')).to.emit([1, 'abc', {error: 'err'}, 3, 'abc', '<end>'], () =>
-        send(a, [1, 2, {error: 'err'}, 3, 4, '<end>'])
+      expect(a.scan(() => 'abc')).to.emit([value(1), value('abc'), error('err'), value(3), value('abc'), end()], () =>
+        send(a, [value(1), value(2), error('err'), value(3), value(4), end()])
       )
     })
   })
@@ -70,16 +74,20 @@ describe('scan', () => {
     })
 
     it('should be ended if source was ended', () =>
-      expect(send(prop(), ['<end>']).scan(noop, 0)).to.emit([{current: 0}, '<end:current>']))
+      expect(send(prop(), [end()]).scan(noop, 0)).to.emit([value(0, {current: true}), end({current: true})]))
 
     it('should handle events and current', () => {
-      const a = send(prop(), [1])
-      expect(a.scan(minus, 0)).to.emit([{current: -1}, -4, -10, '<end>'], () => send(a, [3, 6, '<end>']))
+      const a = send(prop(), [value(1)])
+      expect(a.scan(minus, 0)).to.emit([value(-1, {current: true}), value(-4), value(-10), end()], () =>
+        send(a, [value(3), value(6), end()])
+      )
     })
 
     it('if no seed provided uses first value as seed', () => {
-      const a = send(prop(), [0])
-      expect(a.scan(minus)).to.emit([{current: 0}, -1, -4, '<end>'], () => send(a, [1, 3, '<end>']))
+      const a = send(prop(), [value(0)])
+      expect(a.scan(minus)).to.emit([value(0, {current: true}), value(-1), value(-4), end()], () =>
+        send(a, [value(1), value(3), end()])
+      )
     })
 
     it('errors should flow', () => {

--- a/test/specs/sequentially.js
+++ b/test/specs/sequentially.js
@@ -1,15 +1,15 @@
-const Kefir = require('../../dist/kefir')
+const {Kefir, expect} = require('../test-helpers')
 
 describe('sequentially', () => {
   it('should return stream', () => {
-    expect(Kefir.sequentially(100, [1, 2, 3])).toBeStream()
+    expect(Kefir.sequentially(100, [1, 2, 3])).to.be.observable.stream()
   })
 
   it('should be ended if empty array provided', () => {
-    expect(Kefir.sequentially(100, [])).toEmitInTime([[0, '<end:current>']])
+    expect(Kefir.sequentially(100, [])).to.emitInTime([[0, '<end:current>']])
   })
 
   it('should emmit values at certain time then end', () => {
-    expect(Kefir.sequentially(100, [1, 2, 3])).toEmitInTime([[100, 1], [200, 2], [300, 3], [300, '<end>']])
+    expect(Kefir.sequentially(100, [1, 2, 3])).to.emitInTime([[100, 1], [200, 2], [300, 3], [300, '<end>']])
   })
 })

--- a/test/specs/sequentially.js
+++ b/test/specs/sequentially.js
@@ -1,4 +1,4 @@
-const {Kefir, expect} = require('../test-helpers')
+const {value, end, Kefir, expect} = require('../test-helpers')
 
 describe('sequentially', () => {
   it('should return stream', () => {
@@ -6,10 +6,15 @@ describe('sequentially', () => {
   })
 
   it('should be ended if empty array provided', () => {
-    expect(Kefir.sequentially(100, [])).to.emitInTime([[0, '<end:current>']])
+    expect(Kefir.sequentially(100, [])).to.emitInTime([[0, end({current: true})]])
   })
 
   it('should emmit values at certain time then end', () => {
-    expect(Kefir.sequentially(100, [1, 2, 3])).to.emitInTime([[100, 1], [200, 2], [300, 3], [300, '<end>']])
+    expect(Kefir.sequentially(100, [1, 2, 3])).to.emitInTime([
+      [100, value(1)],
+      [200, value(2)],
+      [300, value(3)],
+      [300, end()],
+    ])
   })
 })

--- a/test/specs/skip-duplicates.js
+++ b/test/specs/skip-duplicates.js
@@ -1,34 +1,34 @@
-const {stream, prop, send, Kefir} = require('../test-helpers')
+const {stream, prop, send, Kefir, expect} = require('../test-helpers')
 
 describe('skipDuplicates', () => {
   const roundlyEqual = (a, b) => Math.round(a) === Math.round(b)
 
   describe('stream', () => {
     it('should return stream', () => {
-      expect(stream().skipDuplicates()).toBeStream()
+      expect(stream().skipDuplicates()).to.be.observable.stream()
     })
 
     it('should activate/deactivate source', () => {
       const a = stream()
-      expect(a.skipDuplicates()).toActivate(a)
+      expect(a.skipDuplicates()).to.activate(a)
     })
 
     it('should be ended if source was ended', () =>
-      expect(send(stream(), ['<end>']).skipDuplicates()).toEmit(['<end:current>']))
+      expect(send(stream(), ['<end>']).skipDuplicates()).to.emit(['<end:current>']))
 
     it('should handle events (default comparator)', () => {
       const a = stream()
-      expect(a.skipDuplicates()).toEmit([1, 2, 3, '<end>'], () => send(a, [1, 1, 2, 3, 3, '<end>']))
+      expect(a.skipDuplicates()).to.emit([1, 2, 3, '<end>'], () => send(a, [1, 1, 2, 3, 3, '<end>']))
     })
 
     it('should handle events (custom comparator)', () => {
       const a = stream()
-      expect(a.skipDuplicates(roundlyEqual)).toEmit([1, 2, 3.8, '<end>'], () => send(a, [1, 1.1, 2, 3.8, 4, '<end>']))
+      expect(a.skipDuplicates(roundlyEqual)).to.emit([1, 2, 3.8, '<end>'], () => send(a, [1, 1.1, 2, 3.8, 4, '<end>']))
     })
 
     it('errors should flow', () => {
       const a = stream()
-      expect(a.skipDuplicates()).errorsToFlow(a)
+      expect(a.skipDuplicates()).to.flowErrors(a)
     })
 
     it('should help with creating circular dependencies', () => {
@@ -38,38 +38,38 @@ describe('skipDuplicates', () => {
       const b = Kefir.pool()
       b.plug(a)
       b.plug(b.map(x => x).skipDuplicates())
-      expect(b).toEmit([1, 1], () => send(a, [1]))
+      expect(b).to.emit([1, 1], () => send(a, [1]))
     })
   })
 
   describe('property', () => {
     it('should return property', () => {
-      expect(prop().skipDuplicates()).toBeProperty()
+      expect(prop().skipDuplicates()).to.be.observable.property()
     })
 
     it('should activate/deactivate source', () => {
       const a = prop()
-      expect(a.skipDuplicates()).toActivate(a)
+      expect(a.skipDuplicates()).to.activate(a)
     })
 
     it('should be ended if source was ended', () =>
-      expect(send(prop(), ['<end>']).skipDuplicates()).toEmit(['<end:current>']))
+      expect(send(prop(), ['<end>']).skipDuplicates()).to.emit(['<end:current>']))
 
     it('should handle events and current (default comparator)', () => {
       const a = send(prop(), [1])
-      expect(a.skipDuplicates()).toEmit([{current: 1}, 2, 3, '<end>'], () => send(a, [1, 1, 2, 3, 3, '<end>']))
+      expect(a.skipDuplicates()).to.emit([{current: 1}, 2, 3, '<end>'], () => send(a, [1, 1, 2, 3, 3, '<end>']))
     })
 
     it('should handle events and current (custom comparator)', () => {
       const a = send(prop(), [1])
-      expect(a.skipDuplicates(roundlyEqual)).toEmit([{current: 1}, 2, 3, '<end>'], () =>
+      expect(a.skipDuplicates(roundlyEqual)).to.emit([{current: 1}, 2, 3, '<end>'], () =>
         send(a, [1.1, 1.2, 2, 3, 3.2, '<end>'])
       )
     })
 
     it('errors should flow', () => {
       const a = prop()
-      expect(a.skipDuplicates()).errorsToFlow(a)
+      expect(a.skipDuplicates()).to.flowErrors(a)
     })
   })
 })

--- a/test/specs/skip-until-by.js
+++ b/test/specs/skip-until-by.js
@@ -1,32 +1,32 @@
-const {stream, prop, send, Kefir, activate, deactivate} = require('../test-helpers')
+const {stream, prop, send, Kefir, activate, deactivate, expect} = require('../test-helpers')
 
 describe('skipUntilBy', () => {
   describe('common', () => {
     it('errors should flow', () => {
       let a = stream()
       let b = stream()
-      expect(a.skipUntilBy(b)).errorsToFlow(a)
+      expect(a.skipUntilBy(b)).to.flowErrors(a)
       a = stream()
       b = stream()
-      expect(a.skipUntilBy(b)).errorsToFlow(b)
+      expect(a.skipUntilBy(b)).to.flowErrors(b)
       a = prop()
       b = stream()
-      expect(a.skipUntilBy(b)).errorsToFlow(a)
+      expect(a.skipUntilBy(b)).to.flowErrors(a)
       a = prop()
       b = stream()
-      expect(a.skipUntilBy(b)).errorsToFlow(b)
+      expect(a.skipUntilBy(b)).to.flowErrors(b)
       a = stream()
       b = prop()
-      expect(a.skipUntilBy(b)).errorsToFlow(a)
+      expect(a.skipUntilBy(b)).to.flowErrors(a)
       a = stream()
       b = prop()
-      expect(a.skipUntilBy(b)).errorsToFlow(b)
+      expect(a.skipUntilBy(b)).to.flowErrors(b)
       a = prop()
       b = prop()
-      expect(a.skipUntilBy(b)).errorsToFlow(a)
+      expect(a.skipUntilBy(b)).to.flowErrors(a)
       a = prop()
       b = prop()
-      expect(a.skipUntilBy(b)).errorsToFlow(b)
+      expect(a.skipUntilBy(b)).to.flowErrors(b)
     })
 
     it('errors should flow after first value from secondary', () => {
@@ -36,19 +36,19 @@ describe('skipUntilBy', () => {
       activate(res)
       send(b, [1])
       deactivate(res)
-      expect(res).errorsToFlow(b)
+      expect(res).to.flowErrors(b)
     })
   })
 
   describe('stream, stream', () => {
     it('should return a stream', () => {
-      expect(stream().skipUntilBy(stream())).toBeStream()
+      expect(stream().skipUntilBy(stream())).to.be.observable.stream()
     })
 
     it('should activate/deactivate sources', () => {
       const a = stream()
       const b = stream()
-      expect(a.skipUntilBy(b)).toActivate(a, b)
+      expect(a.skipUntilBy(b)).to.activate(a, b)
     })
 
     it('should do activate secondary after first value from it', () => {
@@ -58,32 +58,32 @@ describe('skipUntilBy', () => {
       activate(res)
       send(b, [1])
       deactivate(res)
-      expect(res).toActivate(a)
-      expect(res).toActivate(b)
+      expect(res).to.activate(a)
+      expect(res).to.activate(b)
     })
 
     it('should be ended if primary was ended', () =>
-      expect(send(stream(), ['<end>']).skipUntilBy(stream())).toEmit(['<end:current>']))
+      expect(send(stream(), ['<end>']).skipUntilBy(stream())).to.emit(['<end:current>']))
 
     it('should be ended if secondary was ended', () =>
-      expect(stream().skipUntilBy(send(stream(), ['<end>']))).toEmit(['<end:current>']))
+      expect(stream().skipUntilBy(send(stream(), ['<end>']))).to.emit(['<end:current>']))
 
     it('should not end when secondary ends if it produced at least one value', () => {
       const a = stream()
       const b = stream()
-      expect(a.skipUntilBy(b)).toEmit([], () => send(b, [0, '<end>']))
+      expect(a.skipUntilBy(b)).to.emit([], () => send(b, [0, '<end>']))
     })
 
     it('should ignore values from primary until first value from secondary', () => {
       const a = stream()
       const b = stream()
-      expect(a.skipUntilBy(b)).toEmit([], () => send(a, [1, 2]))
+      expect(a.skipUntilBy(b)).to.emit([], () => send(a, [1, 2]))
     })
 
     it('should emit all values from primary after first value from secondary', () => {
       const a = stream()
       const b = stream()
-      expect(a.skipUntilBy(b)).toEmit([3, 4, 5, 6, 7, 8, 9, '<end>'], () => {
+      expect(a.skipUntilBy(b)).to.emit([3, 4, 5, 6, 7, 8, 9, '<end>'], () => {
         send(b, [true])
         send(a, [3, 4])
         send(b, [0])
@@ -98,13 +98,13 @@ describe('skipUntilBy', () => {
 
   describe('stream, property', () => {
     it('should return a stream', () => {
-      expect(stream().skipUntilBy(prop())).toBeStream()
+      expect(stream().skipUntilBy(prop())).to.be.observable.stream()
     })
 
     it('should activate/deactivate sources', () => {
       const a = stream()
       const b = prop()
-      expect(a.skipUntilBy(b)).toActivate(a, b)
+      expect(a.skipUntilBy(b)).to.activate(a, b)
     })
 
     it('should do activate secondary after first value from it', () => {
@@ -114,35 +114,35 @@ describe('skipUntilBy', () => {
       activate(res)
       send(b, [1])
       deactivate(res)
-      expect(res).toActivate(a)
-      expect(res).toActivate(b)
+      expect(res).to.activate(a)
+      expect(res).to.activate(b)
     })
 
     it('should be ended if primary was ended', () =>
-      expect(send(stream(), ['<end>']).skipUntilBy(prop())).toEmit(['<end:current>']))
+      expect(send(stream(), ['<end>']).skipUntilBy(prop())).to.emit(['<end:current>']))
 
     it('should be ended if secondary was ended and has no current', () =>
-      expect(stream().skipUntilBy(send(prop(), ['<end>']))).toEmit(['<end:current>']))
+      expect(stream().skipUntilBy(send(prop(), ['<end>']))).to.emit(['<end:current>']))
 
     it('should not be ended if secondary was ended but has any current', () =>
-      expect(stream().skipUntilBy(send(prop(), [0, '<end>']))).toEmit([]))
+      expect(stream().skipUntilBy(send(prop(), [0, '<end>']))).to.emit([]))
 
     it('should not end when secondary ends if it produced at least one value', () => {
       const a = stream()
       const b = prop()
-      expect(a.skipUntilBy(b)).toEmit([], () => send(b, [true, '<end>']))
+      expect(a.skipUntilBy(b)).to.emit([], () => send(b, [true, '<end>']))
     })
 
     it('should ignore values from primary until first value from secondary', () => {
       const a = stream()
       const b = prop()
-      expect(a.skipUntilBy(b)).toEmit([], () => send(a, [1, 2]))
+      expect(a.skipUntilBy(b)).to.emit([], () => send(a, [1, 2]))
     })
 
     it('should filter values as expected', () => {
       const a = stream()
       const b = send(prop(), [0])
-      expect(a.skipUntilBy(b)).toEmit([3, 4, 5, 6, 7, 8, 9, '<end>'], () => {
+      expect(a.skipUntilBy(b)).to.emit([3, 4, 5, 6, 7, 8, 9, '<end>'], () => {
         send(a, [3, 4])
         send(b, [2])
         send(a, [5, 6])
@@ -156,13 +156,13 @@ describe('skipUntilBy', () => {
 
   describe('property, stream', () => {
     it('should return a property', () => {
-      expect(prop().skipUntilBy(stream())).toBeProperty()
+      expect(prop().skipUntilBy(stream())).to.be.observable.property()
     })
 
     it('should activate/deactivate sources', () => {
       const a = prop()
       const b = stream()
-      expect(a.skipUntilBy(b)).toActivate(a, b)
+      expect(a.skipUntilBy(b)).to.activate(a, b)
     })
 
     it('should do activate secondary after first value from it', () => {
@@ -172,32 +172,32 @@ describe('skipUntilBy', () => {
       activate(res)
       send(b, [1])
       deactivate(res)
-      expect(res).toActivate(a)
-      expect(res).toActivate(b)
+      expect(res).to.activate(a)
+      expect(res).to.activate(b)
     })
 
     it('should be ended if primary was ended', () =>
-      expect(send(prop(), ['<end>']).skipUntilBy(stream())).toEmit(['<end:current>']))
+      expect(send(prop(), ['<end>']).skipUntilBy(stream())).to.emit(['<end:current>']))
 
     it('should be ended if secondary was ended', () =>
-      expect(prop().skipUntilBy(send(stream(), ['<end>']))).toEmit(['<end:current>']))
+      expect(prop().skipUntilBy(send(stream(), ['<end>']))).to.emit(['<end:current>']))
 
     it('should not end when secondary ends if it produced at least one value', () => {
       const a = prop()
       const b = stream()
-      expect(a.skipUntilBy(b)).toEmit([], () => send(b, [0, '<end>']))
+      expect(a.skipUntilBy(b)).to.emit([], () => send(b, [0, '<end>']))
     })
 
     it('should ignore values from primary until first value from secondary', () => {
       const a = prop()
       const b = stream()
-      expect(a.skipUntilBy(b)).toEmit([], () => send(a, [1, 2]))
+      expect(a.skipUntilBy(b)).to.emit([], () => send(a, [1, 2]))
     })
 
     it('should filter values as expected', () => {
       const a = send(prop(), [0])
       const b = stream()
-      expect(a.skipUntilBy(b)).toEmit([3, 4, 5, 6, 7, 8, 9, '<end>'], () => {
+      expect(a.skipUntilBy(b)).to.emit([3, 4, 5, 6, 7, 8, 9, '<end>'], () => {
         send(b, [true])
         send(a, [3, 4])
         send(b, [0])
@@ -211,12 +211,12 @@ describe('skipUntilBy', () => {
   })
 
   describe('property, property', () => {
-    it('should return a property', () => expect(prop().skipUntilBy(prop())).toBeProperty())
+    it('should return a property', () => expect(prop().skipUntilBy(prop())).to.be.observable.property())
 
     it('should activate/deactivate sources', () => {
       const a = prop()
       const b = prop()
-      expect(a.skipUntilBy(b)).toActivate(a, b)
+      expect(a.skipUntilBy(b)).to.activate(a, b)
     })
 
     it('should do activate secondary after first value from it', () => {
@@ -226,35 +226,35 @@ describe('skipUntilBy', () => {
       activate(res)
       send(b, [1])
       deactivate(res)
-      expect(res).toActivate(a)
-      expect(res).toActivate(b)
+      expect(res).to.activate(a)
+      expect(res).to.activate(b)
     })
 
     it('should be ended if primary was ended', () =>
-      expect(send(prop(), ['<end>']).skipUntilBy(prop())).toEmit(['<end:current>']))
+      expect(send(prop(), ['<end>']).skipUntilBy(prop())).to.emit(['<end:current>']))
 
     it('should be ended if secondary was ended and has no current', () =>
-      expect(prop().skipUntilBy(send(prop(), ['<end>']))).toEmit(['<end:current>']))
+      expect(prop().skipUntilBy(send(prop(), ['<end>']))).to.emit(['<end:current>']))
 
     it('should not be ended if secondary was ended but has any current', () =>
-      expect(prop().skipUntilBy(send(prop(), [0, '<end>']))).toEmit([]))
+      expect(prop().skipUntilBy(send(prop(), [0, '<end>']))).to.emit([]))
 
     it('should not end when secondary ends if it produced at least one value', () => {
       const a = prop()
       const b = prop()
-      expect(a.skipUntilBy(b)).toEmit([], () => send(b, [true, '<end>']))
+      expect(a.skipUntilBy(b)).to.emit([], () => send(b, [true, '<end>']))
     })
 
     it('should ignore values from primary until first value from secondary', () => {
       const a = prop()
       const b = prop()
-      expect(a.skipUntilBy(b)).toEmit([], () => send(a, [1, 2]))
+      expect(a.skipUntilBy(b)).to.emit([], () => send(a, [1, 2]))
     })
 
     it('should filter values as expected', () => {
       const a = send(prop(), [0])
       const b = send(prop(), [0])
-      expect(a.skipUntilBy(b)).toEmit([{current: 0}, 3, 4, 5, 6, 7, 8, 9, '<end>'], () => {
+      expect(a.skipUntilBy(b)).to.emit([{current: 0}, 3, 4, 5, 6, 7, 8, 9, '<end>'], () => {
         send(a, [3, 4])
         send(b, [2])
         send(a, [5, 6])

--- a/test/specs/skip-until-by.js
+++ b/test/specs/skip-until-by.js
@@ -1,4 +1,4 @@
-const {stream, prop, send, Kefir, activate, deactivate, expect} = require('../test-helpers')
+const {stream, prop, send, value, end, activate, deactivate, expect} = require('../test-helpers')
 
 describe('skipUntilBy', () => {
   describe('common', () => {
@@ -34,7 +34,7 @@ describe('skipUntilBy', () => {
       const b = stream()
       const res = a.skipUntilBy(b)
       activate(res)
-      send(b, [1])
+      send(b, [value(1)])
       deactivate(res)
       expect(res).to.flowErrors(b)
     })
@@ -56,43 +56,46 @@ describe('skipUntilBy', () => {
       const b = stream()
       const res = a.skipUntilBy(b)
       activate(res)
-      send(b, [1])
+      send(b, [value(1)])
       deactivate(res)
       expect(res).to.activate(a)
       expect(res).to.activate(b)
     })
 
     it('should be ended if primary was ended', () =>
-      expect(send(stream(), ['<end>']).skipUntilBy(stream())).to.emit(['<end:current>']))
+      expect(send(stream(), [end()]).skipUntilBy(stream())).to.emit([end({current: true})]))
 
     it('should be ended if secondary was ended', () =>
-      expect(stream().skipUntilBy(send(stream(), ['<end>']))).to.emit(['<end:current>']))
+      expect(stream().skipUntilBy(send(stream(), [end()]))).to.emit([end({current: true})]))
 
     it('should not end when secondary ends if it produced at least one value', () => {
       const a = stream()
       const b = stream()
-      expect(a.skipUntilBy(b)).to.emit([], () => send(b, [0, '<end>']))
+      expect(a.skipUntilBy(b)).to.emit([], () => send(b, [value(0), end()]))
     })
 
     it('should ignore values from primary until first value from secondary', () => {
       const a = stream()
       const b = stream()
-      expect(a.skipUntilBy(b)).to.emit([], () => send(a, [1, 2]))
+      expect(a.skipUntilBy(b)).to.emit([], () => send(a, [value(1), value(2)]))
     })
 
     it('should emit all values from primary after first value from secondary', () => {
       const a = stream()
       const b = stream()
-      expect(a.skipUntilBy(b)).to.emit([3, 4, 5, 6, 7, 8, 9, '<end>'], () => {
-        send(b, [true])
-        send(a, [3, 4])
-        send(b, [0])
-        send(a, [5, 6])
-        send(b, [1])
-        send(a, [7, 8])
-        send(b, [false])
-        send(a, [9, '<end>'])
-      })
+      expect(a.skipUntilBy(b)).to.emit(
+        [value(3), value(4), value(5), value(6), value(7), value(8), value(9), end()],
+        () => {
+          send(b, [value(true)])
+          send(a, [value(3), value(4)])
+          send(b, [value(0)])
+          send(a, [value(5), value(6)])
+          send(b, [value(1)])
+          send(a, [value(7), value(8)])
+          send(b, [value(false)])
+          send(a, [value(9), end()])
+        }
+      )
     })
   })
 
@@ -112,45 +115,48 @@ describe('skipUntilBy', () => {
       const b = prop()
       const res = a.skipUntilBy(b)
       activate(res)
-      send(b, [1])
+      send(b, [value(1)])
       deactivate(res)
       expect(res).to.activate(a)
       expect(res).to.activate(b)
     })
 
     it('should be ended if primary was ended', () =>
-      expect(send(stream(), ['<end>']).skipUntilBy(prop())).to.emit(['<end:current>']))
+      expect(send(stream(), [end()]).skipUntilBy(prop())).to.emit([end({current: true})]))
 
     it('should be ended if secondary was ended and has no current', () =>
-      expect(stream().skipUntilBy(send(prop(), ['<end>']))).to.emit(['<end:current>']))
+      expect(stream().skipUntilBy(send(prop(), [end()]))).to.emit([end({current: true})]))
 
     it('should not be ended if secondary was ended but has any current', () =>
-      expect(stream().skipUntilBy(send(prop(), [0, '<end>']))).to.emit([]))
+      expect(stream().skipUntilBy(send(prop(), [value(0), end()]))).to.emit([]))
 
     it('should not end when secondary ends if it produced at least one value', () => {
       const a = stream()
       const b = prop()
-      expect(a.skipUntilBy(b)).to.emit([], () => send(b, [true, '<end>']))
+      expect(a.skipUntilBy(b)).to.emit([], () => send(b, [value(true), end()]))
     })
 
     it('should ignore values from primary until first value from secondary', () => {
       const a = stream()
       const b = prop()
-      expect(a.skipUntilBy(b)).to.emit([], () => send(a, [1, 2]))
+      expect(a.skipUntilBy(b)).to.emit([], () => send(a, [value(1), value(2)]))
     })
 
     it('should filter values as expected', () => {
       const a = stream()
-      const b = send(prop(), [0])
-      expect(a.skipUntilBy(b)).to.emit([3, 4, 5, 6, 7, 8, 9, '<end>'], () => {
-        send(a, [3, 4])
-        send(b, [2])
-        send(a, [5, 6])
-        send(b, [1])
-        send(a, [7, 8])
-        send(b, [false])
-        send(a, [9, '<end>'])
-      })
+      const b = send(prop(), [value(0)])
+      expect(a.skipUntilBy(b)).to.emit(
+        [value(3), value(4), value(5), value(6), value(7), value(8), value(9), end()],
+        () => {
+          send(a, [value(3), value(4)])
+          send(b, [value(2)])
+          send(a, [value(5), value(6)])
+          send(b, [value(1)])
+          send(a, [value(7), value(8)])
+          send(b, [value(false)])
+          send(a, [value(9), end()])
+        }
+      )
     })
   })
 
@@ -170,43 +176,46 @@ describe('skipUntilBy', () => {
       const b = stream()
       const res = a.skipUntilBy(b)
       activate(res)
-      send(b, [1])
+      send(b, [value(1)])
       deactivate(res)
       expect(res).to.activate(a)
       expect(res).to.activate(b)
     })
 
     it('should be ended if primary was ended', () =>
-      expect(send(prop(), ['<end>']).skipUntilBy(stream())).to.emit(['<end:current>']))
+      expect(send(prop(), [end()]).skipUntilBy(stream())).to.emit([end({current: true})]))
 
     it('should be ended if secondary was ended', () =>
-      expect(prop().skipUntilBy(send(stream(), ['<end>']))).to.emit(['<end:current>']))
+      expect(prop().skipUntilBy(send(stream(), [end()]))).to.emit([end({current: true})]))
 
     it('should not end when secondary ends if it produced at least one value', () => {
       const a = prop()
       const b = stream()
-      expect(a.skipUntilBy(b)).to.emit([], () => send(b, [0, '<end>']))
+      expect(a.skipUntilBy(b)).to.emit([], () => send(b, [value(0), end()]))
     })
 
     it('should ignore values from primary until first value from secondary', () => {
       const a = prop()
       const b = stream()
-      expect(a.skipUntilBy(b)).to.emit([], () => send(a, [1, 2]))
+      expect(a.skipUntilBy(b)).to.emit([], () => send(a, [value(1), value(2)]))
     })
 
     it('should filter values as expected', () => {
-      const a = send(prop(), [0])
+      const a = send(prop(), [value(0)])
       const b = stream()
-      expect(a.skipUntilBy(b)).to.emit([3, 4, 5, 6, 7, 8, 9, '<end>'], () => {
-        send(b, [true])
-        send(a, [3, 4])
-        send(b, [0])
-        send(a, [5, 6])
-        send(b, [1])
-        send(a, [7, 8])
-        send(b, [false])
-        send(a, [9, '<end>'])
-      })
+      expect(a.skipUntilBy(b)).to.emit(
+        [value(3), value(4), value(5), value(6), value(7), value(8), value(9), end()],
+        () => {
+          send(b, [value(true)])
+          send(a, [value(3), value(4)])
+          send(b, [value(0)])
+          send(a, [value(5), value(6)])
+          send(b, [value(1)])
+          send(a, [value(7), value(8)])
+          send(b, [value(false)])
+          send(a, [value(9), end()])
+        }
+      )
     })
   })
 
@@ -224,45 +233,48 @@ describe('skipUntilBy', () => {
       const b = prop()
       const res = a.skipUntilBy(b)
       activate(res)
-      send(b, [1])
+      send(b, [value(1)])
       deactivate(res)
       expect(res).to.activate(a)
       expect(res).to.activate(b)
     })
 
     it('should be ended if primary was ended', () =>
-      expect(send(prop(), ['<end>']).skipUntilBy(prop())).to.emit(['<end:current>']))
+      expect(send(prop(), [end()]).skipUntilBy(prop())).to.emit([end({current: true})]))
 
     it('should be ended if secondary was ended and has no current', () =>
-      expect(prop().skipUntilBy(send(prop(), ['<end>']))).to.emit(['<end:current>']))
+      expect(prop().skipUntilBy(send(prop(), [end()]))).to.emit([end({current: true})]))
 
     it('should not be ended if secondary was ended but has any current', () =>
-      expect(prop().skipUntilBy(send(prop(), [0, '<end>']))).to.emit([]))
+      expect(prop().skipUntilBy(send(prop(), [value(0), end()]))).to.emit([]))
 
     it('should not end when secondary ends if it produced at least one value', () => {
       const a = prop()
       const b = prop()
-      expect(a.skipUntilBy(b)).to.emit([], () => send(b, [true, '<end>']))
+      expect(a.skipUntilBy(b)).to.emit([], () => send(b, [value(true), end()]))
     })
 
     it('should ignore values from primary until first value from secondary', () => {
       const a = prop()
       const b = prop()
-      expect(a.skipUntilBy(b)).to.emit([], () => send(a, [1, 2]))
+      expect(a.skipUntilBy(b)).to.emit([], () => send(a, [value(1), value(2)]))
     })
 
     it('should filter values as expected', () => {
-      const a = send(prop(), [0])
-      const b = send(prop(), [0])
-      expect(a.skipUntilBy(b)).to.emit([{current: 0}, 3, 4, 5, 6, 7, 8, 9, '<end>'], () => {
-        send(a, [3, 4])
-        send(b, [2])
-        send(a, [5, 6])
-        send(b, [1])
-        send(a, [7, 8])
-        send(b, [false])
-        send(a, [9, '<end>'])
-      })
+      const a = send(prop(), [value(0)])
+      const b = send(prop(), [value(0)])
+      expect(a.skipUntilBy(b)).to.emit(
+        [value(0, {current: true}), value(3), value(4), value(5), value(6), value(7), value(8), value(9), end()],
+        () => {
+          send(a, [value(3), value(4)])
+          send(b, [value(2)])
+          send(a, [value(5), value(6)])
+          send(b, [value(1)])
+          send(a, [value(7), value(8)])
+          send(b, [value(false)])
+          send(a, [value(9), end()])
+        }
+      )
     })
   })
 })

--- a/test/specs/skip-while.js
+++ b/test/specs/skip-while.js
@@ -1,4 +1,4 @@
-const {stream, prop, send, Kefir, expect} = require('../test-helpers')
+const {stream, prop, send, value, error, end, Kefir, expect} = require('../test-helpers')
 
 describe('skipWhile', () => {
   describe('stream', () => {
@@ -12,26 +12,32 @@ describe('skipWhile', () => {
     })
 
     it('should be ended if source was ended', () =>
-      expect(send(stream(), ['<end>']).skipWhile(() => false)).to.emit(['<end:current>']))
+      expect(send(stream(), [end()]).skipWhile(() => false)).to.emit([end({current: true})]))
 
     it('should handle events (`-> true`)', () => {
       const a = stream()
-      expect(a.skipWhile(() => true)).to.emit(['<end>'], () => send(a, [1, 2, '<end>']))
+      expect(a.skipWhile(() => true)).to.emit([end()], () => send(a, [value(1), value(2), end()]))
     })
 
     it('should handle events (`-> false`)', () => {
       const a = stream()
-      expect(a.skipWhile(() => false)).to.emit([1, 2, 3, '<end>'], () => send(a, [1, 2, 3, '<end>']))
+      expect(a.skipWhile(() => false)).to.emit([value(1), value(2), value(3), end()], () =>
+        send(a, [value(1), value(2), value(3), end()])
+      )
     })
 
     it('should handle events (`(x) -> x < 3`)', () => {
       const a = stream()
-      expect(a.skipWhile(x => x < 3)).to.emit([3, 4, 5, '<end>'], () => send(a, [1, 2, 3, 4, 5, '<end>']))
+      expect(a.skipWhile(x => x < 3)).to.emit([value(3), value(4), value(5), end()], () =>
+        send(a, [value(1), value(2), value(3), value(4), value(5), end()])
+      )
     })
 
     it('shoud use id as default predicate', () => {
       const a = stream()
-      expect(a.skipWhile()).to.emit([0, 4, 5, '<end>'], () => send(a, [1, 2, 0, 4, 5, '<end>']))
+      expect(a.skipWhile()).to.emit([value(0), value(4), value(5), end()], () =>
+        send(a, [value(1), value(2), value(0), value(4), value(5), end()])
+      )
     })
 
     it('errors should flow', () => {
@@ -51,28 +57,36 @@ describe('skipWhile', () => {
     })
 
     it('should be ended if source was ended', () =>
-      expect(send(prop(), ['<end>']).skipWhile(() => false)).to.emit(['<end:current>']))
+      expect(send(prop(), [end()]).skipWhile(() => false)).to.emit([end({current: true})]))
 
     it('should handle events and current (`-> true`)', () => {
-      const a = send(prop(), [1])
-      expect(a.skipWhile(() => true)).to.emit(['<end>'], () => send(a, [2, '<end>']))
+      const a = send(prop(), [value(1)])
+      expect(a.skipWhile(() => true)).to.emit([end()], () => send(a, [value(2), end()]))
     })
 
     it('should handle events and current (`-> false`)', () => {
-      const a = send(prop(), [1])
-      expect(a.skipWhile(() => false)).to.emit([{current: 1}, 2, 3, '<end>'], () => send(a, [2, 3, '<end>']))
+      const a = send(prop(), [value(1)])
+      expect(a.skipWhile(() => false)).to.emit([value(1, {current: true}), value(2), value(3), end()], () =>
+        send(a, [value(2), value(3), end()])
+      )
     })
 
     it('should handle events and current (`(x) -> x < 3`)', () => {
-      const a = send(prop(), [1])
-      expect(a.skipWhile(x => x < 3)).to.emit([3, 4, 5, '<end>'], () => send(a, [2, 3, 4, 5, '<end>']))
+      const a = send(prop(), [value(1)])
+      expect(a.skipWhile(x => x < 3)).to.emit([value(3), value(4), value(5), end()], () =>
+        send(a, [value(2), value(3), value(4), value(5), end()])
+      )
     })
 
     it('shoud use id as default predicate', () => {
-      let a = send(prop(), [1])
-      expect(a.skipWhile()).to.emit([0, 4, 5, '<end>'], () => send(a, [2, 0, 4, 5, '<end>']))
-      a = send(prop(), [0])
-      expect(a.skipWhile()).to.emit([{current: 0}, 2, 0, 4, 5, '<end>'], () => send(a, [2, 0, 4, 5, '<end>']))
+      let a = send(prop(), [value(1)])
+      expect(a.skipWhile()).to.emit([value(0), value(4), value(5), end()], () =>
+        send(a, [value(2), value(0), value(4), value(5), end()])
+      )
+      a = send(prop(), [value(0)])
+      expect(a.skipWhile()).to.emit([value(0, {current: true}), value(2), value(0), value(4), value(5), end()], () =>
+        send(a, [value(2), value(0), value(4), value(5), end()])
+      )
     })
 
     it('errors should flow', () => {

--- a/test/specs/skip-while.js
+++ b/test/specs/skip-while.js
@@ -1,83 +1,83 @@
-const {stream, prop, send, Kefir} = require('../test-helpers')
+const {stream, prop, send, Kefir, expect} = require('../test-helpers')
 
 describe('skipWhile', () => {
   describe('stream', () => {
     it('should return stream', () => {
-      expect(stream().skipWhile(() => false)).toBeStream()
+      expect(stream().skipWhile(() => false)).to.be.observable.stream()
     })
 
     it('should activate/deactivate source', () => {
       const a = stream()
-      expect(a.skipWhile(() => false)).toActivate(a)
+      expect(a.skipWhile(() => false)).to.activate(a)
     })
 
     it('should be ended if source was ended', () =>
-      expect(send(stream(), ['<end>']).skipWhile(() => false)).toEmit(['<end:current>']))
+      expect(send(stream(), ['<end>']).skipWhile(() => false)).to.emit(['<end:current>']))
 
     it('should handle events (`-> true`)', () => {
       const a = stream()
-      expect(a.skipWhile(() => true)).toEmit(['<end>'], () => send(a, [1, 2, '<end>']))
+      expect(a.skipWhile(() => true)).to.emit(['<end>'], () => send(a, [1, 2, '<end>']))
     })
 
     it('should handle events (`-> false`)', () => {
       const a = stream()
-      expect(a.skipWhile(() => false)).toEmit([1, 2, 3, '<end>'], () => send(a, [1, 2, 3, '<end>']))
+      expect(a.skipWhile(() => false)).to.emit([1, 2, 3, '<end>'], () => send(a, [1, 2, 3, '<end>']))
     })
 
     it('should handle events (`(x) -> x < 3`)', () => {
       const a = stream()
-      expect(a.skipWhile(x => x < 3)).toEmit([3, 4, 5, '<end>'], () => send(a, [1, 2, 3, 4, 5, '<end>']))
+      expect(a.skipWhile(x => x < 3)).to.emit([3, 4, 5, '<end>'], () => send(a, [1, 2, 3, 4, 5, '<end>']))
     })
 
     it('shoud use id as default predicate', () => {
       const a = stream()
-      expect(a.skipWhile()).toEmit([0, 4, 5, '<end>'], () => send(a, [1, 2, 0, 4, 5, '<end>']))
+      expect(a.skipWhile()).to.emit([0, 4, 5, '<end>'], () => send(a, [1, 2, 0, 4, 5, '<end>']))
     })
 
     it('errors should flow', () => {
       const a = stream()
-      expect(a.skipWhile()).errorsToFlow(a)
+      expect(a.skipWhile()).to.flowErrors(a)
     })
   })
 
   describe('property', () => {
     it('should return property', () => {
-      expect(prop().skipWhile(() => false)).toBeProperty()
+      expect(prop().skipWhile(() => false)).to.be.observable.property()
     })
 
     it('should activate/deactivate source', () => {
       const a = prop()
-      expect(a.skipWhile(() => false)).toActivate(a)
+      expect(a.skipWhile(() => false)).to.activate(a)
     })
 
     it('should be ended if source was ended', () =>
-      expect(send(prop(), ['<end>']).skipWhile(() => false)).toEmit(['<end:current>']))
+      expect(send(prop(), ['<end>']).skipWhile(() => false)).to.emit(['<end:current>']))
 
     it('should handle events and current (`-> true`)', () => {
       const a = send(prop(), [1])
-      expect(a.skipWhile(() => true)).toEmit(['<end>'], () => send(a, [2, '<end>']))
+      expect(a.skipWhile(() => true)).to.emit(['<end>'], () => send(a, [2, '<end>']))
     })
 
     it('should handle events and current (`-> false`)', () => {
       const a = send(prop(), [1])
-      expect(a.skipWhile(() => false)).toEmit([{current: 1}, 2, 3, '<end>'], () => send(a, [2, 3, '<end>']))
+      expect(a.skipWhile(() => false)).to.emit([{current: 1}, 2, 3, '<end>'], () => send(a, [2, 3, '<end>']))
     })
 
     it('should handle events and current (`(x) -> x < 3`)', () => {
       const a = send(prop(), [1])
-      expect(a.skipWhile(x => x < 3)).toEmit([3, 4, 5, '<end>'], () => send(a, [2, 3, 4, 5, '<end>']))
+      expect(a.skipWhile(x => x < 3)).to.emit([3, 4, 5, '<end>'], () => send(a, [2, 3, 4, 5, '<end>']))
     })
 
     it('shoud use id as default predicate', () => {
       let a = send(prop(), [1])
-      expect(a.skipWhile()).toEmit([0, 4, 5, '<end>'], () => send(a, [2, 0, 4, 5, '<end>']))
+      expect(a.skipWhile()).to.emit([0, 4, 5, '<end>'], () => send(a, [2, 0, 4, 5, '<end>']))
       a = send(prop(), [0])
-      expect(a.skipWhile()).toEmit([{current: 0}, 2, 0, 4, 5, '<end>'], () => send(a, [2, 0, 4, 5, '<end>']))
+      expect(a.skipWhile()).to.emit([{current: 0}, 2, 0, 4, 5, '<end>'], () => send(a, [2, 0, 4, 5, '<end>']))
     })
 
     it('errors should flow', () => {
       const a = prop()
-      expect(a.skipWhile()).errorsToFlow(a)
+      expect(a.skipWhile()).to.flowErrors(a)
     })
   })
 })

--- a/test/specs/skip.js
+++ b/test/specs/skip.js
@@ -1,4 +1,4 @@
-const {stream, prop, send, Kefir, expect} = require('../test-helpers')
+const {stream, prop, send, value, error, end, Kefir, expect} = require('../test-helpers')
 
 describe('skip', () => {
   describe('stream', () => {
@@ -12,27 +12,33 @@ describe('skip', () => {
     })
 
     it('should be ended if source was ended', () => {
-      expect(send(stream(), ['<end>']).skip(3)).to.emit(['<end:current>'])
+      expect(send(stream(), [end()]).skip(3)).to.emit([end({current: true})])
     })
 
     it('should handle events (less than `n`)', () => {
       const a = stream()
-      expect(a.skip(3)).to.emit(['<end>'], () => send(a, [1, 2, '<end>']))
+      expect(a.skip(3)).to.emit([end()], () => send(a, [value(1), value(2), end()]))
     })
 
     it('should handle events (more than `n`)', () => {
       const a = stream()
-      expect(a.skip(3)).to.emit([4, 5, '<end>'], () => send(a, [1, 2, 3, 4, 5, '<end>']))
+      expect(a.skip(3)).to.emit([value(4), value(5), end()], () =>
+        send(a, [value(1), value(2), value(3), value(4), value(5), end()])
+      )
     })
 
     it('should handle events (n == 0)', () => {
       const a = stream()
-      expect(a.skip(0)).to.emit([1, 2, 3, '<end>'], () => send(a, [1, 2, 3, '<end>']))
+      expect(a.skip(0)).to.emit([value(1), value(2), value(3), end()], () =>
+        send(a, [value(1), value(2), value(3), end()])
+      )
     })
 
     it('should handle events (n == -1)', () => {
       const a = stream()
-      expect(a.skip(-1)).to.emit([1, 2, 3, '<end>'], () => send(a, [1, 2, 3, '<end>']))
+      expect(a.skip(-1)).to.emit([value(1), value(2), value(3), end()], () =>
+        send(a, [value(1), value(2), value(3), end()])
+      )
     })
 
     it('errors should flow', () => {
@@ -51,26 +57,33 @@ describe('skip', () => {
       expect(a.skip(3)).to.activate(a)
     })
 
-    it('should be ended if source was ended', () => expect(send(prop(), ['<end>']).skip(3)).to.emit(['<end:current>']))
+    it('should be ended if source was ended', () =>
+      expect(send(prop(), [end()]).skip(3)).to.emit([end({current: true})]))
 
     it('should handle events and current (less than `n`)', () => {
-      const a = send(prop(), [1])
-      expect(a.skip(3)).to.emit(['<end>'], () => send(a, [2, '<end>']))
+      const a = send(prop(), [value(1)])
+      expect(a.skip(3)).to.emit([end()], () => send(a, [value(2), end()]))
     })
 
     it('should handle events and current (more than `n`)', () => {
-      const a = send(prop(), [1])
-      expect(a.skip(3)).to.emit([4, 5, '<end>'], () => send(a, [2, 3, 4, 5, '<end>']))
+      const a = send(prop(), [value(1)])
+      expect(a.skip(3)).to.emit([value(4), value(5), end()], () =>
+        send(a, [value(2), value(3), value(4), value(5), end()])
+      )
     })
 
     it('should handle events and current (n == 0)', () => {
-      const a = send(prop(), [1])
-      expect(a.skip(0)).to.emit([{current: 1}, 2, 3, '<end>'], () => send(a, [2, 3, '<end>']))
+      const a = send(prop(), [value(1)])
+      expect(a.skip(0)).to.emit([value(1, {current: true}), value(2), value(3), end()], () =>
+        send(a, [value(2), value(3), end()])
+      )
     })
 
     it('should handle events and current (n == -1)', () => {
-      const a = send(prop(), [1])
-      expect(a.skip(-1)).to.emit([{current: 1}, 2, 3, '<end>'], () => send(a, [2, 3, '<end>']))
+      const a = send(prop(), [value(1)])
+      expect(a.skip(-1)).to.emit([value(1, {current: true}), value(2), value(3), end()], () =>
+        send(a, [value(2), value(3), end()])
+      )
     })
 
     it('errors should flow', () => {

--- a/test/specs/skip.js
+++ b/test/specs/skip.js
@@ -1,81 +1,81 @@
-const {stream, prop, send, Kefir} = require('../test-helpers')
+const {stream, prop, send, Kefir, expect} = require('../test-helpers')
 
 describe('skip', () => {
   describe('stream', () => {
     it('should return stream', () => {
-      expect(stream().skip(3)).toBeStream()
+      expect(stream().skip(3)).to.be.observable.stream()
     })
 
     it('should activate/deactivate source', () => {
       const a = stream()
-      expect(a.skip(3)).toActivate(a)
+      expect(a.skip(3)).to.activate(a)
     })
 
     it('should be ended if source was ended', () => {
-      expect(send(stream(), ['<end>']).skip(3)).toEmit(['<end:current>'])
+      expect(send(stream(), ['<end>']).skip(3)).to.emit(['<end:current>'])
     })
 
     it('should handle events (less than `n`)', () => {
       const a = stream()
-      expect(a.skip(3)).toEmit(['<end>'], () => send(a, [1, 2, '<end>']))
+      expect(a.skip(3)).to.emit(['<end>'], () => send(a, [1, 2, '<end>']))
     })
 
     it('should handle events (more than `n`)', () => {
       const a = stream()
-      expect(a.skip(3)).toEmit([4, 5, '<end>'], () => send(a, [1, 2, 3, 4, 5, '<end>']))
+      expect(a.skip(3)).to.emit([4, 5, '<end>'], () => send(a, [1, 2, 3, 4, 5, '<end>']))
     })
 
     it('should handle events (n == 0)', () => {
       const a = stream()
-      expect(a.skip(0)).toEmit([1, 2, 3, '<end>'], () => send(a, [1, 2, 3, '<end>']))
+      expect(a.skip(0)).to.emit([1, 2, 3, '<end>'], () => send(a, [1, 2, 3, '<end>']))
     })
 
     it('should handle events (n == -1)', () => {
       const a = stream()
-      expect(a.skip(-1)).toEmit([1, 2, 3, '<end>'], () => send(a, [1, 2, 3, '<end>']))
+      expect(a.skip(-1)).to.emit([1, 2, 3, '<end>'], () => send(a, [1, 2, 3, '<end>']))
     })
 
     it('errors should flow', () => {
       const a = stream()
-      expect(a.skip(1)).errorsToFlow(a)
+      expect(a.skip(1)).to.flowErrors(a)
     })
   })
 
   describe('property', () => {
     it('should return property', () => {
-      expect(prop().skip(3)).toBeProperty()
+      expect(prop().skip(3)).to.be.observable.property()
     })
 
     it('should activate/deactivate source', () => {
       const a = prop()
-      expect(a.skip(3)).toActivate(a)
+      expect(a.skip(3)).to.activate(a)
     })
 
-    it('should be ended if source was ended', () => expect(send(prop(), ['<end>']).skip(3)).toEmit(['<end:current>']))
+    it('should be ended if source was ended', () => expect(send(prop(), ['<end>']).skip(3)).to.emit(['<end:current>']))
 
     it('should handle events and current (less than `n`)', () => {
       const a = send(prop(), [1])
-      expect(a.skip(3)).toEmit(['<end>'], () => send(a, [2, '<end>']))
+      expect(a.skip(3)).to.emit(['<end>'], () => send(a, [2, '<end>']))
     })
 
     it('should handle events and current (more than `n`)', () => {
       const a = send(prop(), [1])
-      expect(a.skip(3)).toEmit([4, 5, '<end>'], () => send(a, [2, 3, 4, 5, '<end>']))
+      expect(a.skip(3)).to.emit([4, 5, '<end>'], () => send(a, [2, 3, 4, 5, '<end>']))
     })
 
     it('should handle events and current (n == 0)', () => {
       const a = send(prop(), [1])
-      expect(a.skip(0)).toEmit([{current: 1}, 2, 3, '<end>'], () => send(a, [2, 3, '<end>']))
+      expect(a.skip(0)).to.emit([{current: 1}, 2, 3, '<end>'], () => send(a, [2, 3, '<end>']))
     })
 
     it('should handle events and current (n == -1)', () => {
       const a = send(prop(), [1])
-      expect(a.skip(-1)).toEmit([{current: 1}, 2, 3, '<end>'], () => send(a, [2, 3, '<end>']))
+      expect(a.skip(-1)).to.emit([{current: 1}, 2, 3, '<end>'], () => send(a, [2, 3, '<end>']))
     })
 
     it('errors should flow', () => {
       const a = prop()
-      expect(a.skip(1)).errorsToFlow(a)
+      expect(a.skip(1)).to.flowErrors(a)
     })
   })
 })

--- a/test/specs/sliding-window.js
+++ b/test/specs/sliding-window.js
@@ -1,93 +1,93 @@
-const {stream, prop, send, Kefir} = require('../test-helpers')
+const {stream, prop, send, Kefir, expect} = require('../test-helpers')
 
 describe('slidingWindow', () => {
   describe('stream', () => {
     it('should return stream', () => {
-      expect(stream().slidingWindow(1)).toBeStream()
+      expect(stream().slidingWindow(1)).to.be.observable.stream()
     })
 
     it('should activate/deactivate source', () => {
       const a = stream()
-      expect(a.slidingWindow(1)).toActivate(a)
+      expect(a.slidingWindow(1)).to.activate(a)
     })
 
     it('should be ended if source was ended', () =>
-      expect(send(stream(), ['<end>']).slidingWindow(1)).toEmit(['<end:current>']))
+      expect(send(stream(), ['<end>']).slidingWindow(1)).to.emit(['<end:current>']))
 
     it('.slidingWindow(3) should work correctly', () => {
       const a = stream()
-      expect(a.slidingWindow(3)).toEmit([[1], [1, 2], [1, 2, 3], [2, 3, 4], [3, 4, 5], '<end>'], () =>
+      expect(a.slidingWindow(3)).to.emit([[1], [1, 2], [1, 2, 3], [2, 3, 4], [3, 4, 5], '<end>'], () =>
         send(a, [1, 2, 3, 4, 5, '<end>'])
       )
     })
 
     it('.slidingWindow(3, 2) should work correctly', () => {
       const a = stream()
-      expect(a.slidingWindow(3, 2)).toEmit([[1, 2], [1, 2, 3], [2, 3, 4], [3, 4, 5], '<end>'], () =>
+      expect(a.slidingWindow(3, 2)).to.emit([[1, 2], [1, 2, 3], [2, 3, 4], [3, 4, 5], '<end>'], () =>
         send(a, [1, 2, 3, 4, 5, '<end>'])
       )
     })
 
     it('.slidingWindow(3, 3) should work correctly', () => {
       const a = stream()
-      expect(a.slidingWindow(3, 3)).toEmit([[1, 2, 3], [2, 3, 4], [3, 4, 5], '<end>'], () =>
+      expect(a.slidingWindow(3, 3)).to.emit([[1, 2, 3], [2, 3, 4], [3, 4, 5], '<end>'], () =>
         send(a, [1, 2, 3, 4, 5, '<end>'])
       )
     })
 
     it('.slidingWindow(3, 4) should work correctly', () => {
       const a = stream()
-      expect(a.slidingWindow(3, 4)).toEmit(['<end>'], () => send(a, [1, 2, 3, 4, 5, '<end>']))
+      expect(a.slidingWindow(3, 4)).to.emit(['<end>'], () => send(a, [1, 2, 3, 4, 5, '<end>']))
     })
 
     it('errors should flow', () => {
       const a = stream()
-      expect(a.slidingWindow(3, 4)).errorsToFlow(a)
+      expect(a.slidingWindow(3, 4)).to.flowErrors(a)
     })
   })
 
   describe('property', () => {
     it('should return property', () => {
-      expect(prop().slidingWindow(1)).toBeProperty()
+      expect(prop().slidingWindow(1)).to.be.observable.property()
     })
 
     it('should activate/deactivate source', () => {
       const a = prop()
-      expect(a.slidingWindow(1)).toActivate(a)
+      expect(a.slidingWindow(1)).to.activate(a)
     })
 
     it('should be ended if source was ended', () =>
-      expect(send(prop(), ['<end>']).slidingWindow(1)).toEmit(['<end:current>']))
+      expect(send(prop(), ['<end>']).slidingWindow(1)).to.emit(['<end:current>']))
 
     it('.slidingWindow(3) should work correctly', () => {
       const a = send(prop(), [1])
-      expect(a.slidingWindow(3)).toEmit([{current: [1]}, [1, 2], [1, 2, 3], [2, 3, 4], [3, 4, 5], '<end>'], () =>
+      expect(a.slidingWindow(3)).to.emit([{current: [1]}, [1, 2], [1, 2, 3], [2, 3, 4], [3, 4, 5], '<end>'], () =>
         send(a, [2, 3, 4, 5, '<end>'])
       )
     })
 
     it('.slidingWindow(3, 2) should work correctly', () => {
       const a = send(prop(), [1])
-      expect(a.slidingWindow(3, 2)).toEmit([[1, 2], [1, 2, 3], [2, 3, 4], [3, 4, 5], '<end>'], () =>
+      expect(a.slidingWindow(3, 2)).to.emit([[1, 2], [1, 2, 3], [2, 3, 4], [3, 4, 5], '<end>'], () =>
         send(a, [2, 3, 4, 5, '<end>'])
       )
     })
 
     it('.slidingWindow(3, 3) should work correctly', () => {
       const a = send(prop(), [1])
-      expect(a.slidingWindow(3, 3)).toEmit([[1, 2, 3], [2, 3, 4], [3, 4, 5], '<end>'], () =>
+      expect(a.slidingWindow(3, 3)).to.emit([[1, 2, 3], [2, 3, 4], [3, 4, 5], '<end>'], () =>
         send(a, [2, 3, 4, 5, '<end>'])
       )
     })
 
     it('.slidingWindow(3, 4) should work correctly', () => {
       const a = send(prop(), [1])
-      expect(a.slidingWindow(3, 4)).toEmit(['<end>'], () => send(a, [2, 3, 4, 5, '<end>']))
+      expect(a.slidingWindow(3, 4)).to.emit(['<end>'], () => send(a, [2, 3, 4, 5, '<end>']))
     })
 
     it('errors should flow', () => {
       const a = prop()
-      expect(a.slidingWindow(3, 4)).errorsToFlow(a)
+      expect(a.slidingWindow(3, 4)).to.flowErrors(a)
     })
   })
 })

--- a/test/specs/sliding-window.js
+++ b/test/specs/sliding-window.js
@@ -1,4 +1,4 @@
-const {stream, prop, send, Kefir, expect} = require('../test-helpers')
+const {stream, prop, send, value, error, end, Kefir, expect} = require('../test-helpers')
 
 describe('slidingWindow', () => {
   describe('stream', () => {
@@ -12,32 +12,36 @@ describe('slidingWindow', () => {
     })
 
     it('should be ended if source was ended', () =>
-      expect(send(stream(), ['<end>']).slidingWindow(1)).to.emit(['<end:current>']))
+      expect(send(stream(), [end()]).slidingWindow(1)).to.emit([end({current: true})]))
 
     it('.slidingWindow(3) should work correctly', () => {
       const a = stream()
-      expect(a.slidingWindow(3)).to.emit([[1], [1, 2], [1, 2, 3], [2, 3, 4], [3, 4, 5], '<end>'], () =>
-        send(a, [1, 2, 3, 4, 5, '<end>'])
+      expect(a.slidingWindow(3)).to.emit(
+        [value([1]), value([1, 2]), value([1, 2, 3]), value([2, 3, 4]), value([3, 4, 5]), end()],
+        () => send(a, [value(1), value(2), value(3), value(4), value(5), end()])
       )
     })
 
     it('.slidingWindow(3, 2) should work correctly', () => {
       const a = stream()
-      expect(a.slidingWindow(3, 2)).to.emit([[1, 2], [1, 2, 3], [2, 3, 4], [3, 4, 5], '<end>'], () =>
-        send(a, [1, 2, 3, 4, 5, '<end>'])
+      expect(a.slidingWindow(3, 2)).to.emit(
+        [value([1, 2]), value([1, 2, 3]), value([2, 3, 4]), value([3, 4, 5]), end()],
+        () => send(a, [value(1), value(2), value(3), value(4), value(5), end()])
       )
     })
 
     it('.slidingWindow(3, 3) should work correctly', () => {
       const a = stream()
-      expect(a.slidingWindow(3, 3)).to.emit([[1, 2, 3], [2, 3, 4], [3, 4, 5], '<end>'], () =>
-        send(a, [1, 2, 3, 4, 5, '<end>'])
+      expect(a.slidingWindow(3, 3)).to.emit([value([1, 2, 3]), value([2, 3, 4]), value([3, 4, 5]), end()], () =>
+        send(a, [value(1), value(2), value(3), value(4), value(5), end()])
       )
     })
 
     it('.slidingWindow(3, 4) should work correctly', () => {
       const a = stream()
-      expect(a.slidingWindow(3, 4)).to.emit(['<end>'], () => send(a, [1, 2, 3, 4, 5, '<end>']))
+      expect(a.slidingWindow(3, 4)).to.emit([end()], () =>
+        send(a, [value(1), value(2), value(3), value(4), value(5), end()])
+      )
     })
 
     it('errors should flow', () => {
@@ -57,32 +61,34 @@ describe('slidingWindow', () => {
     })
 
     it('should be ended if source was ended', () =>
-      expect(send(prop(), ['<end>']).slidingWindow(1)).to.emit(['<end:current>']))
+      expect(send(prop(), [end()]).slidingWindow(1)).to.emit([end({current: true})]))
 
     it('.slidingWindow(3) should work correctly', () => {
-      const a = send(prop(), [1])
-      expect(a.slidingWindow(3)).to.emit([{current: [1]}, [1, 2], [1, 2, 3], [2, 3, 4], [3, 4, 5], '<end>'], () =>
-        send(a, [2, 3, 4, 5, '<end>'])
+      const a = send(prop(), [value(1)])
+      expect(a.slidingWindow(3)).to.emit(
+        [value([1], {current: true}), value([1, 2]), value([1, 2, 3]), value([2, 3, 4]), value([3, 4, 5]), end()],
+        () => send(a, [value(2), value(3), value(4), value(5), end()])
       )
     })
 
     it('.slidingWindow(3, 2) should work correctly', () => {
-      const a = send(prop(), [1])
-      expect(a.slidingWindow(3, 2)).to.emit([[1, 2], [1, 2, 3], [2, 3, 4], [3, 4, 5], '<end>'], () =>
-        send(a, [2, 3, 4, 5, '<end>'])
+      const a = send(prop(), [value(1)])
+      expect(a.slidingWindow(3, 2)).to.emit(
+        [value([1, 2]), value([1, 2, 3]), value([2, 3, 4]), value([3, 4, 5]), end()],
+        () => send(a, [value(2), value(3), value(4), value(5), end()])
       )
     })
 
     it('.slidingWindow(3, 3) should work correctly', () => {
-      const a = send(prop(), [1])
-      expect(a.slidingWindow(3, 3)).to.emit([[1, 2, 3], [2, 3, 4], [3, 4, 5], '<end>'], () =>
-        send(a, [2, 3, 4, 5, '<end>'])
+      const a = send(prop(), [value(1)])
+      expect(a.slidingWindow(3, 3)).to.emit([value([1, 2, 3]), value([2, 3, 4]), value([3, 4, 5]), end()], () =>
+        send(a, [value(2), value(3), value(4), value(5), end()])
       )
     })
 
     it('.slidingWindow(3, 4) should work correctly', () => {
-      const a = send(prop(), [1])
-      expect(a.slidingWindow(3, 4)).to.emit(['<end>'], () => send(a, [2, 3, 4, 5, '<end>']))
+      const a = send(prop(), [value(1)])
+      expect(a.slidingWindow(3, 4)).to.emit([end()], () => send(a, [value(2), value(3), value(4), value(5), end()]))
     })
 
     it('errors should flow', () => {

--- a/test/specs/spy.js
+++ b/test/specs/spy.js
@@ -1,50 +1,54 @@
-const {stream, send} = require('../test-helpers')
+const {stream, send, expect} = require('../test-helpers')
+const sinon = require('sinon')
 
 describe('spy', () => {
   describe('adding', () => {
     it('should return the stream', () => {
-      expect(stream().spy()).toBeStream()
+      expect(stream().spy()).to.be.observable.stream()
     })
 
     it('should not activate the stream', () => {
       const a = stream().spy()
-      expect(a).not.toBeActive()
+      expect(a).not.to.be.active()
     })
   })
 
   describe('removing', () => {
     it('should return the stream', () => {
-      expect(stream().spy().offSpy()).toBeStream()
+      expect(stream().spy().offSpy()).to.be.observable.stream()
     })
 
     it('should not activate the stream', () => {
       const a = stream().spy().offSpy()
-      expect(a).not.toBeActive()
+      expect(a).not.to.be.active()
     })
   })
 
   describe('console', () => {
-    beforeEach(() => spyOn(console, 'log'))
+    let stub
+    beforeEach(() => stub = sinon.stub(console, 'log'))
+
+    afterEach(() => stub.restore())
 
     it('should have a default name', () => {
       const a = stream()
       a.spy()
-      expect(a).toEmit([1, 2, 3], () => {
+      expect(a).to.emit([1, 2, 3], () => {
         send(a, [1, 2, 3])
-        expect(console.log).toHaveBeenCalledWith('[stream]', '<value>', 1)
-        expect(console.log).toHaveBeenCalledWith('[stream]', '<value>', 2)
-        expect(console.log).toHaveBeenCalledWith('[stream]', '<value>', 3)
+        expect(console.log).to.have.been.calledWith('[stream]', '<value>', 1)
+        expect(console.log).to.have.been.calledWith('[stream]', '<value>', 2)
+        expect(console.log).to.have.been.calledWith('[stream]', '<value>', 3)
       })
     })
 
     it('should use the name', () => {
       const a = stream()
       a.spy('spied')
-      expect(a).toEmit([1, 2, 3], () => {
+      expect(a).to.emit([1, 2, 3], () => {
         send(a, [1, 2, 3])
-        expect(console.log).toHaveBeenCalledWith('spied', '<value>', 1)
-        expect(console.log).toHaveBeenCalledWith('spied', '<value>', 2)
-        expect(console.log).toHaveBeenCalledWith('spied', '<value>', 3)
+        expect(console.log).to.have.been.calledWith('spied', '<value>', 1)
+        expect(console.log).to.have.been.calledWith('spied', '<value>', 2)
+        expect(console.log).to.have.been.calledWith('spied', '<value>', 3)
       })
     })
 
@@ -52,9 +56,9 @@ describe('spy', () => {
       const a = stream()
       a.spy()
       a.offSpy()
-      expect(a).toEmit([1, 2, 3], () => {
+      expect(a).to.emit([1, 2, 3], () => {
         send(a, [1, 2, 3])
-        expect(console.log).not.toHaveBeenCalled()
+        expect(console.log).not.to.have.been.called
       })
     })
   })

--- a/test/specs/spy.js
+++ b/test/specs/spy.js
@@ -1,4 +1,4 @@
-const {stream, send, expect} = require('../test-helpers')
+const {stream, send, value, error, end, expect} = require('../test-helpers')
 const sinon = require('sinon')
 
 describe('spy', () => {
@@ -33,8 +33,8 @@ describe('spy', () => {
     it('should have a default name', () => {
       const a = stream()
       a.spy()
-      expect(a).to.emit([1, 2, 3], () => {
-        send(a, [1, 2, 3])
+      expect(a).to.emit([value(1), value(2), value(3)], () => {
+        send(a, [value(1), value(2), value(3)])
         expect(console.log).to.have.been.calledWith('[stream]', '<value>', 1)
         expect(console.log).to.have.been.calledWith('[stream]', '<value>', 2)
         expect(console.log).to.have.been.calledWith('[stream]', '<value>', 3)
@@ -44,8 +44,8 @@ describe('spy', () => {
     it('should use the name', () => {
       const a = stream()
       a.spy('spied')
-      expect(a).to.emit([1, 2, 3], () => {
-        send(a, [1, 2, 3])
+      expect(a).to.emit([value(1), value(2), value(3)], () => {
+        send(a, [value(1), value(2), value(3)])
         expect(console.log).to.have.been.calledWith('spied', '<value>', 1)
         expect(console.log).to.have.been.calledWith('spied', '<value>', 2)
         expect(console.log).to.have.been.calledWith('spied', '<value>', 3)
@@ -56,8 +56,8 @@ describe('spy', () => {
       const a = stream()
       a.spy()
       a.offSpy()
-      expect(a).to.emit([1, 2, 3], () => {
-        send(a, [1, 2, 3])
+      expect(a).to.emit([value(1), value(2), value(3)], () => {
+        send(a, [value(1), value(2), value(3)])
         expect(console.log).not.to.have.been.called
       })
     })

--- a/test/specs/static-land.js
+++ b/test/specs/static-land.js
@@ -1,33 +1,33 @@
-let {Kefir} = require('../test-helpers')
+let {Kefir, expect} = require('../test-helpers')
 const {Observable} = Kefir.staticLand
 
 describe('Kefir.staticLand.Observable', () => {
   it('of works', () => {
-    expect(Observable.of(2)).toEmit([{current: 2}, '<end:current>'])
+    expect(Observable.of(2)).to.emit([{current: 2}, '<end:current>'])
   })
 
   it('empty works', () => {
-    expect(Observable.empty()).toEmit(['<end:current>'])
+    expect(Observable.empty()).to.emit(['<end:current>'])
   })
 
   it('concat works', () => {
-    expect(Observable.concat(Observable.of(2), Observable.empty())).toEmit([{current: 2}, '<end:current>'])
+    expect(Observable.concat(Observable.of(2), Observable.empty())).to.emit([{current: 2}, '<end:current>'])
   })
 
   it('map works', () => {
-    expect(Observable.map(x => x * 3, Observable.of(2))).toEmit([{current: 6}, '<end:current>'])
+    expect(Observable.map(x => x * 3, Observable.of(2))).to.emit([{current: 6}, '<end:current>'])
   })
 
   it('bimap works', () => {
-    expect(Observable.bimap(x => x, x => x * 3, Observable.of(2))).toEmit([{current: 6}, '<end:current>'])
-    expect(Observable.bimap(x => x * 3, x => x, Kefir.constantError(2))).toEmit([{currentError: 6}, '<end:current>'])
+    expect(Observable.bimap(x => x, x => x * 3, Observable.of(2))).to.emit([{current: 6}, '<end:current>'])
+    expect(Observable.bimap(x => x * 3, x => x, Kefir.constantError(2))).to.emit([{currentError: 6}, '<end:current>'])
   })
 
   it('ap works', () => {
-    expect(Observable.ap(Observable.of(x => x * 3), Observable.of(2))).toEmit([{current: 6}, '<end:current>'])
+    expect(Observable.ap(Observable.of(x => x * 3), Observable.of(2))).to.emit([{current: 6}, '<end:current>'])
   })
 
   it('chain works', () => {
-    expect(Observable.chain(x => Observable.of(x * 3), Observable.of(2))).toEmit([{current: 6}, '<end:current>'])
+    expect(Observable.chain(x => Observable.of(x * 3), Observable.of(2))).to.emit([{current: 6}, '<end:current>'])
   })
 })

--- a/test/specs/static-land.js
+++ b/test/specs/static-land.js
@@ -1,33 +1,48 @@
-let {Kefir, expect} = require('../test-helpers')
+const {value, error, end, Kefir, expect} = require('../test-helpers')
 const {Observable} = Kefir.staticLand
 
 describe('Kefir.staticLand.Observable', () => {
   it('of works', () => {
-    expect(Observable.of(2)).to.emit([{current: 2}, '<end:current>'])
+    expect(Observable.of(2)).to.emit([value(2, {current: true}), end({current: true})])
   })
 
   it('empty works', () => {
-    expect(Observable.empty()).to.emit(['<end:current>'])
+    expect(Observable.empty()).to.emit([end({current: true})])
   })
 
   it('concat works', () => {
-    expect(Observable.concat(Observable.of(2), Observable.empty())).to.emit([{current: 2}, '<end:current>'])
+    expect(Observable.concat(Observable.of(2), Observable.empty())).to.emit([
+      value(2, {current: true}),
+      end({current: true}),
+    ])
   })
 
   it('map works', () => {
-    expect(Observable.map(x => x * 3, Observable.of(2))).to.emit([{current: 6}, '<end:current>'])
+    expect(Observable.map(x => x * 3, Observable.of(2))).to.emit([value(6, {current: true}), end({current: true})])
   })
 
   it('bimap works', () => {
-    expect(Observable.bimap(x => x, x => x * 3, Observable.of(2))).to.emit([{current: 6}, '<end:current>'])
-    expect(Observable.bimap(x => x * 3, x => x, Kefir.constantError(2))).to.emit([{currentError: 6}, '<end:current>'])
+    expect(Observable.bimap(x => x, x => x * 3, Observable.of(2))).to.emit([
+      value(6, {current: true}),
+      end({current: true}),
+    ])
+    expect(Observable.bimap(x => x * 3, x => x, Kefir.constantError(2))).to.emit([
+      error(6, {current: true}),
+      end({current: true}),
+    ])
   })
 
   it('ap works', () => {
-    expect(Observable.ap(Observable.of(x => x * 3), Observable.of(2))).to.emit([{current: 6}, '<end:current>'])
+    expect(Observable.ap(Observable.of(x => x * 3), Observable.of(2))).to.emit([
+      value(6, {current: true}),
+      end({current: true}),
+    ])
   })
 
   it('chain works', () => {
-    expect(Observable.chain(x => Observable.of(x * 3), Observable.of(2))).to.emit([{current: 6}, '<end:current>'])
+    expect(Observable.chain(x => Observable.of(x * 3), Observable.of(2))).to.emit([
+      value(6, {current: true}),
+      end({current: true}),
+    ])
   })
 })

--- a/test/specs/stream.js
+++ b/test/specs/stream.js
@@ -1,4 +1,4 @@
-const {stream, send, activate, Kefir, expect} = require('../test-helpers')
+const {stream, send, value, error, end, activate, Kefir, expect} = require('../test-helpers')
 
 describe('Stream', () => {
   describe('new', () => {
@@ -19,7 +19,7 @@ describe('Stream', () => {
   describe('end', () => {
     it('should end when `end` sent', () => {
       const s = stream()
-      expect(s).to.emit(['<end>'], () => send(s, ['<end>']))
+      expect(s).to.emit([end()], () => send(s, [end()]))
     })
 
     it('should call `end` subscribers', () => {
@@ -28,13 +28,13 @@ describe('Stream', () => {
       s.onEnd(() => log.push(1))
       s.onEnd(() => log.push(2))
       expect(log).to.deep.equal([])
-      send(s, ['<end>'])
+      send(s, [end()])
       expect(log).to.deep.equal([1, 2])
     })
 
     it('should call `end` subscribers on already ended stream', () => {
       const s = stream()
-      send(s, ['<end>'])
+      send(s, [end()])
       const log = []
       s.onEnd(() => log.push(1))
       s.onEnd(() => log.push(2))
@@ -45,13 +45,13 @@ describe('Stream', () => {
       const s = stream()
       activate(s)
       expect(s).to.be.active()
-      send(s, ['<end>'])
+      send(s, [end()])
       expect(s).not.to.be.active()
     })
 
     it('should stop deliver new values after end', () => {
       const s = stream()
-      expect(s).to.emit([1, 2, '<end>'], () => send(s, [1, 2, '<end>', 3]))
+      expect(s).to.emit([value(1), value(2), end()], () => send(s, [value(1), value(2), end(), value(3)]))
     })
 
     it('calling ._emitEnd twice should work fine', () => {
@@ -131,12 +131,12 @@ describe('Stream', () => {
   describe('subscribers', () => {
     it('should deliver values', () => {
       const s = stream()
-      expect(s).to.emit([1, 2], () => send(s, [1, 2]))
+      expect(s).to.emit([value(1), value(2)], () => send(s, [value(1), value(2)]))
     })
 
     it('should deliver errors', () => {
       const s = stream()
-      expect(s).to.emit([{error: 1}, {error: 2}], () => send(s, [{error: 1}, {error: 2}]))
+      expect(s).to.emit([error(1), error(2)], () => send(s, [error(1), error(2)]))
     })
 
     it('should not deliver values to unsubscribed subscribers', () => {
@@ -146,13 +146,13 @@ describe('Stream', () => {
       const s = stream()
       s.onValue(a)
       s.onValue(b)
-      send(s, [1])
+      send(s, [value(1)])
       s.offValue(() => {})
-      send(s, [2])
+      send(s, [value(2)])
       s.offValue(a)
-      send(s, [3])
+      send(s, [value(3)])
       s.offValue(b)
-      send(s, [4])
+      send(s, [value(4)])
       expect(log).to.deep.equal(['a1', 'b1', 'a2', 'b2', 'b3'])
     })
 
@@ -163,13 +163,13 @@ describe('Stream', () => {
       const s = stream()
       s.onError(a)
       s.onError(b)
-      send(s, [{error: 1}])
+      send(s, [error(1)])
       s.offError(() => {})
-      send(s, [{error: 2}])
+      send(s, [error(2)])
       s.offError(a)
-      send(s, [{error: 3}])
+      send(s, [error(3)])
       s.offError(b)
-      send(s, [{error: 4}])
+      send(s, [error(4)])
       expect(log).to.deep.equal(['a1', 'b1', 'a2', 'b2', 'b3'])
     })
 
@@ -179,7 +179,7 @@ describe('Stream', () => {
       s.onValue(function() {
         return (count = arguments.length)
       })
-      send(s, [1])
+      send(s, [value(1)])
       expect(count).to.equal(1)
     })
 
@@ -189,7 +189,7 @@ describe('Stream', () => {
       s.onError(function() {
         return (count = arguments.length)
       })
-      send(s, [{error: 1}])
+      send(s, [error(1)])
       expect(count).to.equal(1)
     })
 
@@ -199,7 +199,7 @@ describe('Stream', () => {
       s.onAny(function() {
         return (count = arguments.length)
       })
-      send(s, [1])
+      send(s, [value(1)])
       expect(count).to.equal(1)
     })
 
@@ -209,7 +209,7 @@ describe('Stream', () => {
       s.onEnd(function() {
         return (count = arguments.length)
       })
-      send(s, ['<end>'])
+      send(s, [end()])
       expect(count).to.equal(0)
       s.onEnd(function() {
         return (count = arguments.length)
@@ -227,7 +227,7 @@ describe('Stream', () => {
       var s = stream()
       s.onValue(b)
       s.onValue(a)
-      send(s, [1])
+      send(s, [value(1)])
       expect(log).to.deep.equal(['unsub a'])
     })
 
@@ -235,13 +235,13 @@ describe('Stream', () => {
       const log = []
       const a = () => log.push('a')
       const b = () => {
-        send(s, ['<end>'])
+        send(s, [end()])
         return log.push('end fired')
       }
       var s = stream()
       s.onValue(b)
       s.onValue(a)
-      send(s, [1])
+      send(s, [value(1)])
       expect(log).to.deep.equal(['end fired'])
     })
   })

--- a/test/specs/stream.js
+++ b/test/specs/stream.js
@@ -1,25 +1,25 @@
-const {stream, send, activate, Kefir} = require('../test-helpers')
+const {stream, send, activate, Kefir, expect} = require('../test-helpers')
 
 describe('Stream', () => {
   describe('new', () => {
     it('should create a Stream', () => {
-      expect(stream()).toBeStream()
-      expect(new Kefir.Stream()).toBeStream()
+      expect(stream()).to.be.observable.stream()
+      expect(new Kefir.Stream()).to.be.observable.stream()
     })
 
     it('should not be ended', () => {
-      expect(stream()).toEmit([])
+      expect(stream()).to.emit([])
     })
 
     it('should not be active', () => {
-      expect(stream()).not.toBeActive()
+      expect(stream()).not.to.be.active()
     })
   })
 
   describe('end', () => {
     it('should end when `end` sent', () => {
       const s = stream()
-      expect(s).toEmit(['<end>'], () => send(s, ['<end>']))
+      expect(s).to.emit(['<end>'], () => send(s, ['<end>']))
     })
 
     it('should call `end` subscribers', () => {
@@ -27,9 +27,9 @@ describe('Stream', () => {
       const log = []
       s.onEnd(() => log.push(1))
       s.onEnd(() => log.push(2))
-      expect(log).toEqual([])
+      expect(log).to.deep.equal([])
       send(s, ['<end>'])
-      expect(log).toEqual([1, 2])
+      expect(log).to.deep.equal([1, 2])
     })
 
     it('should call `end` subscribers on already ended stream', () => {
@@ -38,20 +38,20 @@ describe('Stream', () => {
       const log = []
       s.onEnd(() => log.push(1))
       s.onEnd(() => log.push(2))
-      expect(log).toEqual([1, 2])
+      expect(log).to.deep.equal([1, 2])
     })
 
     it('should deactivate on end', () => {
       const s = stream()
       activate(s)
-      expect(s).toBeActive()
+      expect(s).to.be.active()
       send(s, ['<end>'])
-      expect(s).not.toBeActive()
+      expect(s).not.to.be.active()
     })
 
     it('should stop deliver new values after end', () => {
       const s = stream()
-      expect(s).toEmit([1, 2, '<end>'], () => send(s, [1, 2, '<end>', 3]))
+      expect(s).to.emit([1, 2, '<end>'], () => send(s, [1, 2, '<end>', 3]))
     })
 
     it('calling ._emitEnd twice should work fine', () => {
@@ -63,7 +63,7 @@ describe('Stream', () => {
       } catch (e) {
         err = e
       }
-      expect(err && err.message).toBe(undefined)
+      expect(err && err.message).to.equal(undefined)
     })
 
     it('calling ._emitEnd in an end handler should work fine', () => {
@@ -75,7 +75,7 @@ describe('Stream', () => {
       } catch (e) {
         err = e
       }
-      expect(err && err.message).toBe(undefined)
+      expect(err && err.message).to.equal(undefined)
     })
   })
 
@@ -83,25 +83,25 @@ describe('Stream', () => {
     it('should activate when first subscriber added (value)', () => {
       const s = stream()
       s.onValue(() => {})
-      expect(s).toBeActive()
+      expect(s).to.be.active()
     })
 
     it('should activate when first subscriber added (error)', () => {
       const s = stream()
       s.onError(() => {})
-      expect(s).toBeActive()
+      expect(s).to.be.active()
     })
 
     it('should activate when first subscriber added (end)', () => {
       const s = stream()
       s.onEnd(() => {})
-      expect(s).toBeActive()
+      expect(s).to.be.active()
     })
 
     it('should activate when first subscriber added (any)', () => {
       const s = stream()
       s.onAny(() => {})
-      expect(s).toBeActive()
+      expect(s).to.be.active()
     })
 
     it('should deactivate when all subscribers removed', () => {
@@ -122,21 +122,21 @@ describe('Stream', () => {
       s.offAny(any1)
       s.offAny(any2)
       s.offEnd(end1)
-      expect(s).toBeActive()
+      expect(s).to.be.active()
       s.offEnd(end2)
-      expect(s).not.toBeActive()
+      expect(s).not.to.be.active()
     })
   })
 
   describe('subscribers', () => {
     it('should deliver values', () => {
       const s = stream()
-      expect(s).toEmit([1, 2], () => send(s, [1, 2]))
+      expect(s).to.emit([1, 2], () => send(s, [1, 2]))
     })
 
     it('should deliver errors', () => {
       const s = stream()
-      expect(s).toEmit([{error: 1}, {error: 2}], () => send(s, [{error: 1}, {error: 2}]))
+      expect(s).to.emit([{error: 1}, {error: 2}], () => send(s, [{error: 1}, {error: 2}]))
     })
 
     it('should not deliver values to unsubscribed subscribers', () => {
@@ -153,7 +153,7 @@ describe('Stream', () => {
       send(s, [3])
       s.offValue(b)
       send(s, [4])
-      expect(log).toEqual(['a1', 'b1', 'a2', 'b2', 'b3'])
+      expect(log).to.deep.equal(['a1', 'b1', 'a2', 'b2', 'b3'])
     })
 
     it('should not deliver errors to unsubscribed subscribers', () => {
@@ -170,7 +170,7 @@ describe('Stream', () => {
       send(s, [{error: 3}])
       s.offError(b)
       send(s, [{error: 4}])
-      expect(log).toEqual(['a1', 'b1', 'a2', 'b2', 'b3'])
+      expect(log).to.deep.equal(['a1', 'b1', 'a2', 'b2', 'b3'])
     })
 
     it('onValue subscribers should be called with 1 argument', () => {
@@ -180,7 +180,7 @@ describe('Stream', () => {
         return (count = arguments.length)
       })
       send(s, [1])
-      expect(count).toBe(1)
+      expect(count).to.equal(1)
     })
 
     it('onError subscribers should be called with 1 argument', () => {
@@ -190,7 +190,7 @@ describe('Stream', () => {
         return (count = arguments.length)
       })
       send(s, [{error: 1}])
-      expect(count).toBe(1)
+      expect(count).to.equal(1)
     })
 
     it('onAny subscribers should be called with 1 arguments', () => {
@@ -200,7 +200,7 @@ describe('Stream', () => {
         return (count = arguments.length)
       })
       send(s, [1])
-      expect(count).toBe(1)
+      expect(count).to.equal(1)
     })
 
     it('onEnd subscribers should be called with 0 arguments', () => {
@@ -210,11 +210,11 @@ describe('Stream', () => {
         return (count = arguments.length)
       })
       send(s, ['<end>'])
-      expect(count).toBe(0)
+      expect(count).to.equal(0)
       s.onEnd(function() {
         return (count = arguments.length)
       })
-      expect(count).toBe(0)
+      expect(count).to.equal(0)
     })
 
     it('should not call subscriber after unsubscribing (from another subscriber)', () => {
@@ -228,7 +228,7 @@ describe('Stream', () => {
       s.onValue(b)
       s.onValue(a)
       send(s, [1])
-      expect(log).toEqual(['unsub a'])
+      expect(log).to.deep.equal(['unsub a'])
     })
 
     it('should not call subscribers after end (fired from another subscriber)', () => {
@@ -242,7 +242,7 @@ describe('Stream', () => {
       s.onValue(b)
       s.onValue(a)
       send(s, [1])
-      expect(log).toEqual(['end fired'])
+      expect(log).to.deep.equal(['end fired'])
     })
   })
 })

--- a/test/specs/sugar.js
+++ b/test/specs/sugar.js
@@ -1,4 +1,4 @@
-const {stream, prop, send, expect} = require('../test-helpers')
+const {stream, prop, send, value, error, end, expect} = require('../test-helpers')
 
 describe('setName', () => {
   it('should return same observable', () => {
@@ -21,36 +21,36 @@ describe('awaiting', () => {
   it('stream and stream', () => {
     const a = stream()
     const b = stream()
-    expect(a.awaiting(b)).to.emit([{current: false}, true, false, true], () => {
-      send(a, [1])
-      send(b, [1])
-      send(b, [1])
-      send(a, [1])
-      send(a, [1])
+    expect(a.awaiting(b)).to.emit([value(false, {current: true}), value(true), value(false), value(true)], () => {
+      send(a, [value(1)])
+      send(b, [value(1)])
+      send(b, [value(1)])
+      send(a, [value(1)])
+      send(a, [value(1)])
     })
   })
 
   it('property and stream', () => {
-    const a = send(prop(), [1])
+    const a = send(prop(), [value(1)])
     const b = stream()
-    expect(a.awaiting(b)).to.emit([{current: true}, false, true], () => {
-      send(a, [1])
-      send(b, [1])
-      send(b, [1])
-      send(a, [1])
-      send(a, [1])
+    expect(a.awaiting(b)).to.emit([value(true, {current: true}), value(false), value(true)], () => {
+      send(a, [value(1)])
+      send(b, [value(1)])
+      send(b, [value(1)])
+      send(a, [value(1)])
+      send(a, [value(1)])
     })
   })
 
   it('property and property', () => {
-    const a = send(prop(), [1])
-    const b = send(prop(), [1])
-    expect(a.awaiting(b)).to.emit([{current: false}, true, false, true], () => {
-      send(a, [1])
-      send(b, [1])
-      send(b, [1])
-      send(a, [1])
-      send(a, [1])
+    const a = send(prop(), [value(1)])
+    const b = send(prop(), [value(1)])
+    expect(a.awaiting(b)).to.emit([value(false, {current: true}), value(true), value(false), value(true)], () => {
+      send(a, [value(1)])
+      send(b, [value(1)])
+      send(b, [value(1)])
+      send(a, [value(1)])
+      send(a, [value(1)])
     })
   })
 })

--- a/test/specs/sugar.js
+++ b/test/specs/sugar.js
@@ -1,19 +1,19 @@
-const {stream, prop, send} = require('../test-helpers')
+const {stream, prop, send, expect} = require('../test-helpers')
 
 describe('setName', () => {
   it('should return same observable', () => {
     const a = stream()
-    expect(a.setName('foo')).toBe(a)
-    expect(a.setName(stream(), 'foo')).toBe(a)
+    expect(a.setName('foo')).to.equal(a)
+    expect(a.setName(stream(), 'foo')).to.equal(a)
   })
 
   it('should update observable name', () => {
     const a = stream()
-    expect(a.toString()).toBe('[stream]')
+    expect(a.toString()).to.equal('[stream]')
     a.setName('foo')
-    expect(a.toString()).toBe('[foo]')
+    expect(a.toString()).to.equal('[foo]')
     a.setName(stream().setName('foo'), 'bar')
-    expect(a.toString()).toBe('[foo.bar]')
+    expect(a.toString()).to.equal('[foo.bar]')
   })
 })
 
@@ -21,7 +21,7 @@ describe('awaiting', () => {
   it('stream and stream', () => {
     const a = stream()
     const b = stream()
-    expect(a.awaiting(b)).toEmit([{current: false}, true, false, true], () => {
+    expect(a.awaiting(b)).to.emit([{current: false}, true, false, true], () => {
       send(a, [1])
       send(b, [1])
       send(b, [1])
@@ -33,7 +33,7 @@ describe('awaiting', () => {
   it('property and stream', () => {
     const a = send(prop(), [1])
     const b = stream()
-    expect(a.awaiting(b)).toEmit([{current: true}, false, true], () => {
+    expect(a.awaiting(b)).to.emit([{current: true}, false, true], () => {
       send(a, [1])
       send(b, [1])
       send(b, [1])
@@ -45,7 +45,7 @@ describe('awaiting', () => {
   it('property and property', () => {
     const a = send(prop(), [1])
     const b = send(prop(), [1])
-    expect(a.awaiting(b)).toEmit([{current: false}, true, false, true], () => {
+    expect(a.awaiting(b)).to.emit([{current: false}, true, false, true], () => {
       send(a, [1])
       send(b, [1])
       send(b, [1])

--- a/test/specs/take-errors.js
+++ b/test/specs/take-errors.js
@@ -1,4 +1,4 @@
-const {stream, prop, send, Kefir, pool, expect} = require('../test-helpers')
+const {stream, prop, send, value, error, end, Kefir, pool, expect} = require('../test-helpers')
 
 describe('takeErrors', () => {
   describe('stream', () => {
@@ -12,29 +12,29 @@ describe('takeErrors', () => {
     })
 
     it('should be ended if source was ended', () =>
-      expect(send(stream(), ['<end>']).takeErrors(3)).to.emit(['<end:current>']))
+      expect(send(stream(), [end()]).takeErrors(3)).to.emit([end({current: true})]))
 
     it('should be ended if `n` is 0', () => {
-      expect(stream().takeErrors(0)).to.emit(['<end:current>'])
+      expect(stream().takeErrors(0)).to.emit([end({current: true})])
     })
 
     it('should handle events (less than `n`)', () => {
       const a = stream()
-      expect(a.takeErrors(3)).to.emit([{error: 1}, {error: 2}, '<end>'], () =>
-        send(a, [{error: 1}, {error: 2}, '<end>'])
-      )
+      expect(a.takeErrors(3)).to.emit([error(1), error(2), end()], () => send(a, [error(1), error(2), end()]))
     })
 
     it('should handle events (more than `n`)', () => {
       const a = stream()
-      expect(a.takeErrors(3)).to.emit([{error: 1}, {error: 2}, {error: 3}, '<end>'], () =>
-        send(a, [{error: 1}, {error: 2}, {error: 3}, {error: 4}, {error: 5}, '<end>'])
+      expect(a.takeErrors(3)).to.emit([error(1), error(2), error(3), end()], () =>
+        send(a, [error(1), error(2), error(3), error(4), error(5), end()])
       )
     })
 
     it('values should flow', () => {
       const a = stream()
-      expect(a.takeErrors(1)).to.emit([1, 2, 3, '<end>'], () => send(a, [1, 2, 3, '<end>']))
+      expect(a.takeErrors(1)).to.emit([value(1), value(2), value(3), end()], () =>
+        send(a, [value(1), value(2), value(3), end()])
+      )
     })
 
     it('should emit once on circular dependency', () => {
@@ -42,9 +42,7 @@ describe('takeErrors', () => {
       const b = a.takeErrors(1).mapErrors(x => x + 1)
       a.plug(b)
 
-      expect(b).to.emit([{error: 2}, '<end>'], () =>
-        send(a, [{error: 1}, {error: 2}, {error: 3}, {error: 4}, {error: 5}])
-      )
+      expect(b).to.emit([error(2), end()], () => send(a, [error(1), error(2), error(3), error(4), error(5)]))
     })
   })
 
@@ -59,28 +57,30 @@ describe('takeErrors', () => {
     })
 
     it('should be ended if source was ended', () =>
-      expect(send(prop(), ['<end>']).takeErrors(3)).to.emit(['<end:current>']))
+      expect(send(prop(), [end()]).takeErrors(3)).to.emit([end({current: true})]))
 
-    it('should be ended if `n` is 0', () => expect(prop().takeErrors(0)).to.emit(['<end:current>']))
+    it('should be ended if `n` is 0', () => expect(prop().takeErrors(0)).to.emit([end({current: true})]))
 
     it('should handle events and current (less than `n`)', () => {
-      const a = send(prop(), [{error: 1}])
-      expect(a.takeErrors(3)).to.emit([{currentError: 1}, {error: 2}, '<end>'], () => send(a, [{error: 2}, '<end>']))
+      const a = send(prop(), [error(1)])
+      expect(a.takeErrors(3)).to.emit([error(1, {current: true}), error(2), end()], () => send(a, [error(2), end()]))
     })
 
     it('should handle events and current (more than `n`)', () => {
-      const a = send(prop(), [{error: 1}])
-      expect(a.takeErrors(3)).to.emit([{currentError: 1}, {error: 2}, {error: 3}, '<end>'], () =>
-        send(a, [{error: 2}, {error: 3}, {error: 4}, {error: 5}, '<end>'])
+      const a = send(prop(), [error(1)])
+      expect(a.takeErrors(3)).to.emit([error(1, {current: true}), error(2), error(3), end()], () =>
+        send(a, [error(2), error(3), error(4), error(5), end()])
       )
     })
 
     it('should work correctly with .constant', () =>
-      expect(Kefir.constantError(1).takeErrors(1)).to.emit([{currentError: 1}, '<end:current>']))
+      expect(Kefir.constantError(1).takeErrors(1)).to.emit([error(1, {current: true}), end({current: true})]))
 
     it('values should flow', () => {
-      const a = send(prop(), [1])
-      expect(a.takeErrors(1)).to.emit([{current: 1}, 2, 3, 4, '<end>'], () => send(a, [2, 3, 4, '<end>']))
+      const a = send(prop(), [value(1)])
+      expect(a.takeErrors(1)).to.emit([value(1, {current: true}), value(2), value(3), value(4), end()], () =>
+        send(a, [value(2), value(3), value(4), end()])
+      )
     })
   })
 })

--- a/test/specs/take-errors.js
+++ b/test/specs/take-errors.js
@@ -1,40 +1,40 @@
-const {stream, prop, send, Kefir, pool} = require('../test-helpers')
+const {stream, prop, send, Kefir, pool, expect} = require('../test-helpers')
 
 describe('takeErrors', () => {
   describe('stream', () => {
     it('should return stream', () => {
-      expect(stream().takeErrors(3)).toBeStream()
+      expect(stream().takeErrors(3)).to.be.observable.stream()
     })
 
     it('should activate/deactivate source', () => {
       const a = stream()
-      expect(a.takeErrors(3)).toActivate(a)
+      expect(a.takeErrors(3)).to.activate(a)
     })
 
     it('should be ended if source was ended', () =>
-      expect(send(stream(), ['<end>']).takeErrors(3)).toEmit(['<end:current>']))
+      expect(send(stream(), ['<end>']).takeErrors(3)).to.emit(['<end:current>']))
 
     it('should be ended if `n` is 0', () => {
-      expect(stream().takeErrors(0)).toEmit(['<end:current>'])
+      expect(stream().takeErrors(0)).to.emit(['<end:current>'])
     })
 
     it('should handle events (less than `n`)', () => {
       const a = stream()
-      expect(a.takeErrors(3)).toEmit([{error: 1}, {error: 2}, '<end>'], () =>
+      expect(a.takeErrors(3)).to.emit([{error: 1}, {error: 2}, '<end>'], () =>
         send(a, [{error: 1}, {error: 2}, '<end>'])
       )
     })
 
     it('should handle events (more than `n`)', () => {
       const a = stream()
-      expect(a.takeErrors(3)).toEmit([{error: 1}, {error: 2}, {error: 3}, '<end>'], () =>
+      expect(a.takeErrors(3)).to.emit([{error: 1}, {error: 2}, {error: 3}, '<end>'], () =>
         send(a, [{error: 1}, {error: 2}, {error: 3}, {error: 4}, {error: 5}, '<end>'])
       )
     })
 
     it('values should flow', () => {
       const a = stream()
-      expect(a.takeErrors(1)).toEmit([1, 2, 3, '<end>'], () => send(a, [1, 2, 3, '<end>']))
+      expect(a.takeErrors(1)).to.emit([1, 2, 3, '<end>'], () => send(a, [1, 2, 3, '<end>']))
     })
 
     it('should emit once on circular dependency', () => {
@@ -42,7 +42,7 @@ describe('takeErrors', () => {
       const b = a.takeErrors(1).mapErrors(x => x + 1)
       a.plug(b)
 
-      expect(b).toEmit([{error: 2}, '<end>'], () =>
+      expect(b).to.emit([{error: 2}, '<end>'], () =>
         send(a, [{error: 1}, {error: 2}, {error: 3}, {error: 4}, {error: 5}])
       )
     })
@@ -50,37 +50,37 @@ describe('takeErrors', () => {
 
   describe('property', () => {
     it('should return property', () => {
-      expect(prop().takeErrors(3)).toBeProperty()
+      expect(prop().takeErrors(3)).to.be.observable.property()
     })
 
     it('should activate/deactivate source', () => {
       const a = prop()
-      expect(a.takeErrors(3)).toActivate(a)
+      expect(a.takeErrors(3)).to.activate(a)
     })
 
     it('should be ended if source was ended', () =>
-      expect(send(prop(), ['<end>']).takeErrors(3)).toEmit(['<end:current>']))
+      expect(send(prop(), ['<end>']).takeErrors(3)).to.emit(['<end:current>']))
 
-    it('should be ended if `n` is 0', () => expect(prop().takeErrors(0)).toEmit(['<end:current>']))
+    it('should be ended if `n` is 0', () => expect(prop().takeErrors(0)).to.emit(['<end:current>']))
 
     it('should handle events and current (less than `n`)', () => {
       const a = send(prop(), [{error: 1}])
-      expect(a.takeErrors(3)).toEmit([{currentError: 1}, {error: 2}, '<end>'], () => send(a, [{error: 2}, '<end>']))
+      expect(a.takeErrors(3)).to.emit([{currentError: 1}, {error: 2}, '<end>'], () => send(a, [{error: 2}, '<end>']))
     })
 
     it('should handle events and current (more than `n`)', () => {
       const a = send(prop(), [{error: 1}])
-      expect(a.takeErrors(3)).toEmit([{currentError: 1}, {error: 2}, {error: 3}, '<end>'], () =>
+      expect(a.takeErrors(3)).to.emit([{currentError: 1}, {error: 2}, {error: 3}, '<end>'], () =>
         send(a, [{error: 2}, {error: 3}, {error: 4}, {error: 5}, '<end>'])
       )
     })
 
     it('should work correctly with .constant', () =>
-      expect(Kefir.constantError(1).takeErrors(1)).toEmit([{currentError: 1}, '<end:current>']))
+      expect(Kefir.constantError(1).takeErrors(1)).to.emit([{currentError: 1}, '<end:current>']))
 
     it('values should flow', () => {
       const a = send(prop(), [1])
-      expect(a.takeErrors(1)).toEmit([{current: 1}, 2, 3, 4, '<end>'], () => send(a, [2, 3, 4, '<end>']))
+      expect(a.takeErrors(1)).to.emit([{current: 1}, 2, 3, 4, '<end>'], () => send(a, [2, 3, 4, '<end>']))
     })
   })
 })

--- a/test/specs/take-until-by.js
+++ b/test/specs/take-until-by.js
@@ -1,4 +1,4 @@
-const {stream, prop, send, Kefir, expect} = require('../test-helpers')
+const {stream, prop, send, value, error, end, Kefir, expect} = require('../test-helpers')
 
 describe('takeUntilBy', () => {
   describe('common', () =>
@@ -41,40 +41,40 @@ describe('takeUntilBy', () => {
     })
 
     it('should be ended if primary was ended', () =>
-      expect(send(stream(), ['<end>']).takeUntilBy(stream())).to.emit(['<end:current>']))
+      expect(send(stream(), [end()]).takeUntilBy(stream())).to.emit([end({current: true})]))
 
     it('should not be ended if secondary was ended', () =>
-      expect(stream().takeUntilBy(send(stream(), ['<end>']))).to.emit([]))
+      expect(stream().takeUntilBy(send(stream(), [end()]))).to.emit([]))
 
     it('should not end when secondary ends if there was no values from it', () => {
       const a = stream()
       const b = stream()
-      expect(a.takeUntilBy(b)).to.emit([], () => send(b, ['<end>']))
+      expect(a.takeUntilBy(b)).to.emit([], () => send(b, [end()]))
     })
 
     it('should end on first any value from secondary', () => {
       const a = stream()
       const b = stream()
-      expect(a.takeUntilBy(b)).to.emit(['<end>'], () => send(b, [0]))
+      expect(a.takeUntilBy(b)).to.emit([end()], () => send(b, [value(0)]))
     })
 
     it('should emit values from primary until first value from secondary', () => {
       const a = stream()
       const b = stream()
-      expect(a.takeUntilBy(b)).to.emit([1, 2], () => send(a, [1, 2]))
+      expect(a.takeUntilBy(b)).to.emit([value(1), value(2)], () => send(a, [value(1), value(2)]))
     })
 
     it('should take values as expected', () => {
       const a = stream()
       const b = stream()
-      expect(a.takeUntilBy(b)).to.emit([3, 4, '<end>'], () => {
-        send(a, [3, 4])
-        send(b, [0])
-        send(a, [5, 6])
-        send(b, [false])
-        send(a, [7, 8])
-        send(b, [true])
-        send(a, [9])
+      expect(a.takeUntilBy(b)).to.emit([value(3), value(4), end()], () => {
+        send(a, [value(3), value(4)])
+        send(b, [value(0)])
+        send(a, [value(5), value(6)])
+        send(b, [value(false)])
+        send(a, [value(7), value(8)])
+        send(b, [value(true)])
+        send(a, [value(9)])
       })
     })
   })
@@ -91,43 +91,44 @@ describe('takeUntilBy', () => {
     })
 
     it('should be ended if primary was ended', () =>
-      expect(send(stream(), ['<end>']).takeUntilBy(prop())).to.emit(['<end:current>']))
+      expect(send(stream(), [end()]).takeUntilBy(prop())).to.emit([end({current: true})]))
 
     it('should not be ended if secondary was ended and has no current', () =>
-      expect(stream().takeUntilBy(send(prop(), ['<end>']))).to.emit([]))
+      expect(stream().takeUntilBy(send(prop(), [end()]))).to.emit([]))
 
-    it('should be ended if secondary was ended and has any current', () =>
-      expect(stream().takeUntilBy(send(prop(), [0, '<end>']))).to.emit(['<end:current>']))
+    it('should be ended if secondary was ended and has any current', () => {
+      expect(stream().takeUntilBy(send(prop(), [value(0), end()]))).to.emit([end({current: true})])
+    })
 
     it('should end on first any value from secondary', () => {
       const a = stream()
       const b = prop()
-      expect(a.takeUntilBy(b)).to.emit(['<end>'], () => send(b, [0]))
+      expect(a.takeUntilBy(b)).to.emit([end()], () => send(b, [value(0)]))
     })
 
     it('should not end when secondary ends there was no values from it', () => {
       const a = stream()
       const b = prop()
-      expect(a.takeUntilBy(b)).to.emit([], () => send(b, ['<end>']))
+      expect(a.takeUntilBy(b)).to.emit([], () => send(b, [end()]))
     })
 
     it('should emit values from primary until first value from secondary', () => {
       const a = stream()
       const b = prop()
-      expect(a.takeUntilBy(b)).to.emit([1, 2], () => send(a, [1, 2]))
+      expect(a.takeUntilBy(b)).to.emit([value(1), value(2)], () => send(a, [value(1), value(2)]))
     })
 
     it('should take values as expected', () => {
       const a = stream()
       const b = prop()
-      expect(a.takeUntilBy(b)).to.emit([3, 4, '<end>'], () => {
-        send(a, [3, 4])
-        send(b, [0])
-        send(a, [5, 6])
-        send(b, [false])
-        send(a, [7, 8])
-        send(b, [true])
-        send(a, [9])
+      expect(a.takeUntilBy(b)).to.emit([value(3), value(4), end()], () => {
+        send(a, [value(3), value(4)])
+        send(b, [value(0)])
+        send(a, [value(5), value(6)])
+        send(b, [value(false)])
+        send(a, [value(7), value(8)])
+        send(b, [value(true)])
+        send(a, [value(9)])
       })
     })
   })
@@ -144,40 +145,40 @@ describe('takeUntilBy', () => {
     })
 
     it('should be ended if primary was ended', () =>
-      expect(send(prop(), ['<end>']).takeUntilBy(stream())).to.emit(['<end:current>']))
+      expect(send(prop(), [end()]).takeUntilBy(stream())).to.emit([end({current: true})]))
 
     it('should not be ended if secondary was ended', () =>
-      expect(prop().takeUntilBy(send(stream(), ['<end>']))).to.emit([]))
+      expect(prop().takeUntilBy(send(stream(), [end()]))).to.emit([]))
 
     it('should not end when secondary ends if there was no values from it', () => {
       const a = prop()
       const b = stream()
-      expect(a.takeUntilBy(b)).to.emit([], () => send(b, ['<end>']))
+      expect(a.takeUntilBy(b)).to.emit([], () => send(b, [end()]))
     })
 
     it('should end on first any value from secondary', () => {
       const a = prop()
       const b = stream()
-      expect(a.takeUntilBy(b)).to.emit(['<end>'], () => send(b, [0]))
+      expect(a.takeUntilBy(b)).to.emit([end()], () => send(b, [value(0)]))
     })
 
     it('should emit values from primary until first value from secondary', () => {
       const a = prop()
       const b = stream()
-      expect(a.takeUntilBy(b)).to.emit([1, 2], () => send(a, [1, 2]))
+      expect(a.takeUntilBy(b)).to.emit([value(1), value(2)], () => send(a, [value(1), value(2)]))
     })
 
     it('should take values as expected', () => {
-      const a = send(prop(), [0])
+      const a = send(prop(), [value(0)])
       const b = stream()
-      expect(a.takeUntilBy(b)).to.emit([{current: 0}, 3, 4, '<end>'], () => {
-        send(a, [3, 4])
-        send(b, [1])
-        send(a, [5, 6])
-        send(b, [false])
-        send(a, [7, 8])
-        send(b, [true])
-        send(a, [9])
+      expect(a.takeUntilBy(b)).to.emit([value(0, {current: true}), value(3), value(4), end()], () => {
+        send(a, [value(3), value(4)])
+        send(b, [value(1)])
+        send(a, [value(5), value(6)])
+        send(b, [value(false)])
+        send(a, [value(7), value(8)])
+        send(b, [value(true)])
+        send(a, [value(9)])
       })
     })
   })
@@ -192,43 +193,43 @@ describe('takeUntilBy', () => {
     })
 
     it('should be ended if primary was ended', () =>
-      expect(send(prop(), ['<end>']).takeUntilBy(prop())).to.emit(['<end:current>']))
+      expect(send(prop(), [end()]).takeUntilBy(prop())).to.emit([end({current: true})]))
 
     it('should not be ended if secondary was ended and has no current', () =>
-      expect(prop().takeUntilBy(send(prop(), ['<end>']))).to.emit([]))
+      expect(prop().takeUntilBy(send(prop(), [end()]))).to.emit([]))
 
     it('should be ended if secondary was ended and has any current', () =>
-      expect(prop().takeUntilBy(send(prop(), [0, '<end>']))).to.emit(['<end:current>']))
+      expect(prop().takeUntilBy(send(prop(), [value(0), end()]))).to.emit([end({current: true})]))
 
     it('should end on first any value from secondary', () => {
       const a = prop()
       const b = prop()
-      expect(a.takeUntilBy(b)).to.emit(['<end>'], () => send(b, [0]))
+      expect(a.takeUntilBy(b)).to.emit([end()], () => send(b, [value(0)]))
     })
 
     it('should not end when secondary ends if there was no values from it', () => {
       const a = prop()
       const b = prop()
-      expect(a.takeUntilBy(b)).to.emit([], () => send(b, ['<end>']))
+      expect(a.takeUntilBy(b)).to.emit([], () => send(b, [end()]))
     })
 
     it('should emit values from primary until first value from secondary', () => {
       const a = prop()
       const b = prop()
-      expect(a.takeUntilBy(b)).to.emit([1, 2], () => send(a, [1, 2]))
+      expect(a.takeUntilBy(b)).to.emit([value(1), value(2)], () => send(a, [value(1), value(2)]))
     })
 
     it('should take values as expected', () => {
-      const a = send(prop(), [0])
+      const a = send(prop(), [value(0)])
       const b = prop()
-      expect(a.takeUntilBy(b)).to.emit([{current: 0}, 3, 4, '<end>'], () => {
-        send(a, [3, 4])
-        send(b, [1])
-        send(a, [5, 6])
-        send(b, [false])
-        send(a, [7, 8])
-        send(b, [true])
-        send(a, [9])
+      expect(a.takeUntilBy(b)).to.emit([value(0, {current: true}), value(3), value(4), end()], () => {
+        send(a, [value(3), value(4)])
+        send(b, [value(1)])
+        send(a, [value(5), value(6)])
+        send(b, [value(false)])
+        send(a, [value(7), value(8)])
+        send(b, [value(true)])
+        send(a, [value(9)])
       })
     })
   })

--- a/test/specs/take-until-by.js
+++ b/test/specs/take-until-by.js
@@ -1,73 +1,73 @@
-const {stream, prop, send, Kefir} = require('../test-helpers')
+const {stream, prop, send, Kefir, expect} = require('../test-helpers')
 
 describe('takeUntilBy', () => {
   describe('common', () =>
     it('errors should flow', () => {
       let a = stream()
       let b = stream()
-      expect(a.takeUntilBy(b)).errorsToFlow(a)
+      expect(a.takeUntilBy(b)).to.flowErrors(a)
       a = stream()
       b = stream()
-      expect(a.takeUntilBy(b)).errorsToFlow(b)
+      expect(a.takeUntilBy(b)).to.flowErrors(b)
       a = prop()
       b = stream()
-      expect(a.takeUntilBy(b)).errorsToFlow(a)
+      expect(a.takeUntilBy(b)).to.flowErrors(a)
       a = prop()
       b = stream()
-      expect(a.takeUntilBy(b)).errorsToFlow(b)
+      expect(a.takeUntilBy(b)).to.flowErrors(b)
       a = stream()
       b = prop()
-      expect(a.takeUntilBy(b)).errorsToFlow(a)
+      expect(a.takeUntilBy(b)).to.flowErrors(a)
       a = stream()
       b = prop()
-      expect(a.takeUntilBy(b)).errorsToFlow(b)
+      expect(a.takeUntilBy(b)).to.flowErrors(b)
       a = prop()
       b = prop()
-      expect(a.takeUntilBy(b)).errorsToFlow(a)
+      expect(a.takeUntilBy(b)).to.flowErrors(a)
       a = prop()
       b = prop()
-      expect(a.takeUntilBy(b)).errorsToFlow(b)
+      expect(a.takeUntilBy(b)).to.flowErrors(b)
     }))
 
   describe('stream, stream', () => {
     it('should return a stream', () => {
-      expect(stream().takeUntilBy(stream())).toBeStream()
+      expect(stream().takeUntilBy(stream())).to.be.observable.stream()
     })
 
     it('should activate/deactivate sources', () => {
       const a = stream()
       const b = stream()
-      expect(a.takeUntilBy(b)).toActivate(a, b)
+      expect(a.takeUntilBy(b)).to.activate(a, b)
     })
 
     it('should be ended if primary was ended', () =>
-      expect(send(stream(), ['<end>']).takeUntilBy(stream())).toEmit(['<end:current>']))
+      expect(send(stream(), ['<end>']).takeUntilBy(stream())).to.emit(['<end:current>']))
 
     it('should not be ended if secondary was ended', () =>
-      expect(stream().takeUntilBy(send(stream(), ['<end>']))).toEmit([]))
+      expect(stream().takeUntilBy(send(stream(), ['<end>']))).to.emit([]))
 
     it('should not end when secondary ends if there was no values from it', () => {
       const a = stream()
       const b = stream()
-      expect(a.takeUntilBy(b)).toEmit([], () => send(b, ['<end>']))
+      expect(a.takeUntilBy(b)).to.emit([], () => send(b, ['<end>']))
     })
 
     it('should end on first any value from secondary', () => {
       const a = stream()
       const b = stream()
-      expect(a.takeUntilBy(b)).toEmit(['<end>'], () => send(b, [0]))
+      expect(a.takeUntilBy(b)).to.emit(['<end>'], () => send(b, [0]))
     })
 
     it('should emit values from primary until first value from secondary', () => {
       const a = stream()
       const b = stream()
-      expect(a.takeUntilBy(b)).toEmit([1, 2], () => send(a, [1, 2]))
+      expect(a.takeUntilBy(b)).to.emit([1, 2], () => send(a, [1, 2]))
     })
 
     it('should take values as expected', () => {
       const a = stream()
       const b = stream()
-      expect(a.takeUntilBy(b)).toEmit([3, 4, '<end>'], () => {
+      expect(a.takeUntilBy(b)).to.emit([3, 4, '<end>'], () => {
         send(a, [3, 4])
         send(b, [0])
         send(a, [5, 6])
@@ -81,46 +81,46 @@ describe('takeUntilBy', () => {
 
   describe('stream, property', () => {
     it('should return a stream', () => {
-      expect(stream().takeUntilBy(prop())).toBeStream()
+      expect(stream().takeUntilBy(prop())).to.be.observable.stream()
     })
 
     it('should activate/deactivate sources', () => {
       const a = stream()
       const b = prop()
-      expect(a.takeUntilBy(b)).toActivate(a, b)
+      expect(a.takeUntilBy(b)).to.activate(a, b)
     })
 
     it('should be ended if primary was ended', () =>
-      expect(send(stream(), ['<end>']).takeUntilBy(prop())).toEmit(['<end:current>']))
+      expect(send(stream(), ['<end>']).takeUntilBy(prop())).to.emit(['<end:current>']))
 
     it('should not be ended if secondary was ended and has no current', () =>
-      expect(stream().takeUntilBy(send(prop(), ['<end>']))).toEmit([]))
+      expect(stream().takeUntilBy(send(prop(), ['<end>']))).to.emit([]))
 
     it('should be ended if secondary was ended and has any current', () =>
-      expect(stream().takeUntilBy(send(prop(), [0, '<end>']))).toEmit(['<end:current>']))
+      expect(stream().takeUntilBy(send(prop(), [0, '<end>']))).to.emit(['<end:current>']))
 
     it('should end on first any value from secondary', () => {
       const a = stream()
       const b = prop()
-      expect(a.takeUntilBy(b)).toEmit(['<end>'], () => send(b, [0]))
+      expect(a.takeUntilBy(b)).to.emit(['<end>'], () => send(b, [0]))
     })
 
     it('should not end when secondary ends there was no values from it', () => {
       const a = stream()
       const b = prop()
-      expect(a.takeUntilBy(b)).toEmit([], () => send(b, ['<end>']))
+      expect(a.takeUntilBy(b)).to.emit([], () => send(b, ['<end>']))
     })
 
     it('should emit values from primary until first value from secondary', () => {
       const a = stream()
       const b = prop()
-      expect(a.takeUntilBy(b)).toEmit([1, 2], () => send(a, [1, 2]))
+      expect(a.takeUntilBy(b)).to.emit([1, 2], () => send(a, [1, 2]))
     })
 
     it('should take values as expected', () => {
       const a = stream()
       const b = prop()
-      expect(a.takeUntilBy(b)).toEmit([3, 4, '<end>'], () => {
+      expect(a.takeUntilBy(b)).to.emit([3, 4, '<end>'], () => {
         send(a, [3, 4])
         send(b, [0])
         send(a, [5, 6])
@@ -134,43 +134,43 @@ describe('takeUntilBy', () => {
 
   describe('property, stream', () => {
     it('should return a property', () => {
-      expect(prop().takeUntilBy(stream())).toBeProperty()
+      expect(prop().takeUntilBy(stream())).to.be.observable.property()
     })
 
     it('should activate/deactivate sources', () => {
       const a = prop()
       const b = stream()
-      expect(a.takeUntilBy(b)).toActivate(a, b)
+      expect(a.takeUntilBy(b)).to.activate(a, b)
     })
 
     it('should be ended if primary was ended', () =>
-      expect(send(prop(), ['<end>']).takeUntilBy(stream())).toEmit(['<end:current>']))
+      expect(send(prop(), ['<end>']).takeUntilBy(stream())).to.emit(['<end:current>']))
 
     it('should not be ended if secondary was ended', () =>
-      expect(prop().takeUntilBy(send(stream(), ['<end>']))).toEmit([]))
+      expect(prop().takeUntilBy(send(stream(), ['<end>']))).to.emit([]))
 
     it('should not end when secondary ends if there was no values from it', () => {
       const a = prop()
       const b = stream()
-      expect(a.takeUntilBy(b)).toEmit([], () => send(b, ['<end>']))
+      expect(a.takeUntilBy(b)).to.emit([], () => send(b, ['<end>']))
     })
 
     it('should end on first any value from secondary', () => {
       const a = prop()
       const b = stream()
-      expect(a.takeUntilBy(b)).toEmit(['<end>'], () => send(b, [0]))
+      expect(a.takeUntilBy(b)).to.emit(['<end>'], () => send(b, [0]))
     })
 
     it('should emit values from primary until first value from secondary', () => {
       const a = prop()
       const b = stream()
-      expect(a.takeUntilBy(b)).toEmit([1, 2], () => send(a, [1, 2]))
+      expect(a.takeUntilBy(b)).to.emit([1, 2], () => send(a, [1, 2]))
     })
 
     it('should take values as expected', () => {
       const a = send(prop(), [0])
       const b = stream()
-      expect(a.takeUntilBy(b)).toEmit([{current: 0}, 3, 4, '<end>'], () => {
+      expect(a.takeUntilBy(b)).to.emit([{current: 0}, 3, 4, '<end>'], () => {
         send(a, [3, 4])
         send(b, [1])
         send(a, [5, 6])
@@ -183,45 +183,45 @@ describe('takeUntilBy', () => {
   })
 
   describe('property, property', () => {
-    it('should return a property', () => expect(prop().takeUntilBy(prop())).toBeProperty())
+    it('should return a property', () => expect(prop().takeUntilBy(prop())).to.be.observable.property())
 
     it('should activate/deactivate sources', () => {
       const a = prop()
       const b = prop()
-      expect(a.takeUntilBy(b)).toActivate(a, b)
+      expect(a.takeUntilBy(b)).to.activate(a, b)
     })
 
     it('should be ended if primary was ended', () =>
-      expect(send(prop(), ['<end>']).takeUntilBy(prop())).toEmit(['<end:current>']))
+      expect(send(prop(), ['<end>']).takeUntilBy(prop())).to.emit(['<end:current>']))
 
     it('should not be ended if secondary was ended and has no current', () =>
-      expect(prop().takeUntilBy(send(prop(), ['<end>']))).toEmit([]))
+      expect(prop().takeUntilBy(send(prop(), ['<end>']))).to.emit([]))
 
     it('should be ended if secondary was ended and has any current', () =>
-      expect(prop().takeUntilBy(send(prop(), [0, '<end>']))).toEmit(['<end:current>']))
+      expect(prop().takeUntilBy(send(prop(), [0, '<end>']))).to.emit(['<end:current>']))
 
     it('should end on first any value from secondary', () => {
       const a = prop()
       const b = prop()
-      expect(a.takeUntilBy(b)).toEmit(['<end>'], () => send(b, [0]))
+      expect(a.takeUntilBy(b)).to.emit(['<end>'], () => send(b, [0]))
     })
 
     it('should not end when secondary ends if there was no values from it', () => {
       const a = prop()
       const b = prop()
-      expect(a.takeUntilBy(b)).toEmit([], () => send(b, ['<end>']))
+      expect(a.takeUntilBy(b)).to.emit([], () => send(b, ['<end>']))
     })
 
     it('should emit values from primary until first value from secondary', () => {
       const a = prop()
       const b = prop()
-      expect(a.takeUntilBy(b)).toEmit([1, 2], () => send(a, [1, 2]))
+      expect(a.takeUntilBy(b)).to.emit([1, 2], () => send(a, [1, 2]))
     })
 
     it('should take values as expected', () => {
       const a = send(prop(), [0])
       const b = prop()
-      expect(a.takeUntilBy(b)).toEmit([{current: 0}, 3, 4, '<end>'], () => {
+      expect(a.takeUntilBy(b)).to.emit([{current: 0}, 3, 4, '<end>'], () => {
         send(a, [3, 4])
         send(b, [1])
         send(a, [5, 6])

--- a/test/specs/take-while.js
+++ b/test/specs/take-while.js
@@ -1,4 +1,4 @@
-const {stream, prop, send, Kefir, expect} = require('../test-helpers')
+const {stream, prop, send, value, error, end, Kefir, expect} = require('../test-helpers')
 
 describe('takeWhile', () => {
   describe('stream', () => {
@@ -11,27 +11,32 @@ describe('takeWhile', () => {
       expect(a.takeWhile(() => true)).to.activate(a)
     })
 
-    it('should be ended if source was ended', () =>
-      expect(send(stream(), ['<end>']).takeWhile(() => true)).to.emit(['<end:current>']))
+    it('should be ended if source was ended', () => {
+      expect(send(stream(), [end()]).takeWhile(() => true)).to.emit([end({current: true})])
+    })
 
     it('should handle events', () => {
       const a = stream()
-      expect(a.takeWhile(x => x < 4)).to.emit([1, 2, 3, '<end>'], () => send(a, [1, 2, 3, 4, 5, '<end>']))
+      expect(a.takeWhile(x => x < 4)).to.emit([value(1), value(2), value(3), end()], () => {
+        send(a, [value(1), value(2), value(3), value(4), value(5), end()])
+      })
     })
 
     it('should handle events (natural end)', () => {
       const a = stream()
-      expect(a.takeWhile(x => x < 4)).to.emit([1, 2, '<end>'], () => send(a, [1, 2, '<end>']))
+      expect(a.takeWhile(x => x < 4)).to.emit([value(1), value(2), end()], () => send(a, [value(1), value(2), end()]))
     })
 
     it('should handle events (with `-> false`)', () => {
       const a = stream()
-      expect(a.takeWhile(() => false)).to.emit(['<end>'], () => send(a, [1, 2, '<end>']))
+      expect(a.takeWhile(() => false)).to.emit([end()], () => send(a, [value(1), value(2), end()]))
     })
 
     it('shoud use id as default predicate', () => {
       const a = stream()
-      expect(a.takeWhile()).to.emit([1, 2, '<end>'], () => send(a, [1, 2, 0, 5, '<end>']))
+      expect(a.takeWhile()).to.emit([value(1), value(2), end()], () =>
+        send(a, [value(1), value(2), value(0), value(5), end()])
+      )
     })
 
     it('errors should flow', () => {
@@ -51,31 +56,37 @@ describe('takeWhile', () => {
     })
 
     it('should be ended if source was ended', () =>
-      expect(send(prop(), ['<end>']).takeWhile(() => true)).to.emit(['<end:current>']))
+      expect(send(prop(), [end()]).takeWhile(() => true)).to.emit([end({current: true})]))
 
     it('should be ended if calback was `-> false` and source has a current', () =>
-      expect(send(prop(), [1]).takeWhile(() => false)).to.emit(['<end:current>']))
+      expect(send(prop(), [value(1)]).takeWhile(() => false)).to.emit([end({current: true})]))
 
     it('should handle events', () => {
-      const a = send(prop(), [1])
-      expect(a.takeWhile(x => x < 4)).to.emit([{current: 1}, 2, 3, '<end>'], () => send(a, [2, 3, 4, 5, '<end>']))
+      const a = send(prop(), [value(1)])
+      expect(a.takeWhile(x => x < 4)).to.emit([value(1, {current: true}), value(2), value(3), end()], () =>
+        send(a, [value(2), value(3), value(4), value(5), end()])
+      )
     })
 
     it('should handle events (natural end)', () => {
-      const a = send(prop(), [1])
-      expect(a.takeWhile(x => x < 4)).to.emit([{current: 1}, 2, '<end>'], () => send(a, [2, '<end>']))
+      const a = send(prop(), [value(1)])
+      expect(a.takeWhile(x => x < 4)).to.emit([value(1, {current: true}), value(2), end()], () =>
+        send(a, [value(2), end()])
+      )
     })
 
     it('should handle events (with `-> false`)', () => {
       const a = prop()
-      expect(a.takeWhile(() => false)).to.emit(['<end>'], () => send(a, [1, 2, '<end>']))
+      expect(a.takeWhile(() => false)).to.emit([end()], () => send(a, [value(1), value(2), end()]))
     })
 
     it('shoud use id as default predicate', () => {
-      let a = send(prop(), [1])
-      expect(a.takeWhile()).to.emit([{current: 1}, 2, '<end>'], () => send(a, [2, 0, 5, '<end>']))
-      a = send(prop(), [0])
-      expect(a.takeWhile()).to.emit(['<end:current>'], () => send(a, [2, 0, 5, '<end>']))
+      let a = send(prop(), [value(1)])
+      expect(a.takeWhile()).to.emit([value(1, {current: true}), value(2), end()], () =>
+        send(a, [value(2), value(0), value(5), end()])
+      )
+      a = send(prop(), [value(0)])
+      expect(a.takeWhile()).to.emit([end({current: true})], () => send(a, [value(2), value(0), value(5), end()]))
     })
 
     it('errors should flow', () => {

--- a/test/specs/take-while.js
+++ b/test/specs/take-while.js
@@ -1,86 +1,86 @@
-const {stream, prop, send, Kefir} = require('../test-helpers')
+const {stream, prop, send, Kefir, expect} = require('../test-helpers')
 
 describe('takeWhile', () => {
   describe('stream', () => {
     it('should return stream', () => {
-      expect(stream().takeWhile(() => true)).toBeStream()
+      expect(stream().takeWhile(() => true)).to.be.observable.stream()
     })
 
     it('should activate/deactivate source', () => {
       const a = stream()
-      expect(a.takeWhile(() => true)).toActivate(a)
+      expect(a.takeWhile(() => true)).to.activate(a)
     })
 
     it('should be ended if source was ended', () =>
-      expect(send(stream(), ['<end>']).takeWhile(() => true)).toEmit(['<end:current>']))
+      expect(send(stream(), ['<end>']).takeWhile(() => true)).to.emit(['<end:current>']))
 
     it('should handle events', () => {
       const a = stream()
-      expect(a.takeWhile(x => x < 4)).toEmit([1, 2, 3, '<end>'], () => send(a, [1, 2, 3, 4, 5, '<end>']))
+      expect(a.takeWhile(x => x < 4)).to.emit([1, 2, 3, '<end>'], () => send(a, [1, 2, 3, 4, 5, '<end>']))
     })
 
     it('should handle events (natural end)', () => {
       const a = stream()
-      expect(a.takeWhile(x => x < 4)).toEmit([1, 2, '<end>'], () => send(a, [1, 2, '<end>']))
+      expect(a.takeWhile(x => x < 4)).to.emit([1, 2, '<end>'], () => send(a, [1, 2, '<end>']))
     })
 
     it('should handle events (with `-> false`)', () => {
       const a = stream()
-      expect(a.takeWhile(() => false)).toEmit(['<end>'], () => send(a, [1, 2, '<end>']))
+      expect(a.takeWhile(() => false)).to.emit(['<end>'], () => send(a, [1, 2, '<end>']))
     })
 
     it('shoud use id as default predicate', () => {
       const a = stream()
-      expect(a.takeWhile()).toEmit([1, 2, '<end>'], () => send(a, [1, 2, 0, 5, '<end>']))
+      expect(a.takeWhile()).to.emit([1, 2, '<end>'], () => send(a, [1, 2, 0, 5, '<end>']))
     })
 
     it('errors should flow', () => {
       const a = stream()
-      expect(a.takeWhile()).errorsToFlow(a)
+      expect(a.takeWhile()).to.flowErrors(a)
     })
   })
 
   describe('property', () => {
     it('should return property', () => {
-      expect(prop().takeWhile(() => true)).toBeProperty()
+      expect(prop().takeWhile(() => true)).to.be.observable.property()
     })
 
     it('should activate/deactivate source', () => {
       const a = prop()
-      expect(a.takeWhile(() => true)).toActivate(a)
+      expect(a.takeWhile(() => true)).to.activate(a)
     })
 
     it('should be ended if source was ended', () =>
-      expect(send(prop(), ['<end>']).takeWhile(() => true)).toEmit(['<end:current>']))
+      expect(send(prop(), ['<end>']).takeWhile(() => true)).to.emit(['<end:current>']))
 
     it('should be ended if calback was `-> false` and source has a current', () =>
-      expect(send(prop(), [1]).takeWhile(() => false)).toEmit(['<end:current>']))
+      expect(send(prop(), [1]).takeWhile(() => false)).to.emit(['<end:current>']))
 
     it('should handle events', () => {
       const a = send(prop(), [1])
-      expect(a.takeWhile(x => x < 4)).toEmit([{current: 1}, 2, 3, '<end>'], () => send(a, [2, 3, 4, 5, '<end>']))
+      expect(a.takeWhile(x => x < 4)).to.emit([{current: 1}, 2, 3, '<end>'], () => send(a, [2, 3, 4, 5, '<end>']))
     })
 
     it('should handle events (natural end)', () => {
       const a = send(prop(), [1])
-      expect(a.takeWhile(x => x < 4)).toEmit([{current: 1}, 2, '<end>'], () => send(a, [2, '<end>']))
+      expect(a.takeWhile(x => x < 4)).to.emit([{current: 1}, 2, '<end>'], () => send(a, [2, '<end>']))
     })
 
     it('should handle events (with `-> false`)', () => {
       const a = prop()
-      expect(a.takeWhile(() => false)).toEmit(['<end>'], () => send(a, [1, 2, '<end>']))
+      expect(a.takeWhile(() => false)).to.emit(['<end>'], () => send(a, [1, 2, '<end>']))
     })
 
     it('shoud use id as default predicate', () => {
       let a = send(prop(), [1])
-      expect(a.takeWhile()).toEmit([{current: 1}, 2, '<end>'], () => send(a, [2, 0, 5, '<end>']))
+      expect(a.takeWhile()).to.emit([{current: 1}, 2, '<end>'], () => send(a, [2, 0, 5, '<end>']))
       a = send(prop(), [0])
-      expect(a.takeWhile()).toEmit(['<end:current>'], () => send(a, [2, 0, 5, '<end>']))
+      expect(a.takeWhile()).to.emit(['<end:current>'], () => send(a, [2, 0, 5, '<end>']))
     })
 
     it('errors should flow', () => {
       const a = prop()
-      expect(a.takeWhile()).errorsToFlow(a)
+      expect(a.takeWhile()).to.flowErrors(a)
     })
   })
 })

--- a/test/specs/take.js
+++ b/test/specs/take.js
@@ -1,37 +1,37 @@
-const {stream, prop, send, Kefir, pool} = require('../test-helpers')
+const {stream, prop, send, Kefir, pool, expect} = require('../test-helpers')
 
 describe('take', () => {
   describe('stream', () => {
     it('should return stream', () => {
-      expect(stream().take(3)).toBeStream()
+      expect(stream().take(3)).to.be.observable.stream()
     })
 
     it('should activate/deactivate source', () => {
       const a = stream()
-      expect(a.take(3)).toActivate(a)
+      expect(a.take(3)).to.activate(a)
     })
 
     it('should be ended if source was ended', () => {
-      expect(send(stream(), ['<end>']).take(3)).toEmit(['<end:current>'])
+      expect(send(stream(), ['<end>']).take(3)).to.emit(['<end:current>'])
     })
 
     it('should be ended if `n` is 0', () => {
-      expect(stream().take(0)).toEmit(['<end:current>'])
+      expect(stream().take(0)).to.emit(['<end:current>'])
     })
 
     it('should handle events (less than `n`)', () => {
       const a = stream()
-      expect(a.take(3)).toEmit([1, 2, '<end>'], () => send(a, [1, 2, '<end>']))
+      expect(a.take(3)).to.emit([1, 2, '<end>'], () => send(a, [1, 2, '<end>']))
     })
 
     it('should handle events (more than `n`)', () => {
       const a = stream()
-      expect(a.take(3)).toEmit([1, 2, 3, '<end>'], () => send(a, [1, 2, 3, 4, 5, '<end>']))
+      expect(a.take(3)).to.emit([1, 2, 3, '<end>'], () => send(a, [1, 2, 3, 4, 5, '<end>']))
     })
 
     it('errors should flow', () => {
       const a = stream()
-      expect(a.take(1)).errorsToFlow(a)
+      expect(a.take(1)).to.flowErrors(a)
     })
 
     it('should emit once on circular dependency', () => {
@@ -39,42 +39,42 @@ describe('take', () => {
       const b = a.take(1).map(x => x + 1)
       a.plug(b)
 
-      expect(b).toEmit([2, '<end>'], () => send(a, [1, 2, 3, 4, 5]))
+      expect(b).to.emit([2, '<end>'], () => send(a, [1, 2, 3, 4, 5]))
     })
   })
 
   describe('property', () => {
-    it('should return property', () => expect(prop().take(3)).toBeProperty())
+    it('should return property', () => expect(prop().take(3)).to.be.observable.property())
 
     it('should activate/deactivate source', () => {
       const a = prop()
-      expect(a.take(3)).toActivate(a)
+      expect(a.take(3)).to.activate(a)
     })
 
     it('should be ended if source was ended', () => {
-      expect(send(prop(), ['<end>']).take(3)).toEmit(['<end:current>'])
+      expect(send(prop(), ['<end>']).take(3)).to.emit(['<end:current>'])
     })
 
     it('should be ended if `n` is 0', () => {
-      expect(prop().take(0)).toEmit(['<end:current>'])
+      expect(prop().take(0)).to.emit(['<end:current>'])
     })
 
     it('should handle events and current (less than `n`)', () => {
       const a = send(prop(), [1])
-      expect(a.take(3)).toEmit([{current: 1}, 2, '<end>'], () => send(a, [2, '<end>']))
+      expect(a.take(3)).to.emit([{current: 1}, 2, '<end>'], () => send(a, [2, '<end>']))
     })
 
     it('should handle events and current (more than `n`)', () => {
       const a = send(prop(), [1])
-      expect(a.take(3)).toEmit([{current: 1}, 2, 3, '<end>'], () => send(a, [2, 3, 4, 5, '<end>']))
+      expect(a.take(3)).to.emit([{current: 1}, 2, 3, '<end>'], () => send(a, [2, 3, 4, 5, '<end>']))
     })
 
     it('should work correctly with .constant', () =>
-      expect(Kefir.constant(1).take(1)).toEmit([{current: 1}, '<end:current>']))
+      expect(Kefir.constant(1).take(1)).to.emit([{current: 1}, '<end:current>']))
 
     it('errors should flow', () => {
       const a = prop()
-      expect(a.take(1)).errorsToFlow(a)
+      expect(a.take(1)).to.flowErrors(a)
     })
   })
 })

--- a/test/specs/throttle.js
+++ b/test/specs/throttle.js
@@ -1,4 +1,4 @@
-const {stream, prop, send, Kefir, expect} = require('../test-helpers')
+const {stream, prop, send, value, end, expect} = require('../test-helpers')
 
 describe('throttle', () => {
   describe('stream', () => {
@@ -12,32 +12,40 @@ describe('throttle', () => {
     })
 
     it('should be ended if source was ended', () =>
-      expect(send(stream(), ['<end>']).throttle(100)).to.emit(['<end:current>']))
+      expect(send(stream(), [end()]).throttle(100)).to.emit([end({current: true})]))
 
     it('should handle events', () => {
       const a = stream()
       expect(a.throttle(100)).to.emitInTime(
-        [[0, 1], [100, 4], [200, 5], [320, 6], [520, 7], [620, 9], [620, '<end>']],
+        [
+          [0, value(1)],
+          [100, value(4)],
+          [200, value(5)],
+          [320, value(6)],
+          [520, value(7)],
+          [620, value(9)],
+          [620, end()],
+        ],
         tick => {
-          send(a, [1])
+          send(a, [value(1)])
           tick(30)
-          send(a, [2])
+          send(a, [value(2)])
           tick(30)
-          send(a, [3])
+          send(a, [value(3)])
           tick(30)
-          send(a, [4])
+          send(a, [value(4)])
           tick(30)
-          send(a, [5])
+          send(a, [value(5)])
           tick(200)
-          send(a, [6])
+          send(a, [value(6)])
           tick(200)
-          send(a, [7])
+          send(a, [value(7)])
           tick(30)
-          send(a, [8])
+          send(a, [value(8)])
           tick(30)
-          send(a, [9])
+          send(a, [value(9)])
           tick(30)
-          send(a, ['<end>'])
+          send(a, [end()])
         }
       )
     })
@@ -45,27 +53,27 @@ describe('throttle', () => {
     it('should handle events {trailing: false}', () => {
       const a = stream()
       expect(a.throttle(100, {trailing: false})).to.emitInTime(
-        [[0, 1], [120, 5], [320, 6], [520, 7], [610, '<end>']],
+        [[0, value(1)], [120, value(5)], [320, value(6)], [520, value(7)], [610, end()]],
         tick => {
-          send(a, [1])
+          send(a, [value(1)])
           tick(30)
-          send(a, [2])
+          send(a, [value(2)])
           tick(30)
-          send(a, [3])
+          send(a, [value(3)])
           tick(30)
-          send(a, [4])
+          send(a, [value(4)])
           tick(30)
-          send(a, [5])
+          send(a, [value(5)])
           tick(200)
-          send(a, [6])
+          send(a, [value(6)])
           tick(200)
-          send(a, [7])
+          send(a, [value(7)])
           tick(30)
-          send(a, [8])
+          send(a, [value(8)])
           tick(30)
-          send(a, [9])
+          send(a, [value(9)])
           tick(30)
-          send(a, ['<end>'])
+          send(a, [end()])
         }
       )
     })
@@ -73,27 +81,27 @@ describe('throttle', () => {
     it('should handle events {leading: false}', () => {
       const a = stream()
       expect(a.throttle(100, {leading: false})).to.emitInTime(
-        [[100, 4], [220, 5], [420, 6], [620, 9], [620, '<end>']],
+        [[100, value(4)], [220, value(5)], [420, value(6)], [620, value(9)], [620, end()]],
         tick => {
-          send(a, [1])
+          send(a, [value(1)])
           tick(30)
-          send(a, [2])
+          send(a, [value(2)])
           tick(30)
-          send(a, [3])
+          send(a, [value(3)])
           tick(30)
-          send(a, [4])
+          send(a, [value(4)])
           tick(30)
-          send(a, [5])
+          send(a, [value(5)])
           tick(200)
-          send(a, [6])
+          send(a, [value(6)])
           tick(200)
-          send(a, [7])
+          send(a, [value(7)])
           tick(30)
-          send(a, [8])
+          send(a, [value(8)])
           tick(30)
-          send(a, [9])
+          send(a, [value(9)])
           tick(30)
-          send(a, ['<end>'])
+          send(a, [end()])
         }
       )
     })
@@ -101,27 +109,27 @@ describe('throttle', () => {
     it('should handle events {leading: false, trailing: false}', () => {
       const a = stream()
       expect(a.throttle(100, {leading: false, trailing: false})).to.emitInTime(
-        [[120, 5], [320, 6], [520, 7], [610, '<end>']],
+        [[120, value(5)], [320, value(6)], [520, value(7)], [610, end()]],
         tick => {
-          send(a, [1])
+          send(a, [value(1)])
           tick(30)
-          send(a, [2])
+          send(a, [value(2)])
           tick(30)
-          send(a, [3])
+          send(a, [value(3)])
           tick(30)
-          send(a, [4])
+          send(a, [value(4)])
           tick(30)
-          send(a, [5])
+          send(a, [value(5)])
           tick(200)
-          send(a, [6])
+          send(a, [value(6)])
           tick(200)
-          send(a, [7])
+          send(a, [value(7)])
           tick(30)
-          send(a, [8])
+          send(a, [value(8)])
           tick(30)
-          send(a, [9])
+          send(a, [value(9)])
           tick(30)
-          send(a, ['<end>'])
+          send(a, [end()])
         }
       )
     })
@@ -143,116 +151,139 @@ describe('throttle', () => {
     })
 
     it('should be ended if source was ended', () =>
-      expect(send(prop(), ['<end>']).throttle(100)).to.emit(['<end:current>']))
+      expect(send(prop(), [end()]).throttle(100)).to.emit([end({current: true})]))
 
     it('should handle events', () => {
-      const a = send(prop(), [0])
+      const a = send(prop(), [value(0)])
       expect(a.throttle(100)).to.emitInTime(
-        [[0, {current: 0}], [0, 1], [100, 4], [200, 5], [320, 6], [520, 7], [620, 9], [620, '<end>']],
+        [
+          [0, value(0, {current: true})],
+          [0, value(1)],
+          [100, value(4)],
+          [200, value(5)],
+          [320, value(6)],
+          [520, value(7)],
+          [620, value(9)],
+          [620, end()],
+        ],
         tick => {
-          send(a, [1])
+          send(a, [value(1)])
           tick(30)
-          send(a, [2])
+          send(a, [value(2)])
           tick(30)
-          send(a, [3])
+          send(a, [value(3)])
           tick(30)
-          send(a, [4])
+          send(a, [value(4)])
           tick(30)
-          send(a, [5])
+          send(a, [value(5)])
           tick(200)
-          send(a, [6])
+          send(a, [value(6)])
           tick(200)
-          send(a, [7])
+          send(a, [value(7)])
           tick(30)
-          send(a, [8])
+          send(a, [value(8)])
           tick(30)
-          send(a, [9])
+          send(a, [value(9)])
           tick(30)
-          send(a, ['<end>'])
+          send(a, [end()])
         }
       )
     })
 
     it('should handle events {trailing: false}', () => {
-      const a = send(prop(), [0])
+      const a = send(prop(), [value(0)])
       expect(a.throttle(100, {trailing: false})).to.emitInTime(
-        [[0, {current: 0}], [0, 1], [120, 5], [320, 6], [520, 7], [610, '<end>']],
+        [
+          [0, value(0, {current: true})],
+          [0, value(1)],
+          [120, value(5)],
+          [320, value(6)],
+          [520, value(7)],
+          [610, end()],
+        ],
         tick => {
-          send(a, [1])
+          send(a, [value(1)])
           tick(30)
-          send(a, [2])
+          send(a, [value(2)])
           tick(30)
-          send(a, [3])
+          send(a, [value(3)])
           tick(30)
-          send(a, [4])
+          send(a, [value(4)])
           tick(30)
-          send(a, [5])
+          send(a, [value(5)])
           tick(200)
-          send(a, [6])
+          send(a, [value(6)])
           tick(200)
-          send(a, [7])
+          send(a, [value(7)])
           tick(30)
-          send(a, [8])
+          send(a, [value(8)])
           tick(30)
-          send(a, [9])
+          send(a, [value(9)])
           tick(30)
-          send(a, ['<end>'])
+          send(a, [end()])
         }
       )
     })
 
     it('should handle events {leading: false}', () => {
-      const a = send(prop(), [0])
+      const a = send(prop(), [value(0)])
       expect(a.throttle(100, {leading: false})).to.emitInTime(
-        [[0, {current: 0}], [100, 4], [220, 5], [420, 6], [620, 9], [620, '<end>']],
+        [
+          [0, value(0, {current: true})],
+          [100, value(4)],
+          [220, value(5)],
+          [420, value(6)],
+          [620, value(9)],
+          [620, end()],
+        ],
         tick => {
-          send(a, [1])
+          send(a, [value(1)])
           tick(30)
-          send(a, [2])
+          send(a, [value(2)])
           tick(30)
-          send(a, [3])
+          send(a, [value(3)])
           tick(30)
-          send(a, [4])
+          send(a, [value(4)])
           tick(30)
-          send(a, [5])
+          send(a, [value(5)])
           tick(200)
-          send(a, [6])
+          send(a, [value(6)])
           tick(200)
-          send(a, [7])
+          send(a, [value(7)])
           tick(30)
-          send(a, [8])
+          send(a, [value(8)])
           tick(30)
-          send(a, [9])
+          send(a, [value(9)])
           tick(30)
-          send(a, ['<end>'])
+          send(a, [end()])
         }
       )
     })
 
     it('should handle events {leading: false, trailing: false}', () => {
-      const a = send(prop(), [0])
+      const a = send(prop(), [value(0)])
       expect(a.throttle(100, {leading: false, trailing: false})).to.emitInTime(
-        [[0, {current: 0}], [120, 5], [320, 6], [520, 7], [610, '<end>']],
+        [[0, value(0, {current: true})], [120, value(5)], [320, value(6)], [520, value(7)], [610, end()]],
         tick => {
-          send(a, [1])
+          send(a, [value(1)])
           tick(30)
-          send(a, [2])
+          send(a, [value(2)])
           tick(30)
-          send(a, [3])
+          send(a, [value(3)])
           tick(30)
-          send(a, [4])
+          send(a, [value(4)])
           tick(30)
-          send(a, [5])
+          send(a, [value(5)])
           tick(200)
-          send(a, [6])
+          send(a, [value(6)])
           tick(200)
-          send(a, [7])
+          send(a, [value(7)])
           tick(30)
-          send(a, [8])
+          send(a, [value(8)])
           tick(30)
-          send(a, [9])
+          send(a, [value(9)])
           tick(30)
-          send(a, ['<end>'])
+          send(a, [end()])
         }
       )
     })

--- a/test/specs/throttle.js
+++ b/test/specs/throttle.js
@@ -1,22 +1,22 @@
-const {stream, prop, send, Kefir} = require('../test-helpers')
+const {stream, prop, send, Kefir, expect} = require('../test-helpers')
 
 describe('throttle', () => {
   describe('stream', () => {
     it('should return stream', () => {
-      expect(stream().throttle(100)).toBeStream()
+      expect(stream().throttle(100)).to.be.observable.stream()
     })
 
     it('should activate/deactivate source', () => {
       const a = stream()
-      expect(a.throttle(100)).toActivate(a)
+      expect(a.throttle(100)).to.activate(a)
     })
 
     it('should be ended if source was ended', () =>
-      expect(send(stream(), ['<end>']).throttle(100)).toEmit(['<end:current>']))
+      expect(send(stream(), ['<end>']).throttle(100)).to.emit(['<end:current>']))
 
     it('should handle events', () => {
       const a = stream()
-      expect(a.throttle(100)).toEmitInTime(
+      expect(a.throttle(100)).to.emitInTime(
         [[0, 1], [100, 4], [200, 5], [320, 6], [520, 7], [620, 9], [620, '<end>']],
         tick => {
           send(a, [1])
@@ -44,7 +44,7 @@ describe('throttle', () => {
 
     it('should handle events {trailing: false}', () => {
       const a = stream()
-      expect(a.throttle(100, {trailing: false})).toEmitInTime(
+      expect(a.throttle(100, {trailing: false})).to.emitInTime(
         [[0, 1], [120, 5], [320, 6], [520, 7], [610, '<end>']],
         tick => {
           send(a, [1])
@@ -72,7 +72,7 @@ describe('throttle', () => {
 
     it('should handle events {leading: false}', () => {
       const a = stream()
-      expect(a.throttle(100, {leading: false})).toEmitInTime(
+      expect(a.throttle(100, {leading: false})).to.emitInTime(
         [[100, 4], [220, 5], [420, 6], [620, 9], [620, '<end>']],
         tick => {
           send(a, [1])
@@ -100,7 +100,7 @@ describe('throttle', () => {
 
     it('should handle events {leading: false, trailing: false}', () => {
       const a = stream()
-      expect(a.throttle(100, {leading: false, trailing: false})).toEmitInTime(
+      expect(a.throttle(100, {leading: false, trailing: false})).to.emitInTime(
         [[120, 5], [320, 6], [520, 7], [610, '<end>']],
         tick => {
           send(a, [1])
@@ -128,26 +128,26 @@ describe('throttle', () => {
 
     it('errors should flow', () => {
       const a = stream()
-      expect(a.throttle(100)).errorsToFlow(a)
+      expect(a.throttle(100)).to.flowErrors(a)
     })
   })
 
   describe('property', () => {
     it('should return property', () => {
-      expect(prop().throttle(100)).toBeProperty()
+      expect(prop().throttle(100)).to.be.observable.property()
     })
 
     it('should activate/deactivate source', () => {
       const a = prop()
-      expect(a.throttle(100)).toActivate(a)
+      expect(a.throttle(100)).to.activate(a)
     })
 
     it('should be ended if source was ended', () =>
-      expect(send(prop(), ['<end>']).throttle(100)).toEmit(['<end:current>']))
+      expect(send(prop(), ['<end>']).throttle(100)).to.emit(['<end:current>']))
 
     it('should handle events', () => {
       const a = send(prop(), [0])
-      expect(a.throttle(100)).toEmitInTime(
+      expect(a.throttle(100)).to.emitInTime(
         [[0, {current: 0}], [0, 1], [100, 4], [200, 5], [320, 6], [520, 7], [620, 9], [620, '<end>']],
         tick => {
           send(a, [1])
@@ -175,7 +175,7 @@ describe('throttle', () => {
 
     it('should handle events {trailing: false}', () => {
       const a = send(prop(), [0])
-      expect(a.throttle(100, {trailing: false})).toEmitInTime(
+      expect(a.throttle(100, {trailing: false})).to.emitInTime(
         [[0, {current: 0}], [0, 1], [120, 5], [320, 6], [520, 7], [610, '<end>']],
         tick => {
           send(a, [1])
@@ -203,7 +203,7 @@ describe('throttle', () => {
 
     it('should handle events {leading: false}', () => {
       const a = send(prop(), [0])
-      expect(a.throttle(100, {leading: false})).toEmitInTime(
+      expect(a.throttle(100, {leading: false})).to.emitInTime(
         [[0, {current: 0}], [100, 4], [220, 5], [420, 6], [620, 9], [620, '<end>']],
         tick => {
           send(a, [1])
@@ -231,7 +231,7 @@ describe('throttle', () => {
 
     it('should handle events {leading: false, trailing: false}', () => {
       const a = send(prop(), [0])
-      expect(a.throttle(100, {leading: false, trailing: false})).toEmitInTime(
+      expect(a.throttle(100, {leading: false, trailing: false})).to.emitInTime(
         [[0, {current: 0}], [120, 5], [320, 6], [520, 7], [610, '<end>']],
         tick => {
           send(a, [1])
@@ -259,7 +259,7 @@ describe('throttle', () => {
 
     it('errors should flow', () => {
       const a = prop()
-      expect(a.throttle(100)).errorsToFlow(a)
+      expect(a.throttle(100)).to.flowErrors(a)
     })
   })
 })

--- a/test/specs/thru.js
+++ b/test/specs/thru.js
@@ -1,12 +1,12 @@
 const sinon = require('sinon')
-const {stream} = require('../test-helpers')
+const {stream, expect} = require('../test-helpers')
 
 describe('thru', () => {
   it('should call function and return result', () => {
     const spy = sinon.spy(() => 0)
     const a = stream()
 
-    expect(a.thru(spy)).toBe(0)
-    expect(spy.calledWith(a)).toBe(true)
+    expect(a.thru(spy)).to.equal(0)
+    expect(spy.calledWith(a)).to.equal(true)
   })
 })

--- a/test/specs/to-promise.js
+++ b/test/specs/to-promise.js
@@ -1,4 +1,4 @@
-const {stream, prop, send} = require('../test-helpers')
+const {stream, prop, send, expect} = require('../test-helpers')
 
 function Promise1(cb) {
   const promise = {type: 1, fulfilled: false, rejected: false}
@@ -50,44 +50,44 @@ describe('toPromise', () => {
 
   describe('stream', () => {
     it('should return a promise', () => {
-      expect(stream().toPromise().type).toBe(2)
-      expect(stream().toPromise(Promise1).type).toBe(1)
+      expect(stream().toPromise().type).to.equal(2)
+      expect(stream().toPromise(Promise1).type).to.equal(1)
     })
 
     it('should not fulfill/reject if obs ends without value', () => {
       let promise = send(stream(), ['<end>']).toPromise()
-      expect(promise.fulfilled || promise.rejected).toBe(false)
+      expect(promise.fulfilled || promise.rejected).to.equal(false)
 
       promise = send(stream(), ['<end>']).toPromise(Promise1)
-      expect(promise.fulfilled || promise.rejected).toBe(false)
+      expect(promise.fulfilled || promise.rejected).to.equal(false)
     })
 
     it('should fulfill with latest value on end', () => {
       let a = stream()
       let promise = a.toPromise()
       send(a, [1, {error: -1}, 2, '<end>'])
-      expect(promise.fulfilled).toBe(true)
-      expect(promise.result).toBe(2)
+      expect(promise.fulfilled).to.equal(true)
+      expect(promise.result).to.equal(2)
 
       a = stream()
       promise = a.toPromise(Promise1)
       send(a, [1, 2, '<end>'])
-      expect(promise.fulfilled).toBe(true)
-      expect(promise.result).toBe(2)
+      expect(promise.fulfilled).to.equal(true)
+      expect(promise.result).to.equal(2)
     })
 
     it('should reject with latest error on end', () => {
       let a = stream()
       let promise = a.toPromise()
       send(a, [{error: -1}, 1, {error: -2}, '<end>'])
-      expect(promise.rejected).toBe(true)
-      expect(promise.result).toBe(-2)
+      expect(promise.rejected).to.equal(true)
+      expect(promise.result).to.equal(-2)
 
       a = stream()
       promise = a.toPromise(Promise1)
       send(a, [{error: -1}, 1, {error: -2}, '<end>'])
-      expect(promise.rejected).toBe(true)
-      expect(promise.result).toBe(-2)
+      expect(promise.rejected).to.equal(true)
+      expect(promise.result).to.equal(-2)
     })
 
     it('should throw when called without Promise constructor and there is no global promise', () => {
@@ -98,29 +98,29 @@ describe('toPromise', () => {
       } catch (e) {
         error = e
       }
-      expect(error.message).toBe("There isn't default Promise, use shim or parameter")
+      expect(error.message).to.equal("There isn't default Promise, use shim or parameter")
     })
   })
 
   describe('property', () => {
     it('should handle currents (resolved)', () => {
       let promise = send(prop(), [1, '<end>']).toPromise()
-      expect(promise.fulfilled).toBe(true)
-      expect(promise.result).toBe(1)
+      expect(promise.fulfilled).to.equal(true)
+      expect(promise.result).to.equal(1)
 
       promise = send(prop(), [1, '<end>']).toPromise(Promise1)
-      expect(promise.fulfilled).toBe(true)
-      expect(promise.result).toBe(1)
+      expect(promise.fulfilled).to.equal(true)
+      expect(promise.result).to.equal(1)
     })
 
     it('should handle currents (rejected)', () => {
       let promise = send(prop(), [{error: -1}, '<end>']).toPromise()
-      expect(promise.rejected).toBe(true)
-      expect(promise.result).toBe(-1)
+      expect(promise.rejected).to.equal(true)
+      expect(promise.result).to.equal(-1)
 
       promise = send(prop(), [{error: -1}, '<end>']).toPromise(Promise1)
-      expect(promise.rejected).toBe(true)
-      expect(promise.result).toBe(-1)
+      expect(promise.rejected).to.equal(true)
+      expect(promise.result).to.equal(-1)
     })
   })
 })

--- a/test/specs/to-promise.js
+++ b/test/specs/to-promise.js
@@ -1,4 +1,4 @@
-const {stream, prop, send, expect} = require('../test-helpers')
+const {stream, prop, send, value, error, end, expect} = require('../test-helpers')
 
 function Promise1(cb) {
   const promise = {type: 1, fulfilled: false, rejected: false}
@@ -55,23 +55,23 @@ describe('toPromise', () => {
     })
 
     it('should not fulfill/reject if obs ends without value', () => {
-      let promise = send(stream(), ['<end>']).toPromise()
+      let promise = send(stream(), [end()]).toPromise()
       expect(promise.fulfilled || promise.rejected).to.equal(false)
 
-      promise = send(stream(), ['<end>']).toPromise(Promise1)
+      promise = send(stream(), [end()]).toPromise(Promise1)
       expect(promise.fulfilled || promise.rejected).to.equal(false)
     })
 
     it('should fulfill with latest value on end', () => {
       let a = stream()
       let promise = a.toPromise()
-      send(a, [1, {error: -1}, 2, '<end>'])
+      send(a, [value(1), error(-1, {current: true}), value(2), end()])
       expect(promise.fulfilled).to.equal(true)
       expect(promise.result).to.equal(2)
 
       a = stream()
       promise = a.toPromise(Promise1)
-      send(a, [1, 2, '<end>'])
+      send(a, [value(1), value(2), end()])
       expect(promise.fulfilled).to.equal(true)
       expect(promise.result).to.equal(2)
     })
@@ -79,13 +79,13 @@ describe('toPromise', () => {
     it('should reject with latest error on end', () => {
       let a = stream()
       let promise = a.toPromise()
-      send(a, [{error: -1}, 1, {error: -2}, '<end>'])
+      send(a, [error(-1, {current: true}), value(1), error(-2), end()])
       expect(promise.rejected).to.equal(true)
       expect(promise.result).to.equal(-2)
 
       a = stream()
       promise = a.toPromise(Promise1)
-      send(a, [{error: -1}, 1, {error: -2}, '<end>'])
+      send(a, [error(-1, {current: true}), value(1), error(-2), end()])
       expect(promise.rejected).to.equal(true)
       expect(promise.result).to.equal(-2)
     })
@@ -104,21 +104,21 @@ describe('toPromise', () => {
 
   describe('property', () => {
     it('should handle currents (resolved)', () => {
-      let promise = send(prop(), [1, '<end>']).toPromise()
+      let promise = send(prop(), [value(1), end()]).toPromise()
       expect(promise.fulfilled).to.equal(true)
       expect(promise.result).to.equal(1)
 
-      promise = send(prop(), [1, '<end>']).toPromise(Promise1)
+      promise = send(prop(), [value(1), end()]).toPromise(Promise1)
       expect(promise.fulfilled).to.equal(true)
       expect(promise.result).to.equal(1)
     })
 
     it('should handle currents (rejected)', () => {
-      let promise = send(prop(), [{error: -1}, '<end>']).toPromise()
+      let promise = send(prop(), [error(-1, {current: true}), end()]).toPromise()
       expect(promise.rejected).to.equal(true)
       expect(promise.result).to.equal(-1)
 
-      promise = send(prop(), [{error: -1}, '<end>']).toPromise(Promise1)
+      promise = send(prop(), [error(-1, {current: true}), end()]).toPromise(Promise1)
       expect(promise.rejected).to.equal(true)
       expect(promise.result).to.equal(-1)
     })

--- a/test/specs/to-property.js
+++ b/test/specs/to-property.js
@@ -1,28 +1,28 @@
-const {stream, prop, send, Kefir, activate, deactivate} = require('../test-helpers')
+const {stream, prop, send, Kefir, activate, deactivate, expect} = require('../test-helpers')
 
 describe('toProperty', () => {
   describe('stream', () => {
     it('should return property', () => {
-      expect(stream().toProperty(() => 0)).toBeProperty()
-      expect(stream().toProperty()).toBeProperty()
+      expect(stream().toProperty(() => 0)).to.be.observable.property()
+      expect(stream().toProperty()).to.be.observable.property()
     })
 
     it('should activate/deactivate source', () => {
       const a = stream()
-      expect(a.toProperty()).toActivate(a)
+      expect(a.toProperty()).to.activate(a)
     })
 
     it('should be ended if source was ended', () =>
-      expect(send(stream(), ['<end>']).toProperty()).toEmit(['<end:current>']))
+      expect(send(stream(), ['<end>']).toProperty()).to.emit(['<end:current>']))
 
     it('should be ended if source was ended (with current)', () =>
-      expect(send(stream(), ['<end>']).toProperty(() => 0)).toEmit([{current: 0}, '<end:current>']))
+      expect(send(stream(), ['<end>']).toProperty(() => 0)).to.emit([{current: 0}, '<end:current>']))
 
     it('should handle events', () => {
       const a = stream()
       const p = a.toProperty(() => 0)
-      expect(p).toEmit([{current: 0}, 1, {error: 3}, 2, '<end>'], () => send(a, [1, {error: 3}, 2, '<end>']))
-      expect(p).toEmit([{current: 2}, '<end:current>'])
+      expect(p).to.emit([{current: 0}, 1, {error: 3}, 2, '<end>'], () => send(a, [1, {error: 3}, 2, '<end>']))
+      expect(p).to.emit([{current: 2}, '<end:current>'])
     })
 
     it('should call callback on each activation', () => {
@@ -30,11 +30,11 @@ describe('toProperty', () => {
       const a = stream()
       const p = a.toProperty(() => count++)
       activate(p)
-      expect(count).toBe(1)
+      expect(count).to.equal(1)
       deactivate(p)
-      expect(count).toBe(1)
+      expect(count).to.equal(1)
       activate(p)
-      expect(count).toBe(2)
+      expect(count).to.equal(2)
     })
 
     it('should reset value by getting new from the callback on each activation', () => {
@@ -49,12 +49,12 @@ describe('toProperty', () => {
       const a = stream()
       const p = a.toProperty(() => 0)
 
-      expect(getCurrent(p)).toBe(0)
+      expect(getCurrent(p)).to.equal(0)
       activate(p)
       send(a, [1])
-      expect(getCurrent(p)).toBe(1)
+      expect(getCurrent(p)).to.equal(1)
       deactivate(p)
-      expect(getCurrent(p)).toBe(0)
+      expect(getCurrent(p)).to.equal(0)
     })
 
     it('should throw when called with not a function', () => {
@@ -64,39 +64,39 @@ describe('toProperty', () => {
       } catch (e) {
         err = e
       }
-      expect(err.message).toBe('You should call toProperty() with a function or no arguments.')
+      expect(err.message).to.equal('You should call toProperty() with a function or no arguments.')
     })
   })
 
   describe('property', () => {
     it('should return property', () => {
-      expect(prop().toProperty(() => 0)).toBeProperty()
-      expect(prop().toProperty()).toBeProperty()
+      expect(prop().toProperty(() => 0)).to.be.observable.property()
+      expect(prop().toProperty()).to.be.observable.property()
     })
 
     it('should activate/deactivate source', () => {
       const a = prop()
-      expect(a.toProperty(() => 0)).toActivate(a)
+      expect(a.toProperty(() => 0)).to.activate(a)
     })
 
     it('should be ended if source was ended', () => {
-      expect(send(prop(), ['<end>']).toProperty(() => 0)).toEmit([{current: 0}, '<end:current>'])
-      expect(send(prop(), [1, '<end>']).toProperty(() => 0)).toEmit([{current: 1}, '<end:current>'])
+      expect(send(prop(), ['<end>']).toProperty(() => 0)).to.emit([{current: 0}, '<end:current>'])
+      expect(send(prop(), [1, '<end>']).toProperty(() => 0)).to.emit([{current: 1}, '<end:current>'])
     })
 
     it('should handle events', () => {
       let a = send(prop(), [1])
       let b = a.toProperty(() => 0)
-      expect(b).toEmit([{current: 1}, 2, {error: 3}, '<end>'], () => send(a, [2, {error: 3}, '<end>']))
-      expect(b).toEmit([{currentError: 3}, '<end:current>'])
+      expect(b).to.emit([{current: 1}, 2, {error: 3}, '<end>'], () => send(a, [2, {error: 3}, '<end>']))
+      expect(b).to.emit([{currentError: 3}, '<end:current>'])
 
       a = prop()
       b = a.toProperty(() => 0)
-      expect(b).toEmit([{current: 0}, 2, {error: 3}, 4, '<end>'], () => send(a, [2, {error: 3}, 4, '<end>']))
-      expect(b).toEmit([{current: 4}, '<end:current>'])
+      expect(b).to.emit([{current: 0}, 2, {error: 3}, 4, '<end>'], () => send(a, [2, {error: 3}, 4, '<end>']))
+      expect(b).to.emit([{current: 4}, '<end:current>'])
     })
 
     it('if original property has no current, and .toProperty called with no arguments, then result should have no current', () =>
-      expect(prop().toProperty()).toEmit([]))
+      expect(prop().toProperty()).to.emit([]))
   })
 })

--- a/test/specs/transduce.js
+++ b/test/specs/transduce.js
@@ -4,7 +4,7 @@
  * DS102: Remove unnecessary code created because of implicit returns
  * Full docs: https://github.com/decaffeinate/decaffeinate/blob/master/docs/suggestions.md
  */
-const {stream, prop, send, Kefir} = require('../test-helpers')
+const {stream, prop, send, Kefir, expect} = require('../test-helpers')
 
 const comp = (...fns) => x => {
   for (let f of Array.from(fns.slice(0).reverse())) {
@@ -18,41 +18,43 @@ const testWithLib = (name, t) =>
     describe('stream', () => {
       it('`map` should work', () => {
         const a = stream()
-        expect(a.transduce(t.map(x => x * 2))).toEmit([2, 4, 6, '<end>'], () => send(a, [1, 2, 3, '<end>']))
+        expect(a.transduce(t.map(x => x * 2))).to.emit([2, 4, 6, '<end>'], () => send(a, [1, 2, 3, '<end>']))
       })
 
       it('`filter` should work', () => {
         const a = stream()
-        expect(a.transduce(t.filter(x => x % 2 === 0))).toEmit([2, 4, '<end>'], () => send(a, [1, 2, 3, 4, '<end>']))
+        expect(a.transduce(t.filter(x => x % 2 === 0))).to.emit([2, 4, '<end>'], () => send(a, [1, 2, 3, 4, '<end>']))
       })
 
       it('`take` should work', () => {
         let a = stream()
-        expect(a.transduce(t.take(2))).toEmit([1, 2, '<end>'], () => send(a, [1, 2, 3, 4]))
+        expect(a.transduce(t.take(2))).to.emit([1, 2, '<end>'], () => send(a, [1, 2, 3, 4]))
         a = stream()
-        expect(a.transduce(t.take(2))).toEmit([1, '<end>'], () => send(a, [1, '<end>']))
+        expect(a.transduce(t.take(2))).to.emit([1, '<end>'], () => send(a, [1, '<end>']))
       })
 
       it('`map.filter.take` should work', () => {
         const tr = comp(t.map(x => x + 10), t.filter(x => x % 2 === 0), t.take(2))
         const a = stream()
-        expect(a.transduce(tr)).toEmit([12, 14, '<end>'], () => send(a, [1, 2, 3, 4, 5, 6]))
+        expect(a.transduce(tr)).to.emit([12, 14, '<end>'], () => send(a, [1, 2, 3, 4, 5, 6]))
       })
 
       if (t.partitionAll) {
         it('`partitionAll` should work', () => {
           let a = stream()
-          expect(a.transduce(t.partitionAll(2))).toEmit([[1, 2], [3, 4], '<end>'], () => send(a, [1, 2, 3, 4, '<end>']))
+          expect(a.transduce(t.partitionAll(2))).to.emit([[1, 2], [3, 4], '<end>'], () =>
+            send(a, [1, 2, 3, 4, '<end>'])
+          )
           a = stream()
-          expect(a.transduce(t.partitionAll(2))).toEmit([[1, 2], [3], '<end>'], () => send(a, [1, 2, 3, '<end>']))
+          expect(a.transduce(t.partitionAll(2))).to.emit([[1, 2], [3], '<end>'], () => send(a, [1, 2, 3, '<end>']))
         })
         it('`take.partitionAll` should work', () => {
           let tr = comp(t.take(3), t.partitionAll(2))
           let a = stream()
-          expect(a.transduce(tr)).toEmit([[1, 2], [3], '<end>'], () => send(a, [1, 2, 3, 4, '<end>']))
+          expect(a.transduce(tr)).to.emit([[1, 2], [3], '<end>'], () => send(a, [1, 2, 3, 4, '<end>']))
           tr = comp(t.take(2), t.partitionAll(2))
           a = stream()
-          expect(a.transduce(tr)).toEmit([[1, 2], '<end>'], () => send(a, [1, 2, 3, 4, '<end>']))
+          expect(a.transduce(tr)).to.emit([[1, 2], '<end>'], () => send(a, [1, 2, 3, 4, '<end>']))
         })
       }
     })
@@ -60,47 +62,47 @@ const testWithLib = (name, t) =>
     describe('property', () => {
       it('`map` should work', () => {
         const a = send(prop(), [1])
-        expect(a.transduce(t.map(x => x * 2))).toEmit([{current: 2}, 4, 6, '<end>'], () => send(a, [2, 3, '<end>']))
+        expect(a.transduce(t.map(x => x * 2))).to.emit([{current: 2}, 4, 6, '<end>'], () => send(a, [2, 3, '<end>']))
       })
 
       it('`filter` should work', () => {
         let a = send(prop(), [1])
-        expect(a.transduce(t.filter(x => x % 2 === 0))).toEmit([2, 4, '<end>'], () => send(a, [2, 3, 4, '<end>']))
+        expect(a.transduce(t.filter(x => x % 2 === 0))).to.emit([2, 4, '<end>'], () => send(a, [2, 3, 4, '<end>']))
         a = send(prop(), [2])
-        expect(a.transduce(t.filter(x => x % 2 === 0))).toEmit([{current: 2}, 4, '<end>'], () =>
+        expect(a.transduce(t.filter(x => x % 2 === 0))).to.emit([{current: 2}, 4, '<end>'], () =>
           send(a, [1, 3, 4, '<end>'])
         )
       })
 
       it('`take` should work', () => {
         let a = send(prop(), [1])
-        expect(a.transduce(t.take(2))).toEmit([{current: 1}, 2, '<end>'], () => send(a, [2, 3, 4]))
+        expect(a.transduce(t.take(2))).to.emit([{current: 1}, 2, '<end>'], () => send(a, [2, 3, 4]))
         a = send(prop(), [1])
-        expect(a.transduce(t.take(3))).toEmit([{current: 1}, 2, '<end>'], () => send(a, [2, '<end>']))
+        expect(a.transduce(t.take(3))).to.emit([{current: 1}, 2, '<end>'], () => send(a, [2, '<end>']))
       })
 
       it('`map.filter.take` should work', () => {
         const tr = comp(t.map(x => x + 10), t.filter(x => x % 2 === 0), t.take(2))
         let a = send(prop(), [1])
-        expect(a.transduce(tr)).toEmit([12, 14, '<end>'], () => send(a, [2, 3, 4, 5, 6]))
+        expect(a.transduce(tr)).to.emit([12, 14, '<end>'], () => send(a, [2, 3, 4, 5, 6]))
         a = send(prop(), [2])
-        expect(a.transduce(tr)).toEmit([{current: 12}, 14, '<end>'], () => send(a, [1, 3, 4, 5, 6]))
+        expect(a.transduce(tr)).to.emit([{current: 12}, 14, '<end>'], () => send(a, [1, 3, 4, 5, 6]))
       })
 
       if (t.partitionAll) {
         it('`partitionAll` should work', () => {
           let a = send(prop(), [1])
-          expect(a.transduce(t.partitionAll(2))).toEmit([[1, 2], [3, 4], '<end>'], () => send(a, [2, 3, 4, '<end>']))
+          expect(a.transduce(t.partitionAll(2))).to.emit([[1, 2], [3, 4], '<end>'], () => send(a, [2, 3, 4, '<end>']))
           a = send(prop(), [1])
-          expect(a.transduce(t.partitionAll(2))).toEmit([[1, 2], [3], '<end>'], () => send(a, [2, 3, '<end>']))
+          expect(a.transduce(t.partitionAll(2))).to.emit([[1, 2], [3], '<end>'], () => send(a, [2, 3, '<end>']))
         })
         it('`take.partitionAll` should work', () => {
           let tr = comp(t.take(3), t.partitionAll(2))
           let a = send(prop(), [1])
-          expect(a.transduce(tr)).toEmit([[1, 2], [3], '<end>'], () => send(a, [2, 3, 4, '<end>']))
+          expect(a.transduce(tr)).to.emit([[1, 2], [3], '<end>'], () => send(a, [2, 3, 4, '<end>']))
           tr = comp(t.take(2), t.partitionAll(2))
           a = send(prop(), [1])
-          expect(a.transduce(tr)).toEmit([[1, 2], '<end>'], () => send(a, [2, 3, 4, '<end>']))
+          expect(a.transduce(tr)).to.emit([[1, 2], '<end>'], () => send(a, [2, 3, 4, '<end>']))
         })
       }
     })
@@ -112,43 +114,43 @@ describe('transduce', () => {
   describe('with `noop` transducer', () => {
     describe('stream', () => {
       it('should return stream', () => {
-        expect(stream().transduce(noop)).toBeStream()
+        expect(stream().transduce(noop)).to.be.observable.stream()
       })
 
       it('should activate/deactivate source', () => {
         const a = stream()
-        expect(a.transduce(noop)).toActivate(a)
+        expect(a.transduce(noop)).to.activate(a)
       })
 
       it('should be ended if source was ended', () =>
-        expect(send(stream(), ['<end>']).transduce(noop)).toEmit(['<end:current>']))
+        expect(send(stream(), ['<end>']).transduce(noop)).to.emit(['<end:current>']))
 
       it('should handle events', () => {
         const a = stream()
-        expect(a.transduce(noop)).toEmit([1, 2, {error: 4}, 3, '<end>'], () => send(a, [1, 2, {error: 4}, 3, '<end>']))
+        expect(a.transduce(noop)).to.emit([1, 2, {error: 4}, 3, '<end>'], () => send(a, [1, 2, {error: 4}, 3, '<end>']))
       })
     })
 
     describe('property', () => {
       it('should return property', () => {
-        expect(prop().transduce(noop)).toBeProperty()
+        expect(prop().transduce(noop)).to.be.observable.property()
       })
 
       it('should activate/deactivate source', () => {
         const a = prop()
-        expect(a.transduce(noop)).toActivate(a)
+        expect(a.transduce(noop)).to.activate(a)
       })
 
       it('should be ended if source was ended', () =>
-        expect(send(prop(), ['<end>']).transduce(noop)).toEmit(['<end:current>']))
+        expect(send(prop(), ['<end>']).transduce(noop)).to.emit(['<end:current>']))
 
       it('should handle events and current', () => {
         let a = send(prop(), [1])
-        expect(a.transduce(noop)).toEmit([{current: 1}, 2, {error: 4}, 3, '<end>'], () =>
+        expect(a.transduce(noop)).to.emit([{current: 1}, 2, {error: 4}, 3, '<end>'], () =>
           send(a, [2, {error: 4}, 3, '<end>'])
         )
         a = send(prop(), [{error: 0}])
-        expect(a.transduce(noop)).toEmit([{currentError: 0}, 2, {error: 4}, 3, '<end>'], () =>
+        expect(a.transduce(noop)).to.emit([{currentError: 0}, 2, {error: 4}, 3, '<end>'], () =>
           send(a, [2, {error: 4}, 3, '<end>'])
         )
       })

--- a/test/specs/values-to-errors.js
+++ b/test/specs/values-to-errors.js
@@ -1,4 +1,4 @@
-const {stream, prop, send, Kefir, expect} = require('../test-helpers')
+const {stream, prop, send, value, error, end, Kefir, expect} = require('../test-helpers')
 
 const handler = x => ({
   convert: x < 0,
@@ -17,19 +17,19 @@ describe('valuesToErrors', () => {
     })
 
     it('should be ended if source was ended', () =>
-      expect(send(stream(), ['<end>']).valuesToErrors(() => {})).to.emit(['<end:current>']))
+      expect(send(stream(), [end()]).valuesToErrors(() => {})).to.emit([end({current: true})]))
 
     it('should handle events', () => {
       const a = stream()
-      expect(a.valuesToErrors(handler)).to.emit([1, {error: -6}, {error: -3}, {error: -12}, 5, '<end>'], () =>
-        send(a, [1, -2, {error: -3}, -4, 5, '<end>'])
+      expect(a.valuesToErrors(handler)).to.emit([value(1), error(-6), error(-3), error(-12), value(5), end()], () =>
+        send(a, [value(1), value(-2), error(-3), value(-4), value(5), end()])
       )
     })
 
     it('default handler should convert all values', () => {
       const a = stream()
-      expect(a.valuesToErrors()).to.emit([{error: 1}, {error: -2}, {error: -3}, {error: -4}, {error: 5}, '<end>'], () =>
-        send(a, [1, -2, {error: -3}, -4, 5, '<end>'])
+      expect(a.valuesToErrors()).to.emit([error(1), error(-2), error(-3), error(-4), error(5), end()], () =>
+        send(a, [value(1), value(-2), error(-3), value(-4), value(5), end()])
       )
     })
   })
@@ -45,23 +45,23 @@ describe('valuesToErrors', () => {
     })
 
     it('should be ended if source was ended', () =>
-      expect(send(prop(), ['<end>']).valuesToErrors(() => {})).to.emit(['<end:current>']))
+      expect(send(prop(), [end()]).valuesToErrors(() => {})).to.emit([end({current: true})]))
 
     it('should handle events', () => {
-      const a = send(prop(), [1])
+      const a = send(prop(), [value(1)])
       expect(a.valuesToErrors(handler)).to.emit(
-        [{current: 1}, {error: -6}, {error: -3}, {error: -12}, 5, '<end>'],
-        () => send(a, [-2, {error: -3}, -4, 5, '<end>'])
+        [value(1, {current: true}), error(-6), error(-3), error(-12), value(5), end()],
+        () => send(a, [value(-2), error(-3), value(-4), value(5), end()])
       )
     })
 
     it('should handle currents', () => {
-      let a = send(prop(), [2])
-      expect(a.valuesToErrors(handler)).to.emit([{current: 2}])
-      a = send(prop(), [-2])
-      expect(a.valuesToErrors(handler)).to.emit([{currentError: -6}])
-      a = send(prop(), [{error: -2}])
-      expect(a.valuesToErrors(handler)).to.emit([{currentError: -2}])
+      let a = send(prop(), [value(2)])
+      expect(a.valuesToErrors(handler)).to.emit([value(2, {current: true})])
+      a = send(prop(), [value(-2)])
+      expect(a.valuesToErrors(handler)).to.emit([error(-6, {current: true})])
+      a = send(prop(), [error(-2)])
+      expect(a.valuesToErrors(handler)).to.emit([error(-2, {current: true})])
     })
   })
 })

--- a/test/specs/values-to-errors.js
+++ b/test/specs/values-to-errors.js
@@ -1,4 +1,4 @@
-const {stream, prop, send, Kefir} = require('../test-helpers')
+const {stream, prop, send, Kefir, expect} = require('../test-helpers')
 
 const handler = x => ({
   convert: x < 0,
@@ -8,27 +8,27 @@ const handler = x => ({
 describe('valuesToErrors', () => {
   describe('stream', () => {
     it('should return stream', () => {
-      expect(stream().valuesToErrors(() => {})).toBeStream()
+      expect(stream().valuesToErrors(() => {})).to.be.observable.stream()
     })
 
     it('should activate/deactivate source', () => {
       const a = stream()
-      expect(a.valuesToErrors(() => {})).toActivate(a)
+      expect(a.valuesToErrors(() => {})).to.activate(a)
     })
 
     it('should be ended if source was ended', () =>
-      expect(send(stream(), ['<end>']).valuesToErrors(() => {})).toEmit(['<end:current>']))
+      expect(send(stream(), ['<end>']).valuesToErrors(() => {})).to.emit(['<end:current>']))
 
     it('should handle events', () => {
       const a = stream()
-      expect(a.valuesToErrors(handler)).toEmit([1, {error: -6}, {error: -3}, {error: -12}, 5, '<end>'], () =>
+      expect(a.valuesToErrors(handler)).to.emit([1, {error: -6}, {error: -3}, {error: -12}, 5, '<end>'], () =>
         send(a, [1, -2, {error: -3}, -4, 5, '<end>'])
       )
     })
 
     it('default handler should convert all values', () => {
       const a = stream()
-      expect(a.valuesToErrors()).toEmit([{error: 1}, {error: -2}, {error: -3}, {error: -4}, {error: 5}, '<end>'], () =>
+      expect(a.valuesToErrors()).to.emit([{error: 1}, {error: -2}, {error: -3}, {error: -4}, {error: 5}, '<end>'], () =>
         send(a, [1, -2, {error: -3}, -4, 5, '<end>'])
       )
     })
@@ -36,31 +36,32 @@ describe('valuesToErrors', () => {
 
   describe('property', () => {
     it('should return property', () => {
-      expect(prop().valuesToErrors(() => {})).toBeProperty()
+      expect(prop().valuesToErrors(() => {})).to.be.observable.property()
     })
 
     it('should activate/deactivate source', () => {
       const a = prop()
-      expect(a.valuesToErrors(() => {})).toActivate(a)
+      expect(a.valuesToErrors(() => {})).to.activate(a)
     })
 
     it('should be ended if source was ended', () =>
-      expect(send(prop(), ['<end>']).valuesToErrors(() => {})).toEmit(['<end:current>']))
+      expect(send(prop(), ['<end>']).valuesToErrors(() => {})).to.emit(['<end:current>']))
 
     it('should handle events', () => {
       const a = send(prop(), [1])
-      expect(a.valuesToErrors(handler)).toEmit([{current: 1}, {error: -6}, {error: -3}, {error: -12}, 5, '<end>'], () =>
-        send(a, [-2, {error: -3}, -4, 5, '<end>'])
+      expect(a.valuesToErrors(handler)).to.emit(
+        [{current: 1}, {error: -6}, {error: -3}, {error: -12}, 5, '<end>'],
+        () => send(a, [-2, {error: -3}, -4, 5, '<end>'])
       )
     })
 
     it('should handle currents', () => {
       let a = send(prop(), [2])
-      expect(a.valuesToErrors(handler)).toEmit([{current: 2}])
+      expect(a.valuesToErrors(handler)).to.emit([{current: 2}])
       a = send(prop(), [-2])
-      expect(a.valuesToErrors(handler)).toEmit([{currentError: -6}])
+      expect(a.valuesToErrors(handler)).to.emit([{currentError: -6}])
       a = send(prop(), [{error: -2}])
-      expect(a.valuesToErrors(handler)).toEmit([{currentError: -2}])
+      expect(a.valuesToErrors(handler)).to.emit([{currentError: -2}])
     })
   })
 })

--- a/test/specs/with-handler.js
+++ b/test/specs/with-handler.js
@@ -1,4 +1,4 @@
-const {stream, prop, send, Kefir} = require('../test-helpers')
+const {stream, prop, send, Kefir, expect} = require('../test-helpers')
 
 describe('withHandler', () => {
   const mirror = (emitter, event) => {
@@ -32,36 +32,36 @@ describe('withHandler', () => {
 
   describe('stream', () => {
     it('should return stream', () => {
-      expect(stream().withHandler(() => {})).toBeStream()
+      expect(stream().withHandler(() => {})).to.be.observable.stream()
     })
 
     it('should activate/deactivate source', () => {
       const a = stream()
-      expect(a.withHandler(() => {})).toActivate(a)
+      expect(a.withHandler(() => {})).to.activate(a)
     })
 
     it('should not be ended if source was ended (by default)', () =>
-      expect(send(stream(), ['<end>']).withHandler(() => {})).toEmit([]))
+      expect(send(stream(), ['<end>']).withHandler(() => {})).to.emit([]))
 
     it('should be ended if source was ended (with `mirror` handler)', () =>
-      expect(send(stream(), ['<end>']).withHandler(mirror)).toEmit(['<end:current>']))
+      expect(send(stream(), ['<end>']).withHandler(mirror)).to.emit(['<end:current>']))
 
     it('should handle events (with `duplicate` handler)', () => {
       const a = stream()
-      expect(a.withHandler(duplicate)).toEmit([1, 1, {error: 3}, {error: 3}, 2, 2, '<end>'], () =>
+      expect(a.withHandler(duplicate)).to.emit([1, 1, {error: 3}, {error: 3}, 2, 2, '<end>'], () =>
         send(a, [1, {error: 3}, 2, '<end>'])
       )
     })
 
     it('should automatically preserve isCurent (end)', () => {
       const a = stream()
-      expect(a.withHandler(mirror)).toEmit(['<end>'], () => send(a, ['<end>']))
-      expect(a.withHandler(mirror)).toEmit(['<end:current>'])
+      expect(a.withHandler(mirror)).to.emit(['<end>'], () => send(a, ['<end>']))
+      expect(a.withHandler(mirror)).to.emit(['<end:current>'])
     })
 
     it('should support emitter.emitEvent', () => {
       const a = stream()
-      expect(a.withHandler(emitEventMirror)).toEmit([1, {error: 3}, 2, '<end>'], () =>
+      expect(a.withHandler(emitEventMirror)).to.emit([1, {error: 3}, 2, '<end>'], () =>
         send(a, [1, {error: 3}, 2, '<end>'])
       )
     })
@@ -69,49 +69,49 @@ describe('withHandler', () => {
 
   describe('property', () => {
     it('should return property', () => {
-      expect(prop().withHandler(() => {})).toBeProperty()
+      expect(prop().withHandler(() => {})).to.be.observable.property()
     })
 
     it('should activate/deactivate source', () => {
       const a = prop()
-      expect(a.withHandler(() => {})).toActivate(a)
+      expect(a.withHandler(() => {})).to.activate(a)
     })
 
     it('should not be ended if source was ended (by default)', () =>
-      expect(send(prop(), ['<end>']).withHandler(() => {})).toEmit([]))
+      expect(send(prop(), ['<end>']).withHandler(() => {})).to.emit([]))
 
     it('should be ended if source was ended (with `mirror` handler)', () =>
-      expect(send(prop(), ['<end>']).withHandler(mirror)).toEmit(['<end:current>']))
+      expect(send(prop(), ['<end>']).withHandler(mirror)).to.emit(['<end:current>']))
 
     it('should handle events and current (with `duplicate` handler)', () => {
       let a = send(prop(), [1])
-      expect(a.withHandler(duplicate)).toEmit([{current: 1}, 2, 2, {error: 4}, {error: 4}, 3, 3, '<end>'], () =>
+      expect(a.withHandler(duplicate)).to.emit([{current: 1}, 2, 2, {error: 4}, {error: 4}, 3, 3, '<end>'], () =>
         send(a, [2, {error: 4}, 3, '<end>'])
       )
       a = send(prop(), [{error: 0}])
-      expect(a.withHandler(duplicate)).toEmit([{currentError: 0}, 2, 2, {error: 4}, {error: 4}, 3, 3, '<end>'], () =>
+      expect(a.withHandler(duplicate)).to.emit([{currentError: 0}, 2, 2, {error: 4}, {error: 4}, 3, 3, '<end>'], () =>
         send(a, [2, {error: 4}, 3, '<end>'])
       )
     })
 
     it('should support emitter.emitEvent', () => {
       const a = send(prop(), [1])
-      expect(a.withHandler(emitEventMirror)).toEmit([{current: 1}, 2, {error: 4}, 3, '<end>'], () =>
+      expect(a.withHandler(emitEventMirror)).to.emit([{current: 1}, 2, {error: 4}, 3, '<end>'], () =>
         send(a, [2, {error: 4}, 3, '<end>'])
       )
-      expect(send(prop(), [{error: -1}]).withHandler(emitEventMirror)).toEmit([{currentError: -1}])
+      expect(send(prop(), [{error: -1}]).withHandler(emitEventMirror)).to.emit([{currentError: -1}])
     })
 
     it('should automatically preserve isCurent (end)', () => {
       const a = prop()
-      expect(a.withHandler(mirror)).toEmit(['<end>'], () => send(a, ['<end>']))
-      expect(a.withHandler(mirror)).toEmit(['<end:current>'])
+      expect(a.withHandler(mirror)).to.emit(['<end>'], () => send(a, ['<end>']))
+      expect(a.withHandler(mirror)).to.emit(['<end:current>'])
     })
 
     it('should automatically preserve isCurent (value)', () => {
       const a = prop()
-      expect(a.withHandler(mirror)).toEmit([1], () => send(a, [1]))
-      expect(a.withHandler(mirror)).toEmit([{current: 1}])
+      expect(a.withHandler(mirror)).to.emit([1], () => send(a, [1]))
+      expect(a.withHandler(mirror)).to.emit([{current: 1}])
 
       let savedEmitter = null
       expect(
@@ -119,13 +119,13 @@ describe('withHandler', () => {
           mirror(emitter, event)
           return (savedEmitter = emitter)
         })
-      ).toEmit([{current: 1}, 2], () => savedEmitter.emit(2))
+      ).to.emit([{current: 1}, 2], () => savedEmitter.emit(2))
     })
 
     it('should automatically preserve isCurent (error)', () => {
       const a = prop()
-      expect(a.withHandler(mirror)).toEmit([{error: 1}], () => send(a, [{error: 1}]))
-      expect(a.withHandler(mirror)).toEmit([{currentError: 1}])
+      expect(a.withHandler(mirror)).to.emit([{error: 1}], () => send(a, [{error: 1}]))
+      expect(a.withHandler(mirror)).to.emit([{currentError: 1}])
 
       let savedEmitter = null
       expect(
@@ -133,7 +133,7 @@ describe('withHandler', () => {
           mirror(emitter, event)
           return (savedEmitter = emitter)
         })
-      ).toEmit([{currentError: 1}, {error: 2}], () => savedEmitter.emit({error: 2}))
+      ).to.emit([{currentError: 1}, {error: 2}], () => savedEmitter.emit({error: 2}))
     })
   })
 })

--- a/test/specs/with-interval.js
+++ b/test/specs/with-interval.js
@@ -1,8 +1,9 @@
-const Kefir = require('../../dist/kefir')
+const {Kefir} = require('../test-helpers')
+const {expect} = require('../test-helpers')
 
 describe('withInterval', () => {
   it('should return stream', () => {
-    expect(Kefir.withInterval(100, () => {})).toBeStream()
+    expect(Kefir.withInterval(100, () => {})).to.be.observable.stream()
   })
 
   it('should work as expected', () => {
@@ -19,7 +20,7 @@ describe('withInterval', () => {
         return emitter.end()
       }
     }
-    expect(Kefir.withInterval(100, fn)).toEmitInTime([
+    expect(Kefir.withInterval(100, fn)).to.emitInTime([
       [100, 1],
       [100, 2],
       [200, {error: -1}],
@@ -43,7 +44,7 @@ describe('withInterval', () => {
         return emitter.emitEvent({type: 'end', value: undefined, current: false})
       }
     }
-    expect(Kefir.withInterval(100, fn)).toEmitInTime([
+    expect(Kefir.withInterval(100, fn)).to.emitInTime([
       [100, 1],
       [100, 2],
       [200, {error: -1}],

--- a/test/specs/with-interval.js
+++ b/test/specs/with-interval.js
@@ -1,5 +1,4 @@
-const {Kefir} = require('../test-helpers')
-const {expect} = require('../test-helpers')
+const {value, error, end, Kefir, expect} = require('../test-helpers')
 
 describe('withInterval', () => {
   it('should return stream', () => {
@@ -21,12 +20,12 @@ describe('withInterval', () => {
       }
     }
     expect(Kefir.withInterval(100, fn)).to.emitInTime([
-      [100, 1],
-      [100, 2],
-      [200, {error: -1}],
-      [300, 3],
-      [300, 6],
-      [300, '<end>'],
+      [100, value(1)],
+      [100, value(2)],
+      [200, error(-1)],
+      [300, value(3)],
+      [300, value(6)],
+      [300, end()],
     ])
   })
 
@@ -45,12 +44,12 @@ describe('withInterval', () => {
       }
     }
     expect(Kefir.withInterval(100, fn)).to.emitInTime([
-      [100, 1],
-      [100, 2],
-      [200, {error: -1}],
-      [300, 3],
-      [300, 6],
-      [300, '<end>'],
+      [100, value(1)],
+      [100, value(2)],
+      [200, error(-1)],
+      [300, value(3)],
+      [300, value(6)],
+      [300, end()],
     ])
   })
 })

--- a/test/specs/zip.js
+++ b/test/specs/zip.js
@@ -1,39 +1,39 @@
-const {stream, prop, send, activate, deactivate, Kefir} = require('../test-helpers')
+const {stream, prop, send, activate, deactivate, Kefir, expect} = require('../test-helpers')
 
 describe('zip', () => {
   it('should return stream', () => {
-    expect(Kefir.zip([])).toBeStream()
-    expect(Kefir.zip([stream(), prop()])).toBeStream()
-    expect(stream().zip(stream())).toBeStream()
-    expect(prop().zip(prop())).toBeStream()
+    expect(Kefir.zip([])).to.be.observable.stream()
+    expect(Kefir.zip([stream(), prop()])).to.be.observable.stream()
+    expect(stream().zip(stream())).to.be.observable.stream()
+    expect(prop().zip(prop())).to.be.observable.stream()
   })
 
   it('should be ended if empty array provided', () => {
-    expect(Kefir.zip([])).toEmit(['<end:current>'])
+    expect(Kefir.zip([])).to.emit(['<end:current>'])
   })
 
   it('should be ended if array of ended observables provided', () => {
     const a = send(stream(), ['<end>'])
     const b = send(prop(), ['<end>'])
     const c = send(stream(), ['<end>'])
-    expect(Kefir.zip([a, b, c])).toEmit(['<end:current>'])
-    expect(a.zip(b)).toEmit(['<end:current>'])
+    expect(Kefir.zip([a, b, c])).to.emit(['<end:current>'])
+    expect(a.zip(b)).to.emit(['<end:current>'])
   })
 
   it('should be ended and has current if array of ended properties provided and each of them has current', () => {
     const a = send(prop(), [1, '<end>'])
     const b = send(prop(), [2, '<end>'])
     const c = send(prop(), [3, '<end>'])
-    expect(Kefir.zip([a, b, c])).toEmit([{current: [1, 2, 3]}, '<end:current>'])
-    expect(a.zip(b)).toEmit([{current: [1, 2]}, '<end:current>'])
+    expect(Kefir.zip([a, b, c])).to.emit([{current: [1, 2, 3]}, '<end:current>'])
+    expect(a.zip(b)).to.emit([{current: [1, 2]}, '<end:current>'])
   })
 
   it('should activate sources', () => {
     const a = stream()
     const b = prop()
     const c = stream()
-    expect(Kefir.zip([a, b, c])).toActivate(a, b, c)
-    expect(a.zip(b)).toActivate(a, b)
+    expect(Kefir.zip([a, b, c])).to.activate(a, b, c)
+    expect(a.zip(b)).to.activate(a, b)
   })
 
   it('should handle events and current from observables', () => {
@@ -45,7 +45,7 @@ describe('zip', () => {
     // c   ----3-------5-------8------X
     //     ----•-------•---------•----X
     //   [1,0,3] [4,2,5]   [6,9,8]
-    expect(Kefir.zip([a, b, c])).toEmit([[1, 0, 3], [4, 2, 5], [6, 9, 8], '<end>'], () => {
+    expect(Kefir.zip([a, b, c])).to.emit([[1, 0, 3], [4, 2, 5], [6, 9, 8], '<end>'], () => {
       send(a, [1])
       send(b, [2])
       send(c, [3])
@@ -60,7 +60,7 @@ describe('zip', () => {
 
     a = stream()
     b = send(prop(), [0])
-    expect(a.zip(b)).toEmit([[1, 0], [3, 2], '<end>'], () => {
+    expect(a.zip(b)).to.emit([[1, 0], [3, 2], '<end>'], () => {
       send(b, [2])
       send(a, [1, 3, '<end>'])
       send(b, ['<end>'])
@@ -76,7 +76,7 @@ describe('zip', () => {
     // c   ----3-------5-------8------X
     //     ----•-------•---------•----X
     //   [1,0,3] [4,2,5]   [6,9,8]
-    expect(Kefir.zip([a, b, c])).toEmit([[1, 0, 3], [4, 2, 5], [6, 9, 8], '<end>'], () => {
+    expect(Kefir.zip([a, b, c])).to.emit([[1, 0, 3], [4, 2, 5], [6, 9, 8], '<end>'], () => {
       send(b, [2])
       send(c, [3])
       send(c, [5])
@@ -87,14 +87,14 @@ describe('zip', () => {
 
     a = [1, 3]
     b = send(prop(), [0])
-    expect(b.zip(a)).toEmit([{current: [0, 1]}, [2, 3], '<end>'], () => {
+    expect(b.zip(a)).to.emit([{current: [0, 1]}, [2, 3], '<end>'], () => {
       send(b, [2])
       send(b, ['<end>'])
     })
   })
 
   it('should work with arrays only', () => {
-    expect(Kefir.zip([[1, 2, 3], [4, 5], [6, 7, 8, 9]])).toEmit([
+    expect(Kefir.zip([[1, 2, 3], [4, 5], [6, 7, 8, 9]])).to.emit([
       {current: [1, 4, 6]},
       {current: [2, 5, 7]},
       '<end:current>',
@@ -106,7 +106,7 @@ describe('zip', () => {
     let a = stream()
     let b = send(prop(), [0])
     const c = stream()
-    expect(Kefir.zip([a, b, c], join)).toEmit(['1+0+3', '4+2+5', '6+9+8', '<end>'], () => {
+    expect(Kefir.zip([a, b, c], join)).to.emit(['1+0+3', '4+2+5', '6+9+8', '<end>'], () => {
       send(a, [1])
       send(b, [2])
       send(c, [3])
@@ -121,7 +121,7 @@ describe('zip', () => {
 
     a = stream()
     b = send(prop(), [0])
-    expect(a.zip(b, join)).toEmit(['1+0', '3+2', '<end>'], () => {
+    expect(a.zip(b, join)).to.emit(['1+0', '3+2', '<end>'], () => {
       send(b, [2])
       send(a, [1, 3, '<end>'])
       send(b, ['<end>'])
@@ -132,15 +132,15 @@ describe('zip', () => {
     let a = stream()
     let b = prop()
     let c = stream()
-    expect(Kefir.zip([a, b, c])).errorsToFlow(a)
+    expect(Kefir.zip([a, b, c])).to.flowErrors(a)
     a = stream()
     b = prop()
     c = stream()
-    expect(Kefir.zip([a, b, c])).errorsToFlow(b)
+    expect(Kefir.zip([a, b, c])).to.flowErrors(b)
     a = stream()
     b = prop()
     c = stream()
-    expect(Kefir.zip([a, b, c])).errorsToFlow(c)
+    expect(Kefir.zip([a, b, c])).to.flowErrors(c)
   })
 
   it('when activating second time and has 2+ properties in sources, should emit current value at most once', () => {
@@ -149,7 +149,7 @@ describe('zip', () => {
     const cb = Kefir.zip([a, b])
     activate(cb)
     deactivate(cb)
-    expect(cb).toEmit([{current: [0, 1]}])
+    expect(cb).to.emit([{current: [0, 1]}])
   })
 
   it('should work correctly when unsuscribing after one sync event', () => {
@@ -166,6 +166,6 @@ describe('zip', () => {
     deactivate(c1)
 
     activate(c.take(1))
-    expect(b).not.toBeActive()
+    expect(b).not.to.be.active()
   })
 })

--- a/test/specs/zip.js
+++ b/test/specs/zip.js
@@ -1,4 +1,4 @@
-const {stream, prop, send, activate, deactivate, Kefir, expect} = require('../test-helpers')
+const {stream, prop, send, value, error, end, activate, deactivate, Kefir, expect} = require('../test-helpers')
 
 describe('zip', () => {
   it('should return stream', () => {
@@ -9,23 +9,23 @@ describe('zip', () => {
   })
 
   it('should be ended if empty array provided', () => {
-    expect(Kefir.zip([])).to.emit(['<end:current>'])
+    expect(Kefir.zip([])).to.emit([end({current: true})])
   })
 
   it('should be ended if array of ended observables provided', () => {
-    const a = send(stream(), ['<end>'])
-    const b = send(prop(), ['<end>'])
-    const c = send(stream(), ['<end>'])
-    expect(Kefir.zip([a, b, c])).to.emit(['<end:current>'])
-    expect(a.zip(b)).to.emit(['<end:current>'])
+    const a = send(stream(), [end()])
+    const b = send(prop(), [end()])
+    const c = send(stream(), [end()])
+    expect(Kefir.zip([a, b, c])).to.emit([end({current: true})])
+    expect(a.zip(b)).to.emit([end({current: true})])
   })
 
   it('should be ended and has current if array of ended properties provided and each of them has current', () => {
-    const a = send(prop(), [1, '<end>'])
-    const b = send(prop(), [2, '<end>'])
-    const c = send(prop(), [3, '<end>'])
-    expect(Kefir.zip([a, b, c])).to.emit([{current: [1, 2, 3]}, '<end:current>'])
-    expect(a.zip(b)).to.emit([{current: [1, 2]}, '<end:current>'])
+    const a = send(prop(), [value(1), end()])
+    const b = send(prop(), [value(2), end()])
+    const c = send(prop(), [value(3), end()])
+    expect(Kefir.zip([a, b, c])).to.emit([value([1, 2, 3], {current: true}), end({current: true})])
+    expect(a.zip(b)).to.emit([value([1, 2], {current: true}), end({current: true})])
   })
 
   it('should activate sources', () => {
@@ -38,93 +38,93 @@ describe('zip', () => {
 
   it('should handle events and current from observables', () => {
     let a = stream()
-    let b = send(prop(), [0])
+    let b = send(prop(), [value(0)])
     const c = stream()
     // a   --1---4-------6-7--------X
     // b  0---2------------------9X
     // c   ----3-------5-------8------X
     //     ----•-------•---------•----X
     //   [1,0,3] [4,2,5]   [6,9,8]
-    expect(Kefir.zip([a, b, c])).to.emit([[1, 0, 3], [4, 2, 5], [6, 9, 8], '<end>'], () => {
-      send(a, [1])
-      send(b, [2])
-      send(c, [3])
-      send(a, [4])
-      send(c, [5])
-      send(a, [6, 7])
-      send(c, [8])
-      send(b, [9, '<end>'])
-      send(a, ['<end>'])
-      send(c, ['<end>'])
+    expect(Kefir.zip([a, b, c])).to.emit([value([1, 0, 3]), value([4, 2, 5]), value([6, 9, 8]), end()], () => {
+      send(a, [value(1)])
+      send(b, [value(2)])
+      send(c, [value(3)])
+      send(a, [value(4)])
+      send(c, [value(5)])
+      send(a, [value(6), value(7)])
+      send(c, [value(8)])
+      send(b, [value(9), end()])
+      send(a, [end()])
+      send(c, [end()])
     })
 
     a = stream()
-    b = send(prop(), [0])
-    expect(a.zip(b)).to.emit([[1, 0], [3, 2], '<end>'], () => {
-      send(b, [2])
-      send(a, [1, 3, '<end>'])
-      send(b, ['<end>'])
+    b = send(prop(), [value(0)])
+    expect(a.zip(b)).to.emit([value([1, 0]), value([3, 2]), end()], () => {
+      send(b, [value(2)])
+      send(a, [value(1), value(3), end()])
+      send(b, [end()])
     })
   })
 
   it('should support arrays', () => {
     let a = [1, 4, 6, 7]
-    let b = send(prop(), [0])
+    let b = send(prop(), [value(0)])
     const c = stream()
     // a   1, 4, 6, 7
     // b  0---2------------------9X
     // c   ----3-------5-------8------X
     //     ----•-------•---------•----X
     //   [1,0,3] [4,2,5]   [6,9,8]
-    expect(Kefir.zip([a, b, c])).to.emit([[1, 0, 3], [4, 2, 5], [6, 9, 8], '<end>'], () => {
-      send(b, [2])
-      send(c, [3])
-      send(c, [5])
-      send(c, [8])
-      send(b, [9, '<end>'])
-      send(c, ['<end>'])
+    expect(Kefir.zip([a, b, c])).to.emit([value([1, 0, 3]), value([4, 2, 5]), value([6, 9, 8]), end()], () => {
+      send(b, [value(2)])
+      send(c, [value(3)])
+      send(c, [value(5)])
+      send(c, [value(8)])
+      send(b, [value(9), end()])
+      send(c, [end()])
     })
 
     a = [1, 3]
-    b = send(prop(), [0])
-    expect(b.zip(a)).to.emit([{current: [0, 1]}, [2, 3], '<end>'], () => {
-      send(b, [2])
-      send(b, ['<end>'])
+    b = send(prop(), [value(0)])
+    expect(b.zip(a)).to.emit([value([0, 1], {current: true}), value([2, 3]), end()], () => {
+      send(b, [value(2)])
+      send(b, [end()])
     })
   })
 
   it('should work with arrays only', () => {
     expect(Kefir.zip([[1, 2, 3], [4, 5], [6, 7, 8, 9]])).to.emit([
-      {current: [1, 4, 6]},
-      {current: [2, 5, 7]},
-      '<end:current>',
+      value([1, 4, 6], {current: true}),
+      value([2, 5, 7], {current: true}),
+      end({current: true}),
     ])
   })
 
   it('should accept optional combinator function', () => {
     const join = (...args) => args.join('+')
     let a = stream()
-    let b = send(prop(), [0])
+    let b = send(prop(), [value(0)])
     const c = stream()
-    expect(Kefir.zip([a, b, c], join)).to.emit(['1+0+3', '4+2+5', '6+9+8', '<end>'], () => {
-      send(a, [1])
-      send(b, [2])
-      send(c, [3])
-      send(a, [4])
-      send(c, [5])
-      send(a, [6, 7])
-      send(c, [8])
-      send(b, [9, '<end>'])
-      send(a, ['<end>'])
-      send(c, ['<end>'])
+    expect(Kefir.zip([a, b, c], join)).to.emit([value('1+0+3'), value('4+2+5'), value('6+9+8'), end()], () => {
+      send(a, [value(1)])
+      send(b, [value(2)])
+      send(c, [value(3)])
+      send(a, [value(4)])
+      send(c, [value(5)])
+      send(a, [value(6), value(7)])
+      send(c, [value(8)])
+      send(b, [value(9), end()])
+      send(a, [end()])
+      send(c, [end()])
     })
 
     a = stream()
-    b = send(prop(), [0])
-    expect(a.zip(b, join)).to.emit(['1+0', '3+2', '<end>'], () => {
-      send(b, [2])
-      send(a, [1, 3, '<end>'])
-      send(b, ['<end>'])
+    b = send(prop(), [value(0)])
+    expect(a.zip(b, join)).to.emit([value('1+0'), value('3+2'), end()], () => {
+      send(b, [value(2)])
+      send(a, [value(1), value(3), end()])
+      send(b, [end()])
     })
   })
 
@@ -144,12 +144,12 @@ describe('zip', () => {
   })
 
   it('when activating second time and has 2+ properties in sources, should emit current value at most once', () => {
-    const a = send(prop(), [0])
-    const b = send(prop(), [1])
+    const a = send(prop(), [value(0)])
+    const b = send(prop(), [value(1)])
     const cb = Kefir.zip([a, b])
     activate(cb)
     deactivate(cb)
-    expect(cb).to.emit([{current: [0, 1]}])
+    expect(cb).to.emit([value([0, 1], {current: true})])
   })
 
   it('should work correctly when unsuscribing after one sync event', () => {
@@ -161,8 +161,8 @@ describe('zip', () => {
     const c = Kefir.zip([a, b])
 
     activate((c1 = c.take(2)))
-    send(b0, [1, 1])
-    send(a0, [1])
+    send(b0, [value(1), value(1)])
+    send(a0, [value(1)])
     deactivate(c1)
 
     activate(c.take(1))

--- a/test/test-helpers.js
+++ b/test/test-helpers.js
@@ -1,334 +1,130 @@
 const Kefir = require('../dist/kefir')
-const sinon = require('sinon')
+const {expect, use} = require('chai')
+const chaiKefir = require('chai-kefir')
+const sinonChai = require('sinon-chai')
+
+use(sinonChai)
+use(chaiKefir.default)
+const {watch, watchWithTime, send, activate, deactivate, prop, stream, pool} = chaiKefir
+
+use(({Assertion}, utils) => {
+  Assertion.addMethod('activate', function assertActivate(...obss) {
+    let obs
+    const isNot = utils.flag(this, 'negate')
+    const actual = utils.getActual(this, arguments)
+
+    const notStr = isNot ? 'not ' : ''
+    const notNotStr = isNot ? '' : 'not '
+
+    const tests = {}
+    tests['some activated at start'] = true
+    tests[`some ${notNotStr}activated`] = true
+    tests[`some ${notNotStr}deactivated`] = true
+    tests[`some ${notNotStr}activated at second try`] = true
+    tests[`some ${notNotStr}deactivated at second try`] = true
+
+    const correctResults = {}
+    correctResults['some activated at start'] = true
+    correctResults[`some ${notNotStr}activated`] = true
+    correctResults[`some ${notNotStr}deactivated`] = true
+    correctResults[`some ${notNotStr}activated at second try`] = true
+    correctResults[`some ${notNotStr}deactivated at second try`] = true
+
+    if (isNot) {
+      correctResults[`some ${notNotStr}activated`] = false
+      correctResults[`some ${notNotStr}activated at second try`] = false
+    }
+
+    const check = (test, conditions) => {
+      if (correctResults[test] === true) {
+        for (let condition of conditions) {
+          if (!condition) {
+            tests[test] = false
+            return
+          }
+        }
+      } else {
+        for (let condition of conditions) {
+          if (condition) {
+            return
+          }
+        }
+        tests[test] = false
+      }
+    }
+
+    check('some activated at start', obss.map(obs => !obs._active))
+
+    activate(actual)
+    check(`some ${notNotStr}activated`, obss.map(obs => obs._active))
+
+    deactivate(actual)
+    check(`some ${notNotStr}deactivated`, obss.map(obs => !obs._active))
+
+    activate(actual)
+    check(`some ${notNotStr}activated at second try`, obss.map(obs => obs._active))
+
+    deactivate(actual)
+    check(`some ${notNotStr}deactivated at second try`, obss.map(obs => !obs._active))
+
+    const message = (() => {
+      const failedTest = (() => {
+        const result5 = []
+        for (let name in tests) {
+          if (tests[name] !== correctResults[name]) {
+            result5.push(name)
+          }
+        }
+        return result5
+      })().join(', ')
+      const obssNames = (() => {
+        const result6 = []
+        for (obs of obss) {
+          result6.push(obs.toString())
+        }
+        return result6
+      })().join(', ')
+      return `Expected ${actual.toString()} to ${notStr}activate: ${obssNames} (${failedTest})`
+    })()
+
+    for (let name in tests) {
+      if (tests[name] !== correctResults[name]) {
+        this.assert(isNot, message, message)
+        return
+      }
+    }
+
+    this.assert(!isNot, message, message)
+  })
+})
 
 Kefir.dissableDeprecationWarnings()
 
 exports.Kefir = Kefir
-
-const logItem = (event, isCurrent) => {
-  if (event.type === 'value') {
-    if (isCurrent) {
-      return {current: event.value}
-    } else {
-      return event.value
-    }
-  } else if (event.type === 'error') {
-    if (isCurrent) {
-      return {currentError: event.value}
-    } else {
-      return {error: event.value}
-    }
-  } else {
-    if (isCurrent) {
-      return '<end:current>'
-    } else {
-      return '<end>'
-    }
-  }
-}
-
-const watch = (exports.watch = obs => {
-  const log = []
-  const fn = event => log.push(logItem(event, isCurrent))
-  const unwatch = () => obs.offAny(fn)
-  let isCurrent = true
-  obs.onAny(fn)
-  isCurrent = false
-  return {log, unwatch}
-})
-
-const watchWithTime = (exports.watchWithTime = function(obs) {
-  const startTime = new Date()
-  const log = []
-  let isCurrent = true
-  obs.onAny(event => log.push([new Date() - startTime, logItem(event, isCurrent)]))
-  isCurrent = false
-  return log
-})
-
-const send = (exports.send = function(obs, events) {
-  for (let event of events) {
-    if (event === '<end>') {
-      obs._emitEnd()
-    }
-    if (typeof event === 'object' && 'error' in event) {
-      obs._emitError(event.error)
-    } else {
-      obs._emitValue(event)
-    }
-  }
-  return obs
-})
-
-const _activateHelper = () => {}
-
-const activate = (exports.activate = obs => {
-  obs.onEnd(_activateHelper)
-  return obs
-})
-
-const deactivate = (exports.deactivate = obs => {
-  obs.offEnd(_activateHelper)
-  return obs
-})
-
-const prop = (exports.prop = () => new Kefir.Property())
-
-const stream = (exports.stream = () => new Kefir.Stream())
-
-const pool = (exports.pool = () => new Kefir.Pool())
-
-// This function changes timers' IDs so "simultaneous" timers are reversed
-// Also sets createdAt to 0 so closk.tick will sort by ID
-// FIXME:
-//   1) Not sure how well it works with interval timers (setInterval), probably bad
-//   2) We need to restore (unshake) them back somehow (after calling tick)
-//   Hopefully we'll get a native implementation, and wont have to fix those
-//   https://github.com/sinonjs/lolex/issues/24
-const shakeTimers = clock => {
-  const ids = Object.keys(clock.timers)
-  const timers = ids.map(id => clock.timers[id])
-
-  // see https://github.com/sinonjs/lolex/blob/a93c8a9af05fb064ae5c2ad1bfc72874973167ee/src/lolex.js#L175-L209
-  timers.sort((a, b) => {
-    if (a.callAt < b.callAt) {
-      return -1
-    }
-    if (a.callAt > b.callAt) {
-      return 1
-    }
-    if (a.immediate && !b.immediate) {
-      return -1
-    }
-    if (!a.immediate && b.immediate) {
-      return 1
-    }
-
-    // Following two cheks are reversed
-    if (a.createdAt < b.createdAt) {
-      return 1
-    }
-    if (a.createdAt > b.createdAt) {
-      return -1
-    }
-    if (a.id < b.id) {
-      return 1
-    }
-    if (a.id > b.id) {
-      return -1
-    }
-  })
-
-  ids.sort((a, b) => a - b)
-  timers.forEach((timer, i) => {
-    const id = ids[i]
-    timer.createdAt = 0
-    timer.id = id
-    clock.timers[id] = timer
-  })
-}
-
-const withFakeTime = (exports.withFakeTime = (cb, reverseSimultaneous) => {
-  if (reverseSimultaneous == null) {
-    reverseSimultaneous = false
-  }
-  const clock = sinon.useFakeTimers(10000)
-  const tick = t => {
-    if (reverseSimultaneous) {
-      shakeTimers(clock)
-    }
-    clock.tick(t)
-  }
-  cb(tick, clock)
-  clock.restore()
-})
-
-const inBrowser = (exports.inBrowser =
-  typeof window !== 'undefined' && window !== null && (typeof document !== 'undefined' && document !== null))
-
-exports.withDOM = cb => {
-  const div = document.createElement('div')
-  document.body.appendChild(div)
-  cb(div)
-  document.body.removeChild(div)
-}
+exports.watch = watch
+exports.watchWithTime = watchWithTime
+exports.send = send
+exports.activate = activate
+exports.deactivate = deactivate
+exports.prop = prop
+exports.stream = stream
+exports.pool = pool
 
 // see:
 //   https://github.com/rpominov/kefir/issues/134
 //   https://github.com/rpominov/kefir/pull/135
-const shakyTimeTest = (exports.shakyTimeTest = testCb => {
+exports.shakyTimeTest = testCb => {
   it('[shaky time test: normal run]', () => {
     const expectToEmitOverShakyTime = (stream, expectedLog, cb, timeLimit) =>
-      expect(stream).toEmitInTime(expectedLog, cb, timeLimit)
+      expect(stream).to.emitInTime(expectedLog, cb, {timeLimit})
     testCb(expectToEmitOverShakyTime)
   })
 
   it('[shaky time test: reverse run]', () => {
     const expectToEmitOverShakyTime = (stream, expectedLog, cb, timeLimit) =>
-      expect(stream).toEmitInTime(expectedLog, cb, timeLimit, true)
+      expect(stream).to.emitInTime(expectedLog, cb, {timeLimit, reverseSimultaneous: true})
     testCb(expectToEmitOverShakyTime)
   })
-})
+}
 
-beforeEach(function() {
-  this.addMatchers({
-    toBeProperty() {
-      this.message = () => `Expected ${this.actual.toString()} to be instance of Property`
-      return this.actual instanceof Kefir.Property
-    },
-    toBeStream() {
-      this.message = () => `Expected ${this.actual.toString()} to be instance of Stream`
-      return this.actual instanceof Kefir.Stream
-    },
-    toBePool() {
-      this.message = () => `Expected ${this.actual.toString()} to be instance of Pool`
-      return this.actual instanceof Kefir.Pool
-    },
-
-    toBeActive() {
-      return this.actual._active
-    },
-
-    toEmit(expectedLog, cb) {
-      const {log, unwatch} = watch(this.actual)
-      if (typeof cb === 'function') {
-        cb()
-      }
-      unwatch()
-      this.message = () => `Expected to emit ${jasmine.pp(expectedLog)}, actually emitted ${jasmine.pp(log)}`
-      return this.env.equals_(expectedLog, log)
-    },
-
-    errorsToFlow(source) {
-      const expectedLog = this.isNot ? [] : [{error: -2}, {error: -3}]
-      if (this.actual instanceof Kefir.Property) {
-        activate(this.actual)
-        send(source, [{error: -1}])
-        deactivate(this.actual)
-        if (!this.isNot) {
-          expectedLog.unshift({currentError: -1})
-        }
-      } else if (source instanceof Kefir.Property) {
-        send(source, [{error: -1}])
-        if (!this.isNot) {
-          expectedLog.unshift({currentError: -1})
-        }
-      }
-      const {log, unwatch} = watch(this.actual)
-      send(source, [{error: -2}, {error: -3}])
-      unwatch()
-      if (this.isNot) {
-        this.message = () => `Expected errors not to flow (i.e. to emit [], actually emitted ${jasmine.pp(log)})`
-        return !this.env.equals_(expectedLog, log)
-      } else {
-        this.message = () =>
-          `Expected errors to flow (i.e. to emit ${jasmine.pp(expectedLog)}, actually emitted ${jasmine.pp(log)})`
-        return this.env.equals_(expectedLog, log)
-      }
-    },
-
-    toEmitInTime(expectedLog, cb, timeLimit, reverseSimultaneous) {
-      if (timeLimit == null) {
-        timeLimit = 10000
-      }
-      if (reverseSimultaneous == null) {
-        reverseSimultaneous = false
-      }
-      let log = null
-      withFakeTime(tick => {
-        log = watchWithTime(this.actual)
-        if (typeof cb === 'function') {
-          cb(tick)
-        }
-        tick(timeLimit)
-      }, reverseSimultaneous)
-      this.message = () => `Expected to emit ${jasmine.pp(expectedLog)}, actually emitted ${jasmine.pp(log)}`
-      return this.env.equals_(expectedLog, log)
-    },
-
-    toActivate(...obss) {
-      let obs
-
-      const notStr = this.isNot ? 'not ' : ''
-      const notNotStr = this.isNot ? '' : 'not '
-
-      const tests = {}
-      tests['some activated at start'] = true
-      tests[`some ${notNotStr}activated`] = true
-      tests[`some ${notNotStr}deactivated`] = true
-      tests[`some ${notNotStr}activated at second try`] = true
-      tests[`some ${notNotStr}deactivated at second try`] = true
-
-      const correctResults = {}
-      correctResults['some activated at start'] = true
-      correctResults[`some ${notNotStr}activated`] = true
-      correctResults[`some ${notNotStr}deactivated`] = true
-      correctResults[`some ${notNotStr}activated at second try`] = true
-      correctResults[`some ${notNotStr}deactivated at second try`] = true
-
-      if (this.isNot) {
-        correctResults[`some ${notNotStr}activated`] = false
-        correctResults[`some ${notNotStr}activated at second try`] = false
-      }
-
-      const check = (test, conditions) => {
-        if (correctResults[test] === true) {
-          for (let condition of conditions) {
-            if (!condition) {
-              tests[test] = false
-              return
-            }
-          }
-        } else {
-          for (let condition of conditions) {
-            if (condition) {
-              return
-            }
-          }
-          tests[test] = false
-        }
-      }
-
-      check('some activated at start', obss.map(obs => !obs._active))
-
-      activate(this.actual)
-      check(`some ${notNotStr}activated`, obss.map(obs => obs._active))
-
-      deactivate(this.actual)
-      check(`some ${notNotStr}deactivated`, obss.map(obs => !obs._active))
-
-      activate(this.actual)
-      check(`some ${notNotStr}activated at second try`, obss.map(obs => obs._active))
-
-      deactivate(this.actual)
-      check(`some ${notNotStr}deactivated at second try`, obss.map(obs => !obs._active))
-
-      this.message = () => {
-        const failedTest = (() => {
-          const result5 = []
-          for (let name in tests) {
-            if (tests[name] !== correctResults[name]) {
-              result5.push(name)
-            }
-          }
-          return result5
-        })().join(', ')
-        const obssNames = (() => {
-          const result6 = []
-          for (obs of obss) {
-            result6.push(obs.toString())
-          }
-          return result6
-        })().join(', ')
-        return `Expected ${this.actual.toString()} to ${notStr}activate: ${obssNames} (${failedTest})`
-      }
-
-      for (let name in tests) {
-        if (tests[name] !== correctResults[name]) {
-          return this.isNot
-        }
-      }
-      return !this.isNot
-    },
-  })
-})
+exports.expect = expect

--- a/test/test-helpers.js
+++ b/test/test-helpers.js
@@ -1,11 +1,13 @@
 const Kefir = require('../dist/kefir')
-const {expect, use} = require('chai')
-const chaiKefir = require('chai-kefir')
+const {config, expect, use} = require('chai')
+const chaiKefir = require('chai-kefir').default
 const sinonChai = require('sinon-chai')
 
+config.truncateThreshold = false
+
+const {plugin, send, value, error, end, activate, deactivate, prop, stream, pool} = chaiKefir(Kefir)
 use(sinonChai)
-use(chaiKefir.default)
-const {watch, watchWithTime, send, activate, deactivate, prop, stream, pool} = chaiKefir
+use(plugin)
 
 use(({Assertion}, utils) => {
   Assertion.addMethod('activate', function assertActivate(...obss) {
@@ -101,14 +103,15 @@ use(({Assertion}, utils) => {
 Kefir.dissableDeprecationWarnings()
 
 exports.Kefir = Kefir
-exports.watch = watch
-exports.watchWithTime = watchWithTime
 exports.send = send
 exports.activate = activate
 exports.deactivate = deactivate
 exports.prop = prop
 exports.stream = stream
 exports.pool = pool
+exports.value = value
+exports.error = error
+exports.end = end
 
 // see:
 //   https://github.com/rpominov/kefir/issues/134


### PR DESCRIPTION
This is still a work-in-progress, but I've migrated most of the tests over to use `chai-kefir`. Wanted to get some eyes on this to make sure we're all on board with this.

Couple of things to note:

1. Right now `chai-kefir` depends on `kefir` directly. I'm going to move that to a `peerDependency`. My goal is to make the `require('kefir')` currently located in the `test-helpers` to point to the project itself, although I'm not entirely sure this is possible. The issue is that it currently installed kefir as a dep of kefir, which causes the chai plugin & the lib itself to point to different versions, making the `x instanceof Property` checks fail. I also have to lower the version we're transpiling `chai-kefir` for, as we're seeing errors on Node 4 that could be fixed through a more aggressive babel config.
2. Instead of changing every file, I re-exported the pieces I moved into `chai-kefir` through the `test-helper`, which allowed them to continue to be used the same way through all the tests. I also exported chai's `expect` method through the `test-helpers`.
3. I'm seeing test failures with `throttle`, which appear to be dropping the first event. I'm using a newer version of `lolex` in `chai-kefir`, which I'm using directly, which could be the cause of this issue. Or the older version of `lolex` had a bug that was fixed that is now exposing an issue in `throttle`. I'm still investigating this, but if anyone who was involved in the timer-related work has any ideas, that would be helpful, as I'm still trying to get my head around them.