### PR TITLE
Make release.js support 2-factor for npm publish

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "kefir",
-  "version": "3.8.4",
+  "version": "3.8.5",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -2642,12 +2642,6 @@
       "version": "5.3.0",
       "resolved": "https://registry.npmjs.org/semver/-/semver-5.3.0.tgz",
       "integrity": "sha1-myzl094C0XxgEq0yaqa00M9U+U8=",
-      "dev": true
-    },
-    "shelljs": {
-      "version": "0.5.3",
-      "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.5.3.tgz",
-      "integrity": "sha1-xUmCuZbHbvDB5rWfvcWCX1txMRM=",
       "dev": true
     },
     "sinon": {

--- a/package.json
+++ b/package.json
@@ -52,7 +52,6 @@
     "rollup-plugin-node-resolve": "3.0.0",
     "rollup-plugin-uglify": "1.0.1",
     "semver": "5.3.0",
-    "shelljs": "0.5.3",
     "sinon": "1.17.1",
     "sinon-chai": "^2.14.0",
     "transducers-js": "0.4.174",

--- a/release.js
+++ b/release.js
@@ -82,7 +82,7 @@ function run(cmd, dry) {
   if (!dry) {
     var proc = child_process.spawnSync(cmd, {
       stdio: 'inherit',
-      shell: true
+      shell: true,
     })
     if (proc.status === 0) {
       console.log('... ok')

--- a/release.js
+++ b/release.js
@@ -1,6 +1,6 @@
+var child_process = require('child_process')
 var inquirer = require('inquirer')
 var semver = require('semver')
-var shell = require('shelljs')
 var fs = require('fs')
 
 var pkg = require('./package.json')
@@ -80,7 +80,11 @@ function bumpVersion(fileName, obj, dry) {
 function run(cmd, dry) {
   console.log('Running `' + cmd + '`')
   if (!dry) {
-    if (shell.exec(cmd, {silent: false}).code === 0) {
+    var proc = child_process.spawnSync(cmd, {
+      stdio: 'inherit',
+      shell: true
+    })
+    if (proc.status === 0) {
       console.log('... ok')
     } else {
       console.error('... fail!')


### PR DESCRIPTION
When release.js executed commands, it wouldn't bind stdio to the parent process's stdio, so `npm publish` can't ask for a one-time password if your account is configured to require it. This PR fixes that. It drops the shelljs dependency because it didn't seem to support any options about stdio, and the native child_process module did.

(I was able to complete the release earlier by running release.js in dry-run mode and manually running each of the commands.)