### PR TITLE
Add License and npm badges to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@ See also [Deprecated API docs](https://github.com/kefirjs/kefir/blob/master/depr
 
 
 
+[![GitHub license](https://img.shields.io/badge/license-MIT-blue.svg)](https://github.com/kefirjs/kefir/blob/master/LICENSE.txt)
+[![npm version](https://img.shields.io/npm/v/kefir.svg?style=flat)](https://www.npmjs.com/package/kefir)
 [![Build Status](https://travis-ci.org/kefirjs/kefir.svg?branch=master)](https://travis-ci.org/kefirjs/kefir)
 [![Dependency Status](https://david-dm.org/kefirjs/kefir.svg)](https://david-dm.org/kefirjs/kefir)
 [![devDependency Status](https://david-dm.org/kefirjs/kefir/dev-status.svg)](https://david-dm.org/kefirjs/kefir#info=devDependencies)


### PR DESCRIPTION
This PR adds two badges to the readme, showing the project's license and latest version on npm in a pretty way. I put these two badges first in a similar order as [React's readme](https://github.com/facebook/react) has them. (License, npm, then build/test status badges. Blue badges grouped together at start.)