### PR TITLE
Add missing Flow annotation for Pool.unplug

### DIFF
--- a/kefir.js.flow
+++ b/kefir.js.flow
@@ -147,6 +147,7 @@ declare class Observable<+V,+E=*> {
 
 declare class Pool<V,E=*> extends Observable<V,E> {
   plug(s: Observable<V,E>): () => void;
+  unplug(s: Observable<V,E>): () => void;
 }
 
 declare class Stream<+V,+E=*> extends Observable<V,E> {


### PR DESCRIPTION
Fixes #288.

----

@rpominov @mAAdhaTTah
I renamed my npm account semi-recently from agentme -> [macil](https://www.npmjs.com/settings/macil/packages) which for some kind of npm reasons caused me to lose publish permissions to any packages not originally created by me including kefir, so I'll need to be re-added to the npm package access list.  

Normally for any changes to Kefir, I'd put a PR up and wait for an approval review from another maintainer before merging, updating the changelog, and releasing, but for very trivial fixes like this, would you all prefer for me to merge my PR and release it immediately without waiting for a review, or prefer for me to always still wait for a review?