### PR TITLE
Add overlapping option to flatMap

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -327,8 +327,10 @@ import FlatMap from './many-sources/flat-map'
 Observable.prototype.flatMap = function(fn) {
   return new FlatMap(this, fn).setName(this, 'flatMap')
 }
-Observable.prototype.flatMapLatest = function(fn) {
-  return new FlatMap(this, fn, {concurLim: 1, drop: 'old'}).setName(this, 'flatMapLatest')
+Observable.prototype.flatMapLatest = function(fn, options = {}) {
+  options.concurLim = 1
+  options.drop = 'old'
+  return new FlatMap(this, fn, options).setName(this, 'flatMapLatest')
 }
 Observable.prototype.flatMapFirst = function(fn) {
   return new FlatMap(this, fn, {concurLim: 1}).setName(this, 'flatMapFirst')

--- a/src/many-sources/flat-map.js
+++ b/src/many-sources/flat-map.js
@@ -2,7 +2,12 @@ import {VALUE, ERROR, END} from '../constants'
 import {inherit} from '../utils/objects'
 import AbstractPool from './abstract-pool'
 
-function FlatMap(source, fn, options) {
+function FlatMap(source, fn, options = {}) {
+  if (fn && typeof fn !== 'function') {
+    options = fn
+    fn = undefined
+  }
+
   AbstractPool.call(this, options)
   this._source = source
   this._fn = fn


### PR DESCRIPTION
This will cause the next stream to be added before any old streams are removed.

```
const channelA = Kefir.stream((emitter) => {
  console.log('connect a');
  let count = 0, id = setInterval(() => emitter.value(count++), 250);
  return () => { console.log('disconnect a'); clearInterval(id); };
});

const channelB = Kefir.stream((emitter) => {
  console.log('connect b');
  let count = 0, id = setInterval(() => emitter.value(count++), 250);
  return () => { console.log('disconnect b'); clearInterval(id); };
});

const data = {
  a: channelA,
  b: Kefir.combine([channelA, channelB]),
  c: channelB,
};

Kefir.sequentially(1000, ['a', 'b', 'c', undefined])
  .flatMapLatest(p => p ? data[p] : Kefir.never())
  .log('result');
```

With overlapping option disabled (default):

```
> connect a
> result <value> 0
> result <value> 1
> result <value> 2
> disconnect a
> connect a
> connect b
> result <value> [0, 0]
> result <value> [1, 0]
> result <value> [1, 1]
> result <value> [2, 1]
> result <value> [2, 2]
> disconnect a
> disconnect b
> connect b
> result <value> 0
> result <value> 1
> result <value> 2
> disconnect b
> result <end>
```

With overlapping option enabled:

```
> connect a
> result <value> 0
> result <value> 1
> result <value> 2
> connect b
> result <value> [3, 0]
> result <value> [3, 1]
> result <value> [4, 1]
> result <value> [4, 2]
> disconnect a
> result <value> 3
> result <value> 4
> result <value> 5
> disconnect b
> result <end>
```

Closes: #235 #236