### PR TITLE
Better atomic emitting in combine operator, check new tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ test/in-browser/spec/KefirSpecs.js
 index.html
 test.html
 test.js
+.idea

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kefir",
-  "version": "3.8.7",
+  "version": "3.8.6",
   "description": "Reactive Programming library for JavaScript inspired by Bacon.js and RxJS with focus on high performance and low memory usage",
   "main": "dist/kefir.js",
   "module": "dist/kefir.esm.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kefir",
-  "version": "3.8.6",
+  "version": "3.8.7",
   "description": "Reactive Programming library for JavaScript inspired by Bacon.js and RxJS with focus on high performance and low memory usage",
   "main": "dist/kefir.js",
   "module": "dist/kefir.esm.js",

--- a/src/batching-queue.js
+++ b/src/batching-queue.js
@@ -1,6 +1,6 @@
 export default function BatchingQueue() {
   this.lockCounter = 0
-  this.batchingQueue = []
+  this.batchingQueue = undefined
 
   this.lock = function() {
     this.lockCounter++
@@ -9,16 +9,20 @@ export default function BatchingQueue() {
   this.release = function() {
     this.lockCounter--
 
-    if (this.lockCounter === 0 && this.batchingQueue.length > 0) {
+    if (this.lockCounter === 0 && this.batchingQueue) {
       this.flushBatchingQueue()
     }
   }
 
   this.push = function(node) {
     if (!this.lockCounter) {
-      batchedNode._emitQueued()
+      node._emitQueued()
+    } else {
+      if (!this.batchingQueue) {
+        this.batchingQueue = []
+      }
+      this.batchingQueue.push(node)
     }
-    this.batchingQueue.push(node)
   }
 
   this.flushBatchingQueue = function() {

--- a/src/batching-queue.js
+++ b/src/batching-queue.js
@@ -1,6 +1,6 @@
 export default function BatchingQueue() {
   this.lockCounter = 0
-  this.batchingQueue = undefined
+  this.batched = undefined
 
   this.lock = function() {
     this.lockCounter++
@@ -9,7 +9,7 @@ export default function BatchingQueue() {
   this.release = function() {
     this.lockCounter--
 
-    if (this.lockCounter === 0 && this.batchingQueue) {
+    if (this.lockCounter === 0 && this.batched) {
       this.flushBatchingQueue()
     }
   }
@@ -18,17 +18,17 @@ export default function BatchingQueue() {
     if (!this.lockCounter) {
       node._emitQueued()
     } else {
-      if (this.batchingQueue) {
-        this.batchingQueue.push(node);
+      if (this.batched) {
+        this.batched.push(node)
       } else {
-        this.batchingQueue = [node];
+        this.batched = [node]
       }
     }
   }
 
   this.flushBatchingQueue = function() {
     let batchedNode
-    while ((batchedNode = this.batchingQueue.shift())) {
+    while ((batchedNode = this.batched.shift())) {
       batchedNode._emitQueued()
     }
   }

--- a/src/batching-queue.js
+++ b/src/batching-queue.js
@@ -1,0 +1,30 @@
+export default function BatchingQueue() {
+  this.lockCounter = 0
+  this.batchingQueue = []
+
+  this.lock = function() {
+    this.lockCounter++
+  }
+
+  this.release = function() {
+    this.lockCounter--
+
+    if (this.lockCounter === 0 && this.batchingQueue.length > 0) {
+      this.flushBatchingQueue()
+    }
+  }
+
+  this.push = function(node) {
+    if (!this.lockCounter) {
+      batchedNode._emitQueued()
+    }
+    this.batchingQueue.push(node)
+  }
+
+  this.flushBatchingQueue = function() {
+    let batchedNode
+    while ((batchedNode = this.batchingQueue.shift())) {
+      batchedNode._emitQueued()
+    }
+  }
+}

--- a/src/batching-queue.js
+++ b/src/batching-queue.js
@@ -18,10 +18,11 @@ export default function BatchingQueue() {
     if (!this.lockCounter) {
       node._emitQueued()
     } else {
-      if (!this.batchingQueue) {
-        this.batchingQueue = []
+      if (this.batchingQueue) {
+        this.batchingQueue.push(node);
+      } else {
+        this.batchingQueue = [node];
       }
-      this.batchingQueue.push(node)
     }
   }
 

--- a/src/index.js
+++ b/src/index.js
@@ -295,6 +295,13 @@ Observable.prototype.combine = function(other, combinator) {
 }
 
 // (Array<Stream|Property>, Function|undefiend) -> Stream
+// (Array<Stream|Property>, Array<Stream|Property>, Function|undefiend) -> Stream
+import combineBatched from './many-sources/combine-batched'
+Observable.prototype.combineBatched = function(other, combinator) {
+  return combineBatched([this, other], combinator)
+}
+
+// (Array<Stream|Property>, Function|undefiend) -> Stream
 import zip from './many-sources/zip'
 Observable.prototype.zip = function(other, combinator) {
   return zip([this, other], combinator)
@@ -461,6 +468,7 @@ const Kefir = {
   fromPromise,
   fromESObservable,
   combine,
+  combineBatched,
   zip,
   merge,
   concat,
@@ -492,6 +500,7 @@ export {
   fromPromise,
   fromESObservable,
   combine,
+  combineBatched,
   zip,
   merge,
   concat,

--- a/src/many-sources/combine-batched.js
+++ b/src/many-sources/combine-batched.js
@@ -18,7 +18,7 @@ inherit(CombineBatched, Combine, {
     if (!this._isQueued) {
       this._isQueued = true
 
-      source.batchingQueue.push(this)
+      source._batchingQueue.push(this)
     }
   },
 })

--- a/src/many-sources/combine-batched.js
+++ b/src/many-sources/combine-batched.js
@@ -1,0 +1,29 @@
+import {inherit} from '../utils/objects'
+import {Combine, handleCombineParameters} from './combine'
+import {BatchingQueueSingleton} from '../dispatcher'
+
+function CombineBatched(active, passive, combinator) {
+  Combine.call(this, active, passive, combinator)
+}
+
+inherit(CombineBatched, Combine, {
+  _isQueued: false,
+
+  _emitQueued() {
+    this._isQueued = false
+
+    Combine.prototype._emitIfFull.call(this)
+  },
+
+  _emitCombined() {
+    if (!this._isQueued) {
+      this._isQueued = true
+
+      BatchingQueueSingleton.push(this)
+    }
+  },
+})
+
+export default function combineBatched(active, passive, combinator) {
+  return handleCombineParameters(active, passive, combinator, CombineBatched)
+}

--- a/src/many-sources/combine-batched.js
+++ b/src/many-sources/combine-batched.js
@@ -1,6 +1,5 @@
 import {inherit} from '../utils/objects'
 import {Combine, handleCombineParameters} from './combine'
-import {BatchingQueueSingleton} from '../dispatcher'
 
 function CombineBatched(active, passive, combinator) {
   Combine.call(this, active, passive, combinator)
@@ -15,11 +14,11 @@ inherit(CombineBatched, Combine, {
     Combine.prototype._emitIfFull.call(this)
   },
 
-  _emitCombined() {
+  _emitCombined(source) {
     if (!this._isQueued) {
       this._isQueued = true
 
-      BatchingQueueSingleton.push(this)
+      source.batchingQueue.push(this)
     }
   },
 })

--- a/src/many-sources/combine.js
+++ b/src/many-sources/combine.js
@@ -4,6 +4,7 @@ import {inherit} from '../utils/objects'
 import {concat, fillArray} from '../utils/collections'
 import {spread} from '../utils/functions'
 import never from '../primary/never'
+import {atomicQueuePush} from '../dispatcher'
 
 function collect(source, keys, values) {
   for (var prop in source) {
@@ -123,7 +124,7 @@ inherit(Combine, Stream, {
         if (this._activating) {
           this._emitAfterActivation = true
         } else {
-          this._emitIfFull()
+          atomicQueuePush(this, this._emitIfFull)
         }
       }
     } else {

--- a/src/many-sources/combine.js
+++ b/src/many-sources/combine.js
@@ -127,7 +127,7 @@ inherit(Combine, Stream, {
         if (this._activating) {
           this._emitAfterActivation = true
         } else {
-          this._emitCombined()
+          this._emitCombined(this._sources[i])
         }
       }
     } else {

--- a/src/observable.js
+++ b/src/observable.js
@@ -2,9 +2,11 @@ import {extend} from './utils/objects'
 import {VALUE, ERROR, ANY, END} from './constants'
 import {Dispatcher, callSubscriber} from './dispatcher'
 import {findByPred} from './utils/collections'
+import BatchingQueue from './batching-queue'
 
-function Observable() {
-  this._dispatcher = new Dispatcher()
+function Observable(batchingQueue) {
+  this.batchingQueue = batchingQueue || new BatchingQueue()
+  this._dispatcher = new Dispatcher(this.batchingQueue)
   this._active = false
   this._alive = true
   this._activating = false

--- a/src/observable.js
+++ b/src/observable.js
@@ -5,8 +5,8 @@ import {findByPred} from './utils/collections'
 import BatchingQueue from './batching-queue'
 
 function Observable(batchingQueue) {
-  this.batchingQueue = batchingQueue || new BatchingQueue()
-  this._dispatcher = new Dispatcher(this.batchingQueue)
+  this._batchingQueue = batchingQueue || new BatchingQueue()
+  this._dispatcher = new Dispatcher(this._batchingQueue)
   this._active = false
   this._alive = true
   this._activating = false

--- a/src/patterns/one-source.js
+++ b/src/patterns/one-source.js
@@ -5,7 +5,7 @@ import {VALUE, ERROR, END} from '../constants'
 
 function createConstructor(BaseClass, name) {
   return function AnonymousObservable(source, options) {
-    BaseClass.call(this)
+    BaseClass.call(this, source.batchingQueue)
     this._source = source
     this._name = `${source._name}.${name}`
     this._init(options)

--- a/src/patterns/one-source.js
+++ b/src/patterns/one-source.js
@@ -5,7 +5,7 @@ import {VALUE, ERROR, END} from '../constants'
 
 function createConstructor(BaseClass, name) {
   return function AnonymousObservable(source, options) {
-    BaseClass.call(this, source.batchingQueue)
+    BaseClass.call(this, source._batchingQueue)
     this._source = source
     this._name = `${source._name}.${name}`
     this._init(options)

--- a/src/property.js
+++ b/src/property.js
@@ -3,8 +3,8 @@ import {VALUE, ERROR, END} from './constants'
 import {callSubscriber} from './dispatcher'
 import Observable from './observable'
 
-function Property() {
-  Observable.call(this)
+function Property(batchingQueue) {
+  Observable.call(this, batchingQueue)
   this._currentEvent = null
 }
 

--- a/src/stream.js
+++ b/src/stream.js
@@ -1,8 +1,8 @@
 import {inherit} from './utils/objects'
 import Observable from './observable'
 
-function Stream() {
-  Observable.call(this)
+function Stream(batchingQueue) {
+  Observable.call(this, batchingQueue)
 }
 
 inherit(Stream, Observable, {

--- a/test/specs/combine-batched.js
+++ b/test/specs/combine-batched.js
@@ -577,7 +577,7 @@ describe('combineBatched', () => {
         const innerFooStream = Kefir.stream(emitter => {
           innerFooBusEmitter = emitter
         })
-        const innerFooCombined = Kefir.combineBatched([innerFooStream], x => x) // Some Kefir observable based on innerFooBus
+        const innerFooCombined = Kefir.combineBatched([innerFooStream], x => x) // Some Kefir observable based on innerFooStream
 
         let log = []
 

--- a/test/specs/combine-batched.js
+++ b/test/specs/combine-batched.js
@@ -1,23 +1,23 @@
 const {stream, prop, send, value, error, end, activate, deactivate, Kefir, expect} = require('../test-helpers')
 
-describe('combine', () => {
+describe('combineBatched', () => {
   describe('array', () => {
     it('should stream', () => {
-      expect(Kefir.combine([])).to.be.observable.stream()
-      expect(Kefir.combine([stream(), prop()])).to.be.observable.stream()
+      expect(Kefir.combineBatched([])).to.be.observable.stream()
+      expect(Kefir.combineBatched([stream(), prop()])).to.be.observable.stream()
       expect(stream().combine(stream())).to.be.observable.stream()
       expect(prop().combine(prop())).to.be.observable.stream()
     })
 
     it('should be ended if empty array provided', () => {
-      expect(Kefir.combine([])).to.emit([end({current: true})])
+      expect(Kefir.combineBatched([])).to.emit([end({current: true})])
     })
 
     it('should be ended if array of ended observables provided', () => {
       const a = send(stream(), [end()])
       const b = send(prop(), [end()])
       const c = send(stream(), [end()])
-      expect(Kefir.combine([a, b, c])).to.emit([end({current: true})])
+      expect(Kefir.combineBatched([a, b, c])).to.emit([end({current: true})])
       expect(a.combine(b)).to.emit([end({current: true})])
     })
 
@@ -25,7 +25,7 @@ describe('combine', () => {
       const a = send(prop(), [value(1), end()])
       const b = send(prop(), [value(2), end()])
       const c = send(prop(), [value(3), end()])
-      expect(Kefir.combine([a, b, c])).to.emit([value([1, 2, 3], {current: true}), end({current: true})])
+      expect(Kefir.combineBatched([a, b, c])).to.emit([value([1, 2, 3], {current: true}), end({current: true})])
       expect(a.combine(b)).to.emit([value([1, 2], {current: true}), end({current: true})])
     })
 
@@ -33,7 +33,7 @@ describe('combine', () => {
       const a = stream()
       const b = prop()
       const c = stream()
-      expect(Kefir.combine([a, b, c])).to.activate(a, b, c)
+      expect(Kefir.combineBatched([a, b, c])).to.activate(a, b, c)
       expect(a.combine(b)).to.activate(a, b)
     })
 
@@ -41,7 +41,7 @@ describe('combine', () => {
       let a = stream()
       let b = send(prop(), [value(0)])
       const c = stream()
-      expect(Kefir.combine([a, b, c])).to.emit(
+      expect(Kefir.combineBatched([a, b, c])).to.emit(
         [value([1, 0, 2]), value([1, 3, 2]), value([1, 4, 2]), value([1, 4, 5]), value([1, 4, 6]), end()],
         () => {
           send(a, [value(1)])
@@ -67,7 +67,7 @@ describe('combine', () => {
       let b = send(prop(), [value(0)])
       const c = stream()
       const join = (...args) => args.join('+')
-      expect(Kefir.combine([a, b, c], join)).to.emit(
+      expect(Kefir.combineBatched([a, b, c], join)).to.emit(
         [value('1+0+2'), value('1+3+2'), value('1+4+2'), value('1+4+5'), value('1+4+6'), end()],
         () => {
           send(a, [value(1)])
@@ -91,7 +91,7 @@ describe('combine', () => {
     it('when activating second time and has 2+ properties in sources, should emit current value at most once', () => {
       const a = send(prop(), [value(0)])
       const b = send(prop(), [value(1)])
-      const cb = Kefir.combine([a, b])
+      const cb = Kefir.combineBatched([a, b])
       activate(cb)
       deactivate(cb)
       expect(cb).to.emit([value([0, 1], {current: true})])
@@ -101,15 +101,15 @@ describe('combine', () => {
       let a = stream()
       let b = prop()
       let c = stream()
-      expect(Kefir.combine([a, b, c])).to.flowErrors(a)
+      expect(Kefir.combineBatched([a, b, c])).to.flowErrors(a)
       a = stream()
       b = prop()
       c = stream()
-      expect(Kefir.combine([a, b, c])).to.flowErrors(b)
+      expect(Kefir.combineBatched([a, b, c])).to.flowErrors(b)
       a = stream()
       b = prop()
       c = stream()
-      expect(Kefir.combine([a, b, c])).to.flowErrors(c)
+      expect(Kefir.combineBatched([a, b, c])).to.flowErrors(c)
     })
 
     it('should handle errors correctly', () => {
@@ -125,7 +125,7 @@ describe('combine', () => {
       const a = stream()
       const b = stream()
       const c = stream()
-      expect(Kefir.combine([a, b, c])).to.emit(
+      expect(Kefir.combineBatched([a, b, c])).to.emit(
         [
           error(-1),
           error(-1),
@@ -153,27 +153,27 @@ describe('combine', () => {
 
     describe('sampledBy al =>ity (3 arity combine)', () => {
       it('should stream', () => {
-        expect(Kefir.combine([], [])).to.be.observable.stream()
-        expect(Kefir.combine([stream(), prop()], [stream(), prop()])).to.be.observable.stream()
+        expect(Kefir.combineBatched([], [])).to.be.observable.stream()
+        expect(Kefir.combineBatched([stream(), prop()], [stream(), prop()])).to.be.observable.stream()
       })
 
       it('should be ended if empty array provided', () => {
-        expect(Kefir.combine([stream(), prop()], [])).to.emit([])
-        expect(Kefir.combine([], [stream(), prop()])).to.emit([end({current: true})])
+        expect(Kefir.combineBatched([stream(), prop()], [])).to.emit([])
+        expect(Kefir.combineBatched([], [stream(), prop()])).to.emit([end({current: true})])
       })
 
       it('should be ended if array of ended observables provided', () => {
         const a = send(stream(), [end()])
         const b = send(prop(), [end()])
         const c = send(stream(), [end()])
-        expect(Kefir.combine([a, b, c], [stream(), prop()])).to.emit([end({current: true})])
+        expect(Kefir.combineBatched([a, b, c], [stream(), prop()])).to.emit([end({current: true})])
       })
 
       it('should be ended and emmit current (once) if array of ended properties provided and each of them has current', () => {
         const a = send(prop(), [value(1), end()])
         const b = send(prop(), [value(2), end()])
         const c = send(prop(), [value(3), end()])
-        const s1 = Kefir.combine([a, b], [c])
+        const s1 = Kefir.combineBatched([a, b], [c])
         expect(s1).to.emit([value([1, 2, 3], {current: true}), end({current: true})])
         expect(s1).to.emit([end({current: true})])
       })
@@ -182,7 +182,7 @@ describe('combine', () => {
         const a = stream()
         const b = prop()
         const c = stream()
-        expect(Kefir.combine([a, b], [c])).to.activate(a, b, c)
+        expect(Kefir.combineBatched([a, b], [c])).to.activate(a, b, c)
       })
 
       it('should handle events and current from observables', () => {
@@ -190,7 +190,7 @@ describe('combine', () => {
         const b = send(prop(), [value(0)])
         const c = stream()
         const d = stream()
-        expect(Kefir.combine([c, d], [a, b])).to.emit(
+        expect(Kefir.combineBatched([c, d], [a, b])).to.emit(
           [value([2, 3, 1, 0]), value([5, 3, 1, 4]), value([6, 3, 1, 4]), value([6, 7, 1, 4]), end()],
           () => {
             send(a, [value(1)])
@@ -209,7 +209,7 @@ describe('combine', () => {
         const b = send(prop(), [value(0)])
         const c = stream()
         const d = stream()
-        expect(Kefir.combine([c, d], [a, b], join)).to.emit(
+        expect(Kefir.combineBatched([c, d], [a, b], join)).to.emit(
           [value('2+3+1+0'), value('5+3+1+4'), value('6+3+1+4'), value('6+7+1+4'), end()],
           () => {
             send(a, [value(1)])
@@ -226,7 +226,7 @@ describe('combine', () => {
         const a = send(prop(), [value(0)])
         const b = send(prop(), [value(1)])
         const c = send(prop(), [value(2)])
-        const sb = Kefir.combine([a, b], [c])
+        const sb = Kefir.combineBatched([a, b], [c])
         activate(sb)
         deactivate(sb)
         expect(sb).to.emit([value([0, 1, 2], {current: true})])
@@ -237,12 +237,12 @@ describe('combine', () => {
         let b = prop()
         let c = stream()
         let d = prop()
-        expect(Kefir.combine([a, b], [c, d])).to.flowErrors(a)
+        expect(Kefir.combineBatched([a, b], [c, d])).to.flowErrors(a)
         a = stream()
         b = prop()
         c = stream()
         d = prop()
-        expect(Kefir.combine([a, b], [c, d])).to.flowErrors(b)
+        expect(Kefir.combineBatched([a, b], [c, d])).to.flowErrors(b)
       })
 
       // https://github.com/kefirjs/kefir/issues/98
@@ -250,7 +250,7 @@ describe('combine', () => {
         const a = stream()
         const b = a.map(x => x + 2)
         const c = a.map(x => x * 2)
-        expect(Kefir.combine([b], [c])).to.emit([value([3, 2]), value([4, 4]), value([5, 6])], () =>
+        expect(Kefir.combineBatched([b], [c])).to.emit([value([3, 2]), value([4, 4]), value([5, 6])], () =>
           send(a, [value(1), value(2), value(3)])
         )
       })
@@ -259,30 +259,26 @@ describe('combine', () => {
         const a = stream()
         const b = a.map(x => x + 2)
         const c = a.map(x => x * 2)
-        let combined = Kefir.combine([b, c])
+        let combined = Kefir.combineBatched([b, c])
 
-        expect(combined).to.emit([value([3, 2]), value([4, 2]), value([4, 4]), value([5, 4]), value([5, 6])], () =>
+        expect(combined).to.emit([value([3, 2]), value([4, 4]), value([5, 6])], () =>
           send(a, [value(1), value(2), value(3)])
         )
 
-        expect(combined.combine(c)).to.emit(
-          [
-            value([[3, 2], 2]),
-            value([[4, 2], 2]),
-            value([[4, 4], 2]),
-            value([[4, 4], 4]),
-            value([[5, 4], 4]),
-            value([[5, 6], 4]),
-            value([[5, 6], 6]),
-          ],
+        expect(combined.combineBatched(c)).to.emit([value([[3, 2], 2]), value([[4, 4], 4]), value([[5, 6], 6])], () =>
+          send(a, [value(1), value(2), value(3)])
+        )
+
+        expect(Kefir.combineBatched([combined, combined])).to.emit(
+          [value([[3, 2], [3, 2]]), value([[4, 4], [4, 4]]), value([[5, 6], [5, 6]])],
           () => send(a, [value(1), value(2), value(3)])
         )
 
         const p = send(prop(), [value(1)])
 
         const basePoolA = Kefir.pool()
-        const combA = Kefir.combine([basePoolA, p])
-        const combB = Kefir.combine([basePoolA, p])
+        const combA = Kefir.combineBatched([basePoolA, p])
+        const combB = Kefir.combineBatched([basePoolA, p])
         let emitted = []
 
         combA.onValue(v => emitted.push(v))
@@ -298,40 +294,43 @@ describe('combine', () => {
 
   describe('object', () => {
     it('should stream', () => {
-      expect(Kefir.combine({})).to.be.observable.stream()
-      expect(Kefir.combine({s: stream(), p: prop()})).to.be.observable.stream()
+      expect(Kefir.combineBatched({})).to.be.observable.stream()
+      expect(Kefir.combineBatched({s: stream(), p: prop()})).to.be.observable.stream()
     })
 
     it('should be ended if empty array provided', () => {
-      expect(Kefir.combine({})).to.emit([end({current: true})])
+      expect(Kefir.combineBatched({})).to.emit([end({current: true})])
     })
 
     it('should be ended if array of ended observables provided', () => {
       const a = send(stream(), [end()])
       const b = send(prop(), [end()])
       const c = send(stream(), [end()])
-      expect(Kefir.combine({a, b, c})).to.emit([end({current: true})])
+      expect(Kefir.combineBatched({a, b, c})).to.emit([end({current: true})])
     })
 
     it('should be ended and has current if array of ended properties provided and each of them has current', () => {
       const a = send(prop(), [value(1), end()])
       const b = send(prop(), [value(2), end()])
       const c = send(prop(), [value(3), end()])
-      expect(Kefir.combine({a, b, c})).to.emit([value({a: 1, b: 2, c: 3}, {current: true}), end({current: true})])
+      expect(Kefir.combineBatched({a, b, c})).to.emit([
+        value({a: 1, b: 2, c: 3}, {current: true}),
+        end({current: true}),
+      ])
     })
 
     it('should activate sources', () => {
       const a = stream()
       const b = prop()
       const c = stream()
-      expect(Kefir.combine({a, b, c})).to.activate(a, b, c)
+      expect(Kefir.combineBatched({a, b, c})).to.activate(a, b, c)
     })
 
     it('should handle events and current from observables', () => {
       const a = stream()
       const b = send(prop(), [value(0)])
       const c = stream()
-      expect(Kefir.combine({a, b, c})).to.emit(
+      expect(Kefir.combineBatched({a, b, c})).to.emit(
         [
           value({a: 1, b: 0, c: 2}),
           value({a: 1, b: 3, c: 2}),
@@ -356,7 +355,7 @@ describe('combine', () => {
       const b = send(prop(), [value(0)])
       const c = stream()
       const join = ev => ev.a + '+' + ev.b + '+' + ev.c
-      expect(Kefir.combine({a, b, c}, join)).to.emit(
+      expect(Kefir.combineBatched({a, b, c}, join)).to.emit(
         [value('1+0+2'), value('1+3+2'), value('1+4+2'), value('1+4+5'), value('1+4+6'), end()],
         () => {
           send(a, [value(1)])
@@ -372,7 +371,7 @@ describe('combine', () => {
     it('when activating second time and has 2+ properties in sources, should emit current value at most once', () => {
       const a = send(prop(), [value(0)])
       const b = send(prop(), [value(1)])
-      const cb = Kefir.combine({a, b})
+      const cb = Kefir.combineBatched({a, b})
       activate(cb)
       deactivate(cb)
       expect(cb).to.emit([value({a: 0, b: 1}, {current: true})])
@@ -382,15 +381,15 @@ describe('combine', () => {
       let a = stream()
       let b = prop()
       let c = stream()
-      expect(Kefir.combine({a, b, c})).to.flowErrors(a)
+      expect(Kefir.combineBatched({a, b, c})).to.flowErrors(a)
       a = stream()
       b = prop()
       c = stream()
-      expect(Kefir.combine({a, b, c})).to.flowErrors(b)
+      expect(Kefir.combineBatched({a, b, c})).to.flowErrors(b)
       a = stream()
       b = prop()
       c = stream()
-      expect(Kefir.combine({a, b, c})).to.flowErrors(c)
+      expect(Kefir.combineBatched({a, b, c})).to.flowErrors(c)
     })
 
     it('should handle errors correctly', () => {
@@ -406,7 +405,7 @@ describe('combine', () => {
       const a = stream()
       const b = stream()
       const c = stream()
-      expect(Kefir.combine({a, b, c})).to.emit(
+      expect(Kefir.combineBatched({a, b, c})).to.emit(
         [
           error(-1),
           error(-1),
@@ -434,27 +433,27 @@ describe('combine', () => {
 
     describe('sampledBy al =>ity (3 arity combine)', () => {
       it('should stream', () => {
-        expect(Kefir.combine({}, {})).to.be.observable.stream()
-        expect(Kefir.combine({s1: stream(), p1: prop()}, {s2: stream(), p2: prop()})).to.be.observable.stream()
+        expect(Kefir.combineBatched({}, {})).to.be.observable.stream()
+        expect(Kefir.combineBatched({s1: stream(), p1: prop()}, {s2: stream(), p2: prop()})).to.be.observable.stream()
       })
 
       it('should be ended if empty array provided', () => {
-        expect(Kefir.combine({s1: stream(), p1: prop()}, {})).to.emit([])
-        expect(Kefir.combine({}, {s2: stream(), p2: prop()})).to.emit([end({current: true})])
+        expect(Kefir.combineBatched({s1: stream(), p1: prop()}, {})).to.emit([])
+        expect(Kefir.combineBatched({}, {s2: stream(), p2: prop()})).to.emit([end({current: true})])
       })
 
       it('should be ended if array of ended observables provided', () => {
         const a = send(stream(), [end()])
         const b = send(prop(), [end()])
         const c = send(stream(), [end()])
-        expect(Kefir.combine({a, b, c}, {d: stream(), e: prop()})).to.emit([end({current: true})])
+        expect(Kefir.combineBatched({a, b, c}, {d: stream(), e: prop()})).to.emit([end({current: true})])
       })
 
       it('should be ended and emmit current (once) if array of ended properties provided and each of them has current', () => {
         const a = send(prop(), [value(1), end()])
         const b = send(prop(), [value(2), end()])
         const c = send(prop(), [value(3), end()])
-        const s1 = Kefir.combine({a, b}, {c})
+        const s1 = Kefir.combineBatched({a, b}, {c})
         expect(s1).to.emit([value({a: 1, b: 2, c: 3}, {current: true}), end({current: true})])
         expect(s1).to.emit([end({current: true})])
       })
@@ -463,7 +462,7 @@ describe('combine', () => {
         const a = stream()
         const b = prop()
         const c = stream()
-        expect(Kefir.combine({a, b}, {c})).to.activate(a, b, c)
+        expect(Kefir.combineBatched({a, b}, {c})).to.activate(a, b, c)
       })
 
       it('should handle events and current from observables', () => {
@@ -471,7 +470,7 @@ describe('combine', () => {
         const b = send(prop(), [value(0)])
         const c = stream()
         const d = stream()
-        expect(Kefir.combine({c, d}, {a, b})).to.emit(
+        expect(Kefir.combineBatched({c, d}, {a, b})).to.emit(
           [
             value({a: 1, b: 0, c: 2, d: 3}),
             value({a: 1, b: 4, c: 5, d: 3}),
@@ -496,7 +495,7 @@ describe('combine', () => {
         const b = send(prop(), [value(0)])
         const c = stream()
         const d = stream()
-        expect(Kefir.combine({c, d}, {a, b}, join)).to.emit(
+        expect(Kefir.combineBatched({c, d}, {a, b}, join)).to.emit(
           [value('2+3+1+0'), value('5+3+1+4'), value('6+3+1+4'), value('6+7+1+4'), end()],
           () => {
             send(a, [value(1)])
@@ -513,7 +512,7 @@ describe('combine', () => {
         const a = send(prop(), [value(0)])
         const b = send(prop(), [value(1)])
         const c = send(prop(), [value(2)])
-        const sb = Kefir.combine({a, b}, {c})
+        const sb = Kefir.combineBatched({a, b}, {c})
         activate(sb)
         deactivate(sb)
         expect(sb).to.emit([value({a: 0, b: 1, c: 2}, {current: true})])
@@ -524,12 +523,12 @@ describe('combine', () => {
         let b = prop()
         let c = stream()
         let d = prop()
-        expect(Kefir.combine({a, b}, {c, d})).to.flowErrors(a)
+        expect(Kefir.combineBatched({a, b}, {c, d})).to.flowErrors(a)
         a = stream()
         b = prop()
         c = stream()
         d = prop()
-        expect(Kefir.combine({a, b}, {c, d})).to.flowErrors(b)
+        expect(Kefir.combineBatched({a, b}, {c, d})).to.flowErrors(b)
       })
 
       // https://github.com/kefirjs/kefir/issues/98
@@ -537,12 +536,19 @@ describe('combine', () => {
         const a = stream()
         const b = a.map(x => x + 2)
         const c = a.map(x => x * 2)
-        expect(Kefir.combine({b}, {c})).to.emit([value({b: 3, c: 2}), value({b: 4, c: 4}), value({b: 5, c: 6})], () =>
-          send(a, [value(1), value(2), value(3)])
+        expect(Kefir.combineBatched({b}, {c})).to.emit(
+          [value({b: 3, c: 2}), value({b: 4, c: 4}), value({b: 5, c: 6})],
+          () => send(a, [value(1), value(2), value(3)])
         )
+      })
 
-        expect(Kefir.combine({b, c})).to.emit(
-          [value({b: 3, c: 2}), value({b: 4, c: 2}), value({b: 4, c: 4}), value({b: 5, c: 4}), value({b: 5, c: 6})],
+      // https://github.com/kefirjs/kefir/issues/98
+      it('should work nice for emitating atomic updates with active props', () => {
+        const a = stream()
+        const b = a.map(x => x + 2)
+        const c = a.map(x => x * 2)
+        expect(Kefir.combineBatched({b, c})).to.emit(
+          [value({b: 3, c: 2}), value({b: 4, c: 4}), value({b: 5, c: 6})],
           () => send(a, [value(1), value(2), value(3)])
         )
       })
@@ -552,7 +558,7 @@ describe('combine', () => {
         const b = stream()
         const _a = stream()
 
-        expect(Kefir.combine({a, b}, {a: _a})).to.emit(
+        expect(Kefir.combineBatched({a, b}, {a: _a})).to.emit(
           [value({a: 1, b: 4}), value({a: 2, b: 4}), value({a: 3, b: 4})],
           () => {
             send(_a, [value(-1)])
@@ -572,8 +578,8 @@ describe('combine', () => {
     it('should not allow mismatched argument types', () => {
       const a = stream()
       const b = stream()
-      const arrayAndObject = () => Kefir.combine([a], {b})
-      const objectAndArray = () => Kefir.combine({a}, [b])
+      const arrayAndObject = () => Kefir.combineBatched([a], {b})
+      const objectAndArray = () => Kefir.combineBatched({a}, [b])
       expect(arrayAndObject).to.throw()
       expect(objectAndArray).to.throw()
     }))

--- a/test/specs/combine-batched.js
+++ b/test/specs/combine-batched.js
@@ -571,6 +571,36 @@ describe('combineBatched', () => {
           }
         )
       })
+
+      it('should emit combined value synchronously', () => {
+        let innerFooBusEmitter
+        const innerFooStream = Kefir.stream(emitter => {
+          innerFooBusEmitter = emitter
+        })
+        const innerFooCombined = Kefir.combineBatched([innerFooStream], x => x) // Some Kefir observable based on innerFooBus
+
+        let log = []
+
+        innerFooCombined.filter(x => x === 123).onValue(x => {
+          log.push('foo ' + x)
+        })
+
+        function foo() {
+          innerFooBusEmitter.emit(123)
+        }
+
+        const bar = innerFooCombined.filter(x => x === 1)
+
+        bar.onValue(x => {
+          log.push('pre-foo')
+          foo()
+          log.push('post-foo')
+        })
+
+        innerFooBusEmitter.emit(1)
+
+        expect(log).to.deep.eq(['pre-foo', 'foo 123', 'post-foo'])
+      })
     })
   })
 

--- a/test/specs/combine.js
+++ b/test/specs/combine.js
@@ -572,7 +572,7 @@ describe('combine', () => {
       const innerFooStream = Kefir.stream(emitter => {
         innerFooBusEmitter = emitter
       })
-      const innerFooCombined = Kefir.combineBatched([innerFooStream], x => x) // Some Kefir observable based on innerFooBus
+      const innerFooCombined = Kefir.combineBatched([innerFooStream], x => x) // Some Kefir observable based on innerFooStream
 
       let log = []
 


### PR DESCRIPTION
In a scenario, when you are combining a stream from X synchronous streams that come from single source (eg. mapped), single emit in origin stream caused combined stream to emit X events (while still in dispatch loop) instead of one with final (atomic) result.

example:
        const source = stream()
        const b = a.map(x => x + 2)
        const c = a.map(x => x * 2)
        const combined = Kefir.combine([b, c])

if source emits Value(1), Value(2), then combined should emit Value([3,2]), Value([5,4]) instead of Value([3,2]), Value([5,2]), Value([5,4])

Value([5,2]) is an incorrect intermediate value

Check the updated tests for the example above.