### PR TITLE
Guarantee that subscription is available in handler

### DIFF
--- a/kefir.js.flow
+++ b/kefir.js.flow
@@ -51,7 +51,11 @@ declare class Observable<+V,+E=*> {
   changes(): Observable<V,E>;
 
   observe(obs: Observer<V,E>, $?: empty): Subscription;
-  observe(onValue?: ?(v: V) => void, onError?: ?(err: E) => void, onEnd?: ?() => void): Subscription;
+  observe(
+      onValue?: ?(v: V, s: Subscription) => void,
+      onError?: ?(err: E, s: Subscription) => void,
+      onEnd?: ?() => void
+  ): Subscription;
   onValue(cb: (v: V) => void): this;
   offValue(cb: (v: V) => void): this;
   onError(cb: (err: E) => void): this;

--- a/test/specs/kefir-observable.js
+++ b/test/specs/kefir-observable.js
@@ -35,7 +35,7 @@ describe('Kefir.Observable', () => {
       expect(sub.closed).to.equal(true)
     })
 
-    it('should unsubcribe early', () => {
+    it('should unsubscribe early', () => {
       expect(count).to.equal(0)
 
       em.emit(1)
@@ -54,6 +54,25 @@ describe('Kefir.Observable', () => {
       })
       sub = obs.observe(() => {})
       em.end()
+      expect(sub.closed).to.equal(true)
+    })
+
+    it('should pass subscription to onValue', () => {
+      obs = Kefir.constant(1)
+      sub = obs.observe((v, s) => {
+        s.unsubscribe()
+      })
+      expect(sub.closed).to.equal(true)
+    })
+
+    it('should pass subscription to onError', () => {
+      obs = Kefir.constant(1).flatMap(Kefir.constantError)
+      sub = obs.observe(
+        () => {},
+        (v, s) => {
+          s.unsubscribe()
+        }
+      )
       expect(sub.closed).to.equal(true)
     })
   })


### PR DESCRIPTION
Completes #297.

Previously, if an Observable emitted an event synchronously when the
observe() method was called (e.g. if it was a Property), the
Subscription object would not be available in the client scope.

For instance, this code would fail because the 'subscription' variable
is assigned after the handler completes:
subscription = obs.observe(v => subscription.unsubscribe())

This commit adds the subscription as a parameter to the 'onValue' and
'onError' handlers, making the object available to handlers without
breaking any existing usage.