### PR TITLE
Adds optional callback method (logger) for Observable.log/spy()

### DIFF
--- a/bacon-vs-kefir-api.md
+++ b/bacon-vs-kefir-api.md
@@ -60,7 +60,7 @@
 | Use `unsub` function, or `Bacon.noMore` | `obs.offError(fn)` |  |
 | Use `unsub` function, or `Bacon.noMore` | `obs.offEnd(fn)` |  |
 | Use `unsub` function, or `Bacon.noMore` | `obs.offAny(fn)` |  |
-| `obs.log([name])` | `obs.log([name])` | The log format is different. Kefir returns `this` unlike Bacon, that returns `unusb` function |
+| `obs.log([name])` | `obs.log([name, fn])` | The log format is different. Kefir returns `this` unlike Bacon, that returns `unusb` function |
 | Use `unsub` function | `obs.offLog([name])` |  |
 | `obs.name(newName)` | `obs.setName(newName)` |  |
 | `observable.withDescription(param...)` | No alt.  |  |

--- a/docs-src/descriptions/main-methods.pug
+++ b/docs-src/descriptions/main-methods.pug
@@ -155,8 +155,8 @@ pre(title='console output')
 +descr-method('off-any', 'offAny', 'obs.offAny(callback)').
   Unsubscribes an #[b onAny] subscriber.
 
-+descr-method('log', 'log', 'obs.log([name])').
-  Turns on logging of any event to the browser console.
++descr-method('log', 'log', 'obs.log([name, fn])').
+  Turns on logging of any event to the browser console (default) or using specified callback function.
   Accepts an optional #[b name] argument that will be shown in the log if provided.
 
 pre.javascript(title='example')
@@ -174,8 +174,8 @@ pre(title='console output')
   Turns off logging. If #[b .log] was called with a #[b name] argument,
   #[b offLog] must be called with the same #[b name] argument.
 
-+descr-method('spy', 'spy', 'obs.spy([name])').
-  Turns on spying of any event to the browser console. Similar to
++descr-method('spy', 'spy', 'obs.spy([name, fn])').
+  Turns on spying of any event to the browser console (default) or using specified callback function. Similar to
   #[b .log], however #[b .spy] will not cause the stream to activate by itself.
   Accepts an optional #[b name] argument that will be shown in the log if provided.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "kefir",
-  "version": "3.8.6",
+  "version": "3.8.8",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/observable.js
+++ b/src/observable.js
@@ -162,14 +162,14 @@ extend(Observable.prototype, {
     return this
   },
 
-  log(name = this.toString()) {
+  log(name = this.toString(), logger = console.log) {
     let isCurrent
     let handler = function(event) {
       let type = `<${event.type}${isCurrent ? ':current' : ''}>`
       if (event.type === END) {
-        console.log(name, type)
+        logger(name, type)
       } else {
-        console.log(name, type, event.value)
+        logger(name, type, event.value)
       }
     }
 
@@ -199,13 +199,13 @@ extend(Observable.prototype, {
     return this
   },
 
-  spy(name = this.toString()) {
+  spy(name = this.toString(), logger = console.log) {
     let handler = function(event) {
       let type = `<${event.type}>`
       if (event.type === END) {
-        console.log(name, type)
+        logger(name, type)
       } else {
-        console.log(name, type, event.value)
+        logger(name, type, event.value)
       }
     }
     if (this._alive) {

--- a/test/specs/log.js
+++ b/test/specs/log.js
@@ -30,7 +30,7 @@ describe('log', () => {
     })
   })
 
-  describe('console', () => {
+  describe('default logger', () => {
     let stub
     beforeEach(() => (stub = sinon.stub(console, 'log')))
 
@@ -65,6 +65,20 @@ describe('log', () => {
       expect(a).to.emit([value(1), value(2), value(3)], () => {
         send(a, [value(1), value(2), value(3)])
         expect(console.log).not.to.have.been.called
+      })
+    })
+  })
+
+  describe('custom logger', () => {
+    it('should log using custom logger function', () => {
+      const a = stream()
+      const logger = sinon.fake()
+      a.log('logged', logger)
+      expect(a).to.emit([value(1), value(2), value(3)], () => {
+        send(a, [value(1), value(2), value(3)])
+        expect(logger).to.have.been.calledWith('logged', '<value>', 1)
+        expect(logger).to.have.been.calledWith('logged', '<value>', 2)
+        expect(logger).to.have.been.calledWith('logged', '<value>', 3)
       })
     })
   })

--- a/test/specs/spy.js
+++ b/test/specs/spy.js
@@ -30,7 +30,7 @@ describe('spy', () => {
     })
   })
 
-  describe('console', () => {
+  describe('default logger', () => {
     let stub
     beforeEach(() => (stub = sinon.stub(console, 'log')))
 
@@ -65,6 +65,20 @@ describe('spy', () => {
       expect(a).to.emit([value(1), value(2), value(3)], () => {
         send(a, [value(1), value(2), value(3)])
         expect(console.log).not.to.have.been.called
+      })
+    })
+  })
+
+  describe('custom logger', () => {
+    it('should log using custom logger function', () => {
+      const a = stream()
+      const logger = sinon.fake()
+      a.spy('spied', logger)
+      expect(a).to.emit([value(1), value(2), value(3)], () => {
+        send(a, [value(1), value(2), value(3)])
+        expect(logger).to.have.been.calledWith('spied', '<value>', 1)
+        expect(logger).to.have.been.calledWith('spied', '<value>', 2)
+        expect(logger).to.have.been.calledWith('spied', '<value>', 3)
       })
     })
   })


### PR DESCRIPTION
I have a use-case where I would like to log/spy using function other than `console.log` and I don't want to override the `log` method on `console`. This PR should make this possible. 

(Ofc, it is possible to simply wrap the observer and build the desired functionality yourself, but it would be more convenient, if this option comes from library itself.)