### PR TITLE
Flow type definition improvements

### DIFF
--- a/kefir.js.flow
+++ b/kefir.js.flow
@@ -30,7 +30,7 @@ export type Observer<V,E> = {
 };
 
 interface ESObserver<-V,-E> {
-  start?: Function,
+  +start?: Function,
   +next?: (value: V) => any,
   +error?: (error: E) => any,
   +complete?: () => any,

--- a/kefir.js.flow
+++ b/kefir.js.flow
@@ -42,7 +42,7 @@ interface ESObserver<-V,-E> {
  * RxJS, and zen-observable.
  */
 type ESObservable<+V,+E=*> = {
-  subscribe(callbacks: ESObserver<V, E>): { unsubscribe: () => void };
+  subscribe(callbacks: ESObserver<V, E>): { unsubscribe(): void };
 };
 
 declare class Observable<+V,+E=*> {

--- a/kefir.js.flow
+++ b/kefir.js.flow
@@ -2,12 +2,12 @@
 
 import type EventEmitter from "events";
 
-export type Event<V,E> =
-  {type: 'value', value: V} |
-  {type: 'error', value: E} |
-  {type: 'end', value: void};
+export type Event<+V,+E> =
+  {type: 'value', +value: V} |
+  {type: 'error', +value: E} |
+  {type: 'end', +value: void};
 
-export type Emitter<V,E> = {
+export type Emitter<-V,-E> = {
   value(value: V): boolean;
   event(event: Event<V,E>): boolean;
   error(e: E): boolean;
@@ -23,7 +23,7 @@ export type Subscription = {
   unsubscribe(): void;
 };
 
-export type Observer<V,E> = {
+export type Observer<-V,-E> = {
   +value?: (value: V) => void;
   +error?: (err: E) => void;
   +end?: () => void;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1487,9 +1487,9 @@
       }
     },
     "flow-bin": {
-      "version": "0.62.0",
-      "resolved": "https://registry.npmjs.org/flow-bin/-/flow-bin-0.62.0.tgz",
-      "integrity": "sha1-FLymaabj+VwLwMLR61XsTpjLHYM=",
+      "version": "0.80.0",
+      "resolved": "https://registry.npmjs.org/flow-bin/-/flow-bin-0.80.0.tgz",
+      "integrity": "sha512-0wRnqvXErQRPrx6GBLB5swgndfWkotd9MgfePgT7Z+VsE046c8Apzl7KKTCypB/pzn0pZF2g5Jurxxb2umET8g==",
       "dev": true
     },
     "flow-parser": {

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "babel-preset-es2015-loose-rollup": "7.0.0",
     "chai": "^4.1.2",
     "chai-kefir": "^2.0.1",
-    "flow-bin": "0.62.0",
+    "flow-bin": "^0.80.0",
     "inquirer": "0.10.1",
     "mocha": "^4.0.1",
     "prettier": "1.0.2",


### PR DESCRIPTION
This PR contains improvements to Kefir's Flow type definitions that allow the types to be used more flexibly, and fixes a type compatibility issue with a package of mine.

I recently updated the version of Flow some projects use, and I noticed that Flow no longer recognized instances of [LiveSet](https://github.com/StreakYC/live-set) as implementing the ESObservable interface (as Kefir's Flow type definition defined them). It looks like older versions of Flow had some bugs fixed that caused it to not understand type variance correctly in certain situations, so issues with the type variance in the type definitions of Kefir (and LiveSet) were incorrectly ignored by Flow. This issue is fixed in commit 4c5fefe. The other commits have various other variance-related improvements. (https://medium.com/@forbeslindesay/covariance-and-contravariance-c3b43d805611 is a good article about Flow's type variance support if anyone is curious.)

I've also updated the version of Flow in the devDependencies list to ensure that Kefir's Flow type definitions are checked by a more correct version of Flow.