### PR TITLE
Fix issue with flatmapped stream that ends while value is being emitted

### DIFF
--- a/src/many-sources/abstract-pool.js
+++ b/src/many-sources/abstract-pool.js
@@ -75,10 +75,13 @@ inherit(AbstractPool, Stream, {
         if (obs._currentEvent) {
           this._emit(obs._currentEvent.type, obs._currentEvent.value)
         }
-        if (this._queue.length !== 0) {
-          this._pullQueue()
-        } else if (this._curSources.length === 0) {
-          this._onEmpty()
+        // The _emit above could have caused this stream to end.
+        if (this._active) {
+          if (this._queue.length !== 0) {
+            this._pullQueue()
+          } else if (this._curSources.length === 0) {
+            this._onEmpty()
+          }
         }
         return
       }

--- a/test/specs/flat-map.js
+++ b/test/specs/flat-map.js
@@ -129,6 +129,21 @@ describe('flatMap', () => {
       expect(unsubs).to.equal(1)
     })
 
+    it('should handle source ending in response to synchronous value', () => {
+      let mainEm
+      Kefir.stream(em => {
+        mainEm = em
+      })
+        .flatMap(x => Kefir.constant(x))
+        .onValue(x => {
+          if (x === 1) {
+            mainEm.end()
+          }
+        })
+
+      mainEm.value(1)
+    })
+
     it('should be possible to add same obs twice on activation', () => {
       const b = send(prop(), [value(1)])
       const a = Kefir.stream(em => {

--- a/test/specs/flat-map.js
+++ b/test/specs/flat-map.js
@@ -129,19 +129,21 @@ describe('flatMap', () => {
       expect(unsubs).to.equal(1)
     })
 
-    it('should handle source ending in response to synchronous value', () => {
-      let mainEm
-      Kefir.stream(em => {
-        mainEm = em
-      })
+    it('should not error when source ends in response to synchronous value', () => {
+      let didEnd = false
+      const src = stream()
+      src
         .flatMap(x => Kefir.constant(x))
         .onValue(x => {
           if (x === 1) {
-            mainEm.end()
+            send(src, [end()])
           }
         })
-
-      mainEm.value(1)
+        .onEnd(() => {
+          didEnd = true
+        })
+      send(src, [value(1)])
+      expect(didEnd).to.be.true
     })
 
     it('should be possible to add same obs twice on activation', () => {

--- a/test/specs/flat-map.js
+++ b/test/specs/flat-map.js
@@ -131,13 +131,11 @@ describe('flatMap', () => {
 
     it('should not error when source ends in response to synchronous value', () => {
       const src = stream()
-      const result = src
-        .flatMap(x => Kefir.constant(x))
-        .onValue(x => {
-          if (x === 1) {
-            send(src, [end()])
-          }
-        })
+      const result = src.flatMap(x => Kefir.constant(x)).onValue(x => {
+        if (x === 1) {
+          send(src, [end()])
+        }
+      })
       expect(result).to.emit([end()], () => {
         send(src, [value(1)])
       })

--- a/test/specs/flat-map.js
+++ b/test/specs/flat-map.js
@@ -130,20 +130,17 @@ describe('flatMap', () => {
     })
 
     it('should not error when source ends in response to synchronous value', () => {
-      let didEnd = false
       const src = stream()
-      src
+      const result = src
         .flatMap(x => Kefir.constant(x))
         .onValue(x => {
           if (x === 1) {
             send(src, [end()])
           }
         })
-        .onEnd(() => {
-          didEnd = true
-        })
-      send(src, [value(1)])
-      expect(didEnd).to.be.true
+      expect(result).to.emit([end()], () => {
+        send(src, [value(1)])
+      })
     })
 
     it('should be possible to add same obs twice on activation', () => {


### PR DESCRIPTION
Currently, if you call .flatMap with a callback that returns an ended property (which triggers an optimized code path in flatMap) and during dispatch of the value the flatMapped stream is ended, then an exception is thrown ("can't read length property of null"). This bug was introduced in https://github.com/kefirjs/kefir/pull/274.

I noticed this issue when updating a project to the latest version of Kefir and one of the unit tests using Kefir failed on this.

This PR contains the fix and a newly-fixed test.

(I renamed my Github account recently. It was previously `@AgentME`.)